### PR TITLE
Save session data to /tmp on development VM

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -6,6 +6,8 @@ framework:
         resource: '%kernel.root_dir%/config/routing_dev.yml'
         strict_requirements: true
     profiler: { only_exceptions: false }
+    session:
+        save_path: '/tmp/sp-dashboard-sessions'
 
 web_profiler:
     toolbar: true


### PR DESCRIPTION
Workaround for unexplained issues with file permissions and
NFS ("session file not created by your uid").