### PR TITLE
Provide JSON formatting for logfiles

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -18,17 +18,10 @@ monolog:
             path: '%kernel.logs_dir%/%kernel.environment%.log'
             level: debug
             channels: ['!event']
+            formatter: dashboard.monolog.json_formatter
         console:
             type: console
             channels: ['!event', '!doctrine']
-        # uncomment to get logging in your browser
-        # you may have to allow bigger header sizes in your Web server configuration
-        #firephp:
-        #    type: firephp
-        #    level: info
-        #chromephp:
-        #    type: chromephp
-        #    level: info
 
 swiftmailer:
     port: 1025

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Monolog/Formatter/JsonFormatter.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Monolog/Formatter/JsonFormatter.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Monolog\Formatter;
+
+use Monolog\Formatter\JsonFormatter as MonologJsonFormatter;
+
+/**
+ * Formats incoming records into a one-line JSON string. Includes only the channel. level, message, context and extra
+ * fields of records.
+ */
+class JsonFormatter extends MonologJsonFormatter
+{
+    public function format(array $record)
+    {
+        return parent::format($this->mapRecord($record));
+    }
+
+    public function formatBatch(array $records)
+    {
+        return parent::formatBatch(
+            array_map(
+                function (array $record) {
+                    return $this->mapRecord($record);
+                },
+                $records
+            )
+        );
+    }
+
+    private function mapRecord(array $record)
+    {
+        return [
+            'datetime' => $record['datetime']->format('c'),
+            'channel' => $record['channel'],
+            'level'   => $record['level_name'],
+            'message' => $record['message'],
+            'context' => $record['context'],
+            'extra'   => $record['extra'],
+        ];
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -1,1 +1,3 @@
 services:
+    dashboard.monolog.json_formatter:
+        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Monolog\Formatter\JsonFormatter


### PR DESCRIPTION
All log entries are formatted in JSON format, making it easier to load them into Kibana.