### PR TITLE
Provide edit support for Suppliers

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Supplier/CreateSupplierCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Supplier/CreateSupplierCommand.php
@@ -21,7 +21,7 @@ namespace Surfnet\ServiceProviderDashboard\Application\Command\Supplier;
 use Surfnet\ServiceProviderDashboard\Application\Command\Command;
 use Symfony\Component\Validator\Constraints as Assert;
 
-class CreateSupplier implements Command
+class CreateSupplierCommand implements Command
 {
     /**
      * @var string

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Supplier/EditSupplierCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Supplier/EditSupplierCommand.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Command\Supplier;
+
+use Surfnet\ServiceProviderDashboard\Application\Command\Command;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class EditSupplierCommand implements Command
+{
+    /**
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @var string
+     * @Assert\NotBlank
+     * @Assert\Uuid
+     */
+    private $guid;
+
+    /**
+     * @var string
+     * @Assert\NotBlank
+     */
+    private $teamName;
+
+    /**
+     * @var string
+     * @Assert\NotBlank
+     */
+    private $name;
+
+    /**
+     * @param int $id
+     * @param string $guid
+     * @param string $teamName
+     * @param string $name
+     */
+    public function __construct($id, $guid, $name, $teamName)
+    {
+        $this->id = $id;
+        $this->guid = $guid;
+        $this->name = $name;
+        $this->teamName = $teamName;
+    }
+
+    /**
+     * @param string $guid
+     */
+    public function setGuid($guid)
+    {
+        $this->guid = $guid;
+    }
+
+    /**
+     * @param string $teamName
+     */
+    public function setTeamName($teamName)
+    {
+        $this->teamName = $teamName;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getGuid()
+    {
+        return $this->guid;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTeamName()
+    {
+        return $this->teamName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Supplier/CreateSupplierCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Supplier/CreateSupplierCommandHandler.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\CommandHandler\Supplier;
 
-use Surfnet\ServiceProviderDashboard\Application\Command\Supplier\CreateSupplier;
+use Surfnet\ServiceProviderDashboard\Application\Command\Supplier\CreateSupplierCommand;
 use Surfnet\ServiceProviderDashboard\Application\CommandHandler\CommandHandler;
 use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Supplier;
@@ -40,10 +40,10 @@ class CreateSupplierCommandHandler implements CommandHandler
     }
 
     /**
-     * @param CreateSupplier $command
+     * @param CreateSupplierCommand $command
      * @throws InvalidArgumentException
      */
-    public function handle(CreateSupplier $command)
+    public function handle(CreateSupplierCommand $command)
     {
         $supplier = new Supplier();
         $supplier->setName($command->getName());

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Supplier/EditSupplierCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Supplier/EditSupplierCommandHandler.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\CommandHandler\Supplier;
+
+use Surfnet\ServiceProviderDashboard\Application\Command\Supplier\EditSupplierCommand;
+use Surfnet\ServiceProviderDashboard\Application\CommandHandler\CommandHandler;
+use Surfnet\ServiceProviderDashboard\Application\Exception\EntityNotFoundException;
+use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\SupplierRepository;
+
+class EditSupplierCommandHandler implements CommandHandler
+{
+    /**
+     * @var SupplierRepository
+     */
+    private $supplierRepository;
+
+    /**
+     * @param SupplierRepository $supplierRepository
+     */
+    public function __construct(SupplierRepository $supplierRepository)
+    {
+        $this->supplierRepository = $supplierRepository;
+    }
+
+    /**
+     * @param EditSupplierCommand $command
+     * @throws InvalidArgumentException
+     * @throws EntityNotFoundException
+     */
+    public function handle(EditSupplierCommand $command)
+    {
+        $supplier = $this->supplierRepository->findById($command->getId());
+
+        if (is_null($supplier)) {
+            throw new EntityNotFoundException('The requested Supplier cannot be found');
+        }
+
+        $supplier->setName($command->getName());
+        $supplier->setGuid($command->getGuid());
+        $supplier->setTeamName($command->getTeamName());
+
+        $this->supplierRepository->isUnique($supplier);
+
+        $this->supplierRepository->save($supplier);
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/Exception/EntityNotFoundException.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Exception/EntityNotFoundException.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Exception;
+
+use Exception;
+
+class EntityNotFoundException extends Exception
+{
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/SupplierController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/SupplierController.php
@@ -23,7 +23,7 @@ use Psr\Log\LoggerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-use Surfnet\ServiceProviderDashboard\Application\Command\Supplier\CreateSupplier;
+use Surfnet\ServiceProviderDashboard\Application\Command\Supplier\CreateSupplierCommand;
 use Surfnet\ServiceProviderDashboard\Application\Command\Supplier\EditSupplierCommand;
 use Surfnet\ServiceProviderDashboard\Application\Exception\EntityNotFoundException;
 use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
@@ -68,7 +68,7 @@ class SupplierController extends Controller
         $this->get('session')->getFlashBag()->clear();
         /** @var LoggerInterface $logger */
         $logger = $this->get('logger');
-        $command = new CreateSupplier();
+        $command = new CreateSupplierCommand();
 
         $form = $this->createForm(SupplierType::class, $command);
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/SupplierController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/SupplierController.php
@@ -24,9 +24,13 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Surfnet\ServiceProviderDashboard\Application\Command\Supplier\CreateSupplier;
+use Surfnet\ServiceProviderDashboard\Application\Command\Supplier\EditSupplierCommand;
+use Surfnet\ServiceProviderDashboard\Application\Exception\EntityNotFoundException;
 use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Command\Supplier\SelectSupplierCommand;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\EditSupplierType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\SupplierType;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AdminSwitcherService;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -38,11 +42,18 @@ class SupplierController extends Controller
     private $commandBus;
 
     /**
-     * @param CommandBus $commandBus
+     * @var AdminSwitcherService
      */
-    public function __construct(CommandBus $commandBus)
+    private $switcherService;
+
+    /**
+     * @param CommandBus $commandBus
+     * @param AdminSwitcherService $switcherService
+     */
+    public function __construct(CommandBus $commandBus, AdminSwitcherService $switcherService)
     {
         $this->commandBus = $commandBus;
+        $this->switcherService = $switcherService;
     }
 
     /**
@@ -74,6 +85,47 @@ class SupplierController extends Controller
         }
 
         return $this->render('DashboardBundle:Supplier:create.html.twig', array(
+            'form' => $form->createView(),
+        ));
+    }
+
+    /**
+     * @Method({"GET", "POST"})
+     * @Route("/supplier/edit", name="supplier_edit")
+     * @Template()
+     * @param Request $request
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     */
+    public function editAction(Request $request)
+    {
+        $this->get('session')->getFlashBag()->clear();
+        /** @var LoggerInterface $logger */
+        $logger = $this->get('logger');
+        $supplier = $this->switcherService->getSupplierById((int) $this->switcherService->getSelectedSupplier());
+
+        $command = new EditSupplierCommand(
+            $supplier->getId(),
+            $supplier->getGuid(),
+            $supplier->getName(),
+            $supplier->getTeamName()
+        );
+
+        $form = $this->createForm(EditSupplierType::class, $command);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $logger->info(sprintf('Supplier was edited by: "%s"', '@todo'), (array)$command);
+            try {
+                $this->commandBus->handle($command);
+                return $this->redirectToRoute('entity_list');
+            } catch (InvalidArgumentException $e) {
+                $this->addFlash('error', $e->getMessage());
+            } catch (EntityNotFoundException $e) {
+                $this->addFlash('error', 'The Supplier could not be found while handling the request');
+            }
+        }
+
+        return $this->render('DashboardBundle:Supplier:edit.html.twig', array(
             'form' => $form->createView(),
         ));
     }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/EditSupplierType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/EditSupplierType.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form;
+
+use Surfnet\ServiceProviderDashboard\Application\Command\Supplier\EditSupplierCommand;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class EditSupplierType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('guid')
+            ->add('name')
+            ->add('teamName')
+            ->add('save', SubmitType::class, ['attr' => ['class'=>'button']]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => EditSupplierCommand::class,
+        ));
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'dashboard_bundle_edit_supplier_type';
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/SupplierType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/SupplierType.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form;
 
-use Surfnet\ServiceProviderDashboard\Application\Command\Supplier\CreateSupplier;
+use Surfnet\ServiceProviderDashboard\Application\Command\Supplier\CreateSupplierCommand;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -38,7 +38,7 @@ class SupplierType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            'data_class' => CreateSupplier::class,
+            'data_class' => CreateSupplierCommand::class,
         ));
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Menu/Builder.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Menu/Builder.php
@@ -35,6 +35,9 @@ class Builder implements ContainerAwareInterface
         $menu->addChild('Add new supplier', array(
             'route' => 'supplier_add',
         ));
+        $menu->addChild('Edit supplier', array(
+            'route' => 'supplier_edit',
+        ));
 
         return $menu;
     }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -2,6 +2,7 @@ services:
   Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Controller\SupplierController:
     arguments:
       - '@tactician.commandbus'
+      - '@dashboard.service.admin_switcher'
 
   Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Controller\ServiceController:
     arguments:
@@ -38,6 +39,14 @@ services:
       - '@surfnet.dashboard.repository.supplier'
     tags:
       - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Supplier\CreateSupplier }
+
+  surfnet.dashboard.command_handler.edit_supplier:
+    class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Supplier\EditSupplierCommandHandler
+    public: true
+    arguments:
+      - '@surfnet.dashboard.repository.supplier'
+    tags:
+      - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Supplier\EditSupplierCommand }
 
   dashboard.service.admin_switcher:
     class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AdminSwitcherService

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Supplier/edit.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Supplier/edit.html.twig
@@ -1,0 +1,19 @@
+{% extends '::base.html.twig' %}
+
+{% block body %}
+
+    <h2>Edit a Supplier</h2>
+
+    {% for message in app.flashes('error') %}
+        <div class="message error">
+            {{ message }}
+        </div>
+    {% endfor %}
+
+
+    {{ form(form, {'attr': {'novalidate': 'novalidate'}}) }}
+    {{ form_start(form) }}
+    {{ form_widget(form) }}
+    {{ form_end(form) }}
+
+{% endblock %}

--- a/tests/integration/Application/CommandHandler/Supplier/CreateSupplierCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Supplier/CreateSupplierCommandHandlerTest.php
@@ -20,13 +20,12 @@ namespace Surfnet\ServiceProviderDashboard\Tests\Integration\Application\Command
 
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
-use Surfnet\ServiceProviderDashboard\Application\Command\Supplier\CreateSupplier;
+use Surfnet\ServiceProviderDashboard\Application\Command\Supplier\CreateSupplierCommand;
 use Surfnet\ServiceProviderDashboard\Application\CommandHandler\Supplier\CreateSupplierCommandHandler;
 use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Supplier;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\SupplierRepository;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\SupplierRepository as DoctrineSupplierRepository;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class CreateSupplierCommandHandlerTest extends MockeryTestCase
 {
@@ -54,7 +53,7 @@ class CreateSupplierCommandHandlerTest extends MockeryTestCase
         $entity->setTeamName('team-foobar');
         $entity->setGuid('30dd879c-ee2f-11db-8314-0800200c9a66');
 
-        $command = new CreateSupplier();
+        $command = new CreateSupplierCommand();
         $command->setName('Foobar');
         $command->setTeamName('team-foobar');
         $command->setGuid('30dd879c-ee2f-11db-8314-0800200c9a66');
@@ -74,7 +73,7 @@ class CreateSupplierCommandHandlerTest extends MockeryTestCase
      */
     public function it_rejects_non_unique_create_supplier_command()
     {
-        $command = new CreateSupplier();
+        $command = new CreateSupplierCommand();
         $command->setName('Foobar');
         $command->setTeamName('team-foobar');
         $command->setGuid('30dd879c-ee2f-11db-8314-0800200c9a66');

--- a/tests/integration/Application/CommandHandler/Supplier/EditSupplierCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Supplier/EditSupplierCommandHandlerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Integration\Application\CommandHandler\Supplier;
+
+use Doctrine\ORM\EntityNotFoundException;
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Surfnet\ServiceProviderDashboard\Application\Command\Supplier\EditSupplierCommand;
+use Surfnet\ServiceProviderDashboard\Application\CommandHandler\Supplier\EditSupplierCommandHandler;
+use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Supplier;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\SupplierRepository;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\SupplierRepository as DoctrineSupplierRepository;
+
+class EditSupplierCommandHandlerTest extends MockeryTestCase
+{
+
+    /** @var EditSupplierCommandHandler */
+    private $commandHandler;
+
+    /** @var SupplierRepository|m\MockInterface */
+    private $repository;
+
+    public function setUp()
+    {
+        $this->repository = m::mock(DoctrineSupplierRepository::class);
+        $this->commandHandler = new EditSupplierCommandHandler($this->repository);
+    }
+
+    /**
+     * @test
+     * @group CommandHandler
+     */
+    public function it_can_process_an_edit_supplier_command()
+    {
+        $command = new EditSupplierCommand('1', '30dd879c-ee2f-11db-8314-0800200c9a66', 'Foobar', 'team-foobar');
+        $command->setName('Foobar');
+        $command->setTeamName('team-foobar');
+        $command->setGuid('30dd879c-ee2f-11db-8314-0800200c9a66');
+
+        $mockEntity = m::mock(Supplier::class)->makePartial();
+        $mockEntity->shouldReceive('getId')->andReturn(1);
+
+        $this->repository
+            ->shouldReceive('save')
+            ->with(m::on(function ($arg) {
+                $this->assertEquals(1, $arg->getId());
+                $this->assertEquals('Foobar', $arg->getName());
+                $this->assertEquals('team-foobar', $arg->getTeamName());
+                $this->assertEquals('30dd879c-ee2f-11db-8314-0800200c9a66', $arg->getGuid());
+
+                return true;
+            }))
+            ->once();
+        $this->repository->shouldReceive('findById')->andReturn($mockEntity)->once();
+        $this->repository->shouldReceive('isUnique')->andReturn(true)->once();
+
+        $this->commandHandler->handle($command);
+    }
+
+    /**
+     * Its highly unlikely to happen, but this tests the event that a supplier was removed while someone else is
+     * editing it. An EntityNotFound exception is thrown in this case.
+     *
+     * @test
+     * @expectedException \Surfnet\ServiceProviderDashboard\Application\Exception\EntityNotFoundException
+     * @expectedExceptionMessage The requested Supplier cannot be found
+     * @group CommandHandler
+     */
+    public function it_rejects_non_existing_supplier()
+    {
+        $command = new EditSupplierCommand(1, '30dd879c-ee2f-11db-8314-0800200c9a66', 'Foobar', 'team-foobar');
+
+        $this->repository->shouldReceive('findById')->andReturn(null)->once();
+
+        $this->commandHandler->handle($command);
+    }
+
+    /**
+     * @test
+     * @expectedException \Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException
+     * @expectedExceptionMessage The Guid of the new Supplier should be unique.
+     *                           This teamname is taken by: HZ with Guid: 30dd879c-ee2f-11db-8314-0800200c9a66
+     * @group CommandHandler
+     */
+    public function it_rejects_non_unique_edit_supplier_command()
+    {
+        $command = new EditSupplierCommand(1, '30dd879c-ee2f-11db-8314-0800200c9a66', 'Foobar', 'team-foobar');
+
+        $mockEntity = m::mock(Supplier::class)->makePartial();
+        $mockEntity->shouldReceive('getId')->andReturn(1);
+
+        $this->repository->shouldReceive('findById')->andReturn($mockEntity)->once();
+
+        $this->repository
+            ->shouldReceive('isUnique')
+            ->andThrow(
+                InvalidArgumentException::class,
+                'The Guid of the new Supplier should be unique. This teamname is taken by: HZ with Guid: 30dd879c-ee2f-11db-8314-0800200c9a66'
+            )
+            ->once();
+        $this->commandHandler->handle($command);
+    }
+}

--- a/tests/webtests/Repository/InMemorySupplierRepository.php
+++ b/tests/webtests/Repository/InMemorySupplierRepository.php
@@ -18,7 +18,6 @@
 
 namespace Surfnet\ServiceProviderDashboard\Webtests\Repository;
 
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Supplier;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\SupplierRepository as SupplierRepositoryInterface;
 


### PR DESCRIPTION
## Provide edit support for Suppliers

This part of the requirement is not yet met:
`A supplier cannot edit its own data (name + GUID)`

In my opinion this is more easily implemented when authorisation is implemented in the project. A new story was created to implement this feature at a later stage.

 - [x] Use selected supplier from admin switcher