### PR TITLE
Configure Xdebug to connect back

### DIFF
--- a/ansible/roles/app/templates/xdebug.ini.j2
+++ b/ansible/roles/app/templates/xdebug.ini.j2
@@ -1,5 +1,6 @@
 zend_extension = /usr/lib64/php/modules/xdebug.so
 
 xdebug.remote_enable = 1
+xdebug.remote_connect_back = 1
 xdebug.remote_host = 192.168.33.19
 xdebug.idekey = "PHPSTORM"


### PR DESCRIPTION
This was not configured correctly while setting up the development environment in #7 

The only change made to the xdebug configuration is the addition of 

`xdebug.remote_connect_back = 1`