### PR TITLE
Integrate the creation of Services

### DIFF
--- a/app/DoctrineMigrations/Version20171002152200.php
+++ b/app/DoctrineMigrations/Version20171002152200.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * This migration will change the numeric auto increment primary key to an alphanumeric UUID.
+ */
+class Version20171002152200 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE service CHANGE id id CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\'');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_E19D9AD2BF396750 ON service (id)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX UNIQ_E19D9AD2BF396750 ON service');
+        $this->addSql('ALTER TABLE service CHANGE id id INT AUTO_INCREMENT NOT NULL');
+    }
+}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -75,3 +75,9 @@ swiftmailer:
     username: '%mailer_user%'
     password: '%mailer_password%'
     spool: { type: memory }
+
+stof_doctrine_extensions:
+    default_locale: en_US
+    orm:
+        default:
+            timestampable: true

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "doctrine/orm": "^2.5",
         "knplabs/knp-menu-bundle": "^2.1",
         "league/tactician-bundle": "^0.4.1",
+        "ramsey/uuid": "^3.7",
         "sensio/framework-extra-bundle": "^3.0",
         "stof/doctrine-extensions-bundle": "^1.2",
         "symfony/monolog-bundle": "^3.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2df226aae0d34135948f10fd8a73e01",
+    "content-hash": "158fc9b03cc988c7993732c3dae37fdc",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -1528,16 +1528,16 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.10",
+            "version": "v2.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d"
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/634bae8e911eefa89c1abfbf1b66da679ac8f54d",
-                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/5da4d3c796c275c55f057af5a643ae297d96b4d8",
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8",
                 "shasum": ""
             },
             "require": {
@@ -1572,7 +1572,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2017-03-13T16:27:32+00:00"
+            "time": "2017-09-27T21:40:39+00:00"
         },
         {
             "name": "psr/cache",
@@ -1812,6 +1812,88 @@
                 "simple-cache"
             ],
             "time": "2017-01-02T13:31:39+00:00"
+        },
+        {
+            "name": "ramsey/uuid",
+            "version": "3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/uuid.git",
+                "reference": "45cffe822057a09e05f7bd09ec5fb88eeecd2334"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/45cffe822057a09e05f7bd09ec5fb88eeecd2334",
+                "reference": "45cffe822057a09e05f7bd09ec5fb88eeecd2334",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/random_compat": "^1.0|^2.0",
+                "php": "^5.4 || ^7.0"
+            },
+            "replace": {
+                "rhumsaa/uuid": "self.version"
+            },
+            "require-dev": {
+                "apigen/apigen": "^4.1",
+                "codeception/aspect-mock": "^1.0 | ^2.0",
+                "doctrine/annotations": "~1.2.0",
+                "goaop/framework": "1.0.0-alpha.2 | ^1.0 | ^2.1",
+                "ircmaxell/random-lib": "^1.1",
+                "jakub-onderka/php-parallel-lint": "^0.9.0",
+                "mockery/mockery": "^0.9.4",
+                "moontoast/math": "^1.1",
+                "php-mock/php-mock-phpunit": "^0.3|^1.1",
+                "phpunit/phpunit": "^4.7|>=5.0 <5.4",
+                "satooshi/php-coveralls": "^0.6.1",
+                "squizlabs/php_codesniffer": "^2.3"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides the PECL libsodium extension for use with the SodiumRandomGenerator",
+                "ext-uuid": "Provides the PECL UUID extension for use with the PeclUuidTimeGenerator and PeclUuidRandomGenerator",
+                "ircmaxell/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
+                "moontoast/math": "Provides support for converting UUID to 128-bit integer (in string form).",
+                "ramsey/uuid-console": "A console application for generating UUIDs with ramsey/uuid",
+                "ramsey/uuid-doctrine": "Allows the use of Ramsey\\Uuid\\Uuid as Doctrine field type."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ramsey\\Uuid\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marijn Huizendveld",
+                    "email": "marijn.huizendveld@gmail.com"
+                },
+                {
+                    "name": "Thibaud Fabre",
+                    "email": "thibaud@aztech.io"
+                },
+                {
+                    "name": "Ben Ramsey",
+                    "email": "ben@benramsey.com",
+                    "homepage": "https://benramsey.com"
+                }
+            ],
+            "description": "Formerly rhumsaa/uuid. A PHP 5.4+ library for generating RFC 4122 version 1, 3, 4, and 5 universally unique identifiers (UUID).",
+            "homepage": "https://github.com/ramsey/uuid",
+            "keywords": [
+                "guid",
+                "identifier",
+                "uuid"
+            ],
+            "time": "2017-09-22T20:46:04+00:00"
         },
         {
             "name": "sensio/framework-extra-bundle",

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/CreateServiceCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/CreateServiceCommand.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Command\Service;
+
+use Surfnet\ServiceProviderDashboard\Application\Command\Command;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Supplier;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class CreateServiceCommand implements Command
+{
+    /**
+     * @var string
+     * @Assert\NotBlank
+     * @Assert\Uuid
+     */
+    private $id;
+
+    /**
+     * @var Supplier
+     * @Assert\NotNull
+     */
+    private $supplier;
+
+    /**
+     * @var string
+     * @Assert\NotBlank
+     */
+    private $ticketNumber;
+
+    /**
+     * @param string $id
+     * @param Supplier $supplier
+     * @param string $ticketNumber
+     */
+    public function __construct($id, Supplier $supplier, $ticketNumber)
+    {
+        $this->id = $id;
+        $this->supplier = $supplier;
+        $this->ticketNumber = $ticketNumber;
+    }
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return Supplier
+     */
+    public function getSupplier()
+    {
+        return $this->supplier;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTicketNumber()
+    {
+        return $this->ticketNumber;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/CreateServiceCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/CreateServiceCommandHandler.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\CommandHandler\Service;
+
+use Surfnet\ServiceProviderDashboard\Application\Command\Service\CreateServiceCommand;
+use Surfnet\ServiceProviderDashboard\Application\CommandHandler\CommandHandler;
+use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\ServiceRepository;
+
+class CreateServiceCommandHandler implements CommandHandler
+{
+    /**
+     * @var ServiceRepository
+     */
+    private $serviceRepository;
+
+    /**
+     * @param ServiceRepository $serviceRepository
+     */
+    public function __construct(ServiceRepository $serviceRepository)
+    {
+        $this->serviceRepository = $serviceRepository;
+    }
+
+    /**
+     * @param CreateServiceCommand $command
+     *
+     * @throws InvalidArgumentException
+     */
+    public function handle(CreateServiceCommand $command)
+    {
+
+        $id = $command->getId();
+
+        if (!$this->serviceRepository->isUnique($id)) {
+            throw new InvalidArgumentException(
+                'The id that was generated for the Service was not unique, please try again'
+            );
+        }
+
+        $service = new Service();
+        $service->setId($id);
+        $service->setSupplier($command->getSupplier());
+        $service->setTicketNumber($command->getTicketNumber());
+
+        $this->serviceRepository->save($service);
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
@@ -27,7 +27,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 /**
  * @package Surfnet\ServiceProviderDashboard\Entity
  *
- * @ORM\Entity
+ * @ORM\Entity(repositoryClass="Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\ServiceRepository")
  *
  * @SuppressWarnings(PHPMD.UnusedPrivateField Fields of this class are not yet used, remove this once they are used)
  * @SuppressWarnings(PHPMD.TooManyFields)
@@ -64,7 +64,7 @@ class Service
      * @var int
      * @ORM\Column(type="integer")
      */
-    private $status;
+    private $status = self::STATE_DRAFT;
 
     /**
      * @var \DateTime $created
@@ -301,4 +301,68 @@ class Service
      * @ORM\JoinColumn(nullable=false)
      */
     private $supplier;
+
+    /**
+     * @param string $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @param Supplier $supplier
+     */
+    public function setSupplier($supplier)
+    {
+        $this->supplier = $supplier;
+    }
+
+    /**
+     * @param string $ticketNumber
+     */
+    public function setTicketNumber($ticketNo)
+    {
+        $this->ticketNo = $ticketNo;
+    }
+
+    /**
+     * @return Supplier
+     */
+    public function getSupplier()
+    {
+        return $this->supplier;
+    }
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTicketNumber()
+    {
+        return $this->ticketNo;
+    }
+
+    /**
+     * @return int
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEnvironment()
+    {
+        return $this->environment;
+    }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
@@ -42,9 +42,9 @@ class Service
 
     /**
      * @var string
+     *
      * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\Column(type="guid", unique=true, length=36)
      */
     private $id;
 

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Repository/ServiceRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Repository/ServiceRepository.php
@@ -18,33 +18,19 @@
 
 namespace Surfnet\ServiceProviderDashboard\Domain\Repository;
 
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Supplier;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 
-interface SupplierRepository
+interface ServiceRepository
 {
     /**
-     * @param Supplier $supplier
+     * @param Service $service
      */
-    public function save(Supplier $supplier);
-
-    /**
-     * Is the proposed supplier entity unique? The id of the supplier is not taken into account in this test.
-     *
-     * @param Supplier $supplier
-     *
-     * @return bool
-     */
-    public function isUnique(Supplier $supplier);
-
-    /**
-     * @return Supplier[]
-     */
-    public function findAll();
+    public function save(Service $service);
 
     /**
      * @param int $id
      *
-     * @return Supplier|null
+     * @return bool
      */
-    public function findById($id);
+    public function isUnique($id);
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Controller;
+
+use League\Tactician\CommandBus;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Surfnet\ServiceProviderDashboard\Application\Command\Service\CreateServiceCommand;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AdminSwitcherService;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\SamlServiceService;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\TicketService;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
+
+class ServiceController extends Controller
+{
+    /**
+     * @var CommandBus
+     */
+    private $commandBus;
+
+    /**
+     * @var SamlServiceService
+     */
+    private $samlService;
+
+    /**
+     * @var AdminSwitcherService
+     */
+    private $switcherService;
+    /**
+     * @var TicketService
+     */
+    private $ticketService;
+
+    /**
+     * @param CommandBus $commandBus
+     * @param SamlServiceService $samlService
+     * @param AdminSwitcherService $switcherService
+     * @param TicketService $ticketService
+     */
+    public function __construct(
+        CommandBus $commandBus,
+        SamlServiceService $samlService,
+        AdminSwitcherService $switcherService,
+        TicketService $ticketService
+    ) {
+        $this->commandBus = $commandBus;
+        $this->samlService = $samlService;
+        $this->switcherService = $switcherService;
+        $this->ticketService = $ticketService;
+    }
+
+    /**
+     * @Method("GET")
+     * @Route("/service/create", name="service_add")
+     *
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     */
+    public function createAction()
+    {
+        // Todo: perform authorization check
+        $supplier = $this->switcherService->getSupplierById((int) $this->switcherService->getSelectedSupplier());
+        $serviceId = $this->samlService->createServiceId();
+        $ticketNumber = $this->ticketService->getTicketIdForService($serviceId, $supplier);
+        if (is_null($supplier)) {
+            $this->get('logger')->error('Unable to find selected Supplier while creating a new Service');
+            // Todo: show error page?
+        }
+
+        $command = new CreateServiceCommand($serviceId, $supplier, $ticketNumber);
+        $this->commandBus->handle($command);
+
+        return $this->redirectToRoute('service_edit', ['serviceId' => $serviceId]);
+    }
+
+    /**
+     * @Method({"GET", "POST"})
+     * @Route("/service/edit/{serviceId}", name="service_edit")
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     */
+    public function editAction($serviceId)
+    {
+        return new Response($serviceId);
+//        // Todo: perform authorization check
+//        $this->get('session')->getFlashBag()->clear();
+//        /** @var LoggerInterface $logger */
+//        $command = new EditServiceCommand();
+//
+//        $form = $this->createForm(ServiceType::class, $command);
+//
+//        $form->handleRequest($request);
+//
+//        if ($form->isSubmitted() && $form->isValid()) {
+//            try {
+//                $this->commandBus->handle($command);
+//                return $this->redirectToRoute('entity_list');
+//            } catch (InvalidArgumentException $e) {
+//                $this->addFlash('error', $e->getMessage());
+//            }
+//        }
+//
+//        return $this->render('DashboardBundle:Service:edit.html.twig', array(
+//            'form' => $form->createView(),
+//        ));
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/SupplierController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/SupplierController.php
@@ -25,9 +25,8 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Surfnet\ServiceProviderDashboard\Application\Command\Supplier\CreateSupplier;
 use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Supplier;
-use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\SupplierType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Command\Supplier\SelectSupplierCommand;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\SupplierType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Repository/ServiceRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Repository/ServiceRepository.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\ServiceRepository as ServiceRepositoryInterface;
+
+class ServiceRepository extends EntityRepository implements ServiceRepositoryInterface
+{
+    /**
+     * @param Service $service
+     */
+    public function save(Service $service)
+    {
+        $this->_em->persist($service);
+        $this->_em->flush($service);
+    }
+
+    /**
+     * @param int $id
+     *
+     * @return bool
+     */
+    public function isUnique($id)
+    {
+        $service = $this->createQueryBuilder('s')
+            ->where('s.id = :id')
+            ->setParameter('id', $id)
+            ->getQuery()
+            ->getOneOrNullResult();
+        if (is_null($service)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Repository/SupplierRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Repository/SupplierRepository.php
@@ -90,4 +90,13 @@ class SupplierRepository extends EntityRepository implements SupplierRepositoryI
             );
         }
     }
+
+    /**
+     * @param int $id
+     * @return Supplier|null
+     */
+    public function findById($id)
+    {
+        return $this->find($id);
+    }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -3,6 +3,13 @@ services:
     arguments:
       - '@tactician.commandbus'
 
+  Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Controller\ServiceController:
+    arguments:
+      - '@tactician.commandbus'
+      - '@dashboard.service.saml_service'
+      - '@dashboard.service.admin_switcher'
+      - '@dashboard.service.ticket'
+
   dashboard.monolog.json_formatter:
     class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Monolog\Formatter\JsonFormatter
 
@@ -11,12 +18,24 @@ services:
     factory: ['@doctrine', 'getRepository']
     arguments: [Surfnet\ServiceProviderDashboard\Domain\Entity\Supplier]
 
+  surfnet.dashboard.repository.service:
+    class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\ServiceRepository
+    factory: ['@doctrine', 'getRepository']
+    arguments: [Surfnet\ServiceProviderDashboard\Domain\Entity\Service]
+
+  surfnet.dashboard.command_handler.create_service:
+    class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Service\CreateServiceCommandHandler
+    public: true
+    arguments:
+      - '@surfnet.dashboard.repository.service'
+    tags:
+      - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Service\CreateServiceCommand }
+
   surfnet.dashboard.command_handler.create_supplier:
     class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Supplier\CreateSupplierCommandHandler
     public: true
     arguments:
       - '@surfnet.dashboard.repository.supplier'
-      - '@validator'
     tags:
       - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Supplier\CreateSupplier }
 
@@ -25,6 +44,12 @@ services:
     arguments:
       - '@session'
       - '@surfnet.dashboard.repository.supplier'
+
+  dashboard.service.saml_service:
+    class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\SamlServiceService
+
+  dashboard.service.ticket:
+    class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\TicketService
 
   surfnet.dashboard.command_handler.select_supplier:
     class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\CommandHandler\Supplier\SelectSupplierCommandHandler

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/AdminSwitcherService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/AdminSwitcherService.php
@@ -17,6 +17,7 @@
  */
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service;
 
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Supplier;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\SupplierRepository;
 use Symfony\Component\HttpFoundation\Session\Session;
 
@@ -70,5 +71,15 @@ class AdminSwitcherService
     public function getSelectedSupplier()
     {
         return $this->session->get('selected_supplier');
+    }
+
+    /**
+     * @param int $id
+     *
+     * @return Supplier|null
+     */
+    public function getSupplierById($id)
+    {
+        return $this->repository->findById($id);
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/SamlServiceService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/SamlServiceService.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service;
+
+use Ramsey\Uuid\Uuid;
+
+class SamlServiceService
+{
+    /**
+     * @return string
+     */
+    public function createServiceId()
+    {
+        return (string) Uuid::uuid1();
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/TicketService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/TicketService.php
@@ -15,36 +15,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service;
 
-namespace Surfnet\ServiceProviderDashboard\Domain\Repository;
-
+use Ramsey\Uuid\Uuid;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Supplier;
 
-interface SupplierRepository
+class TicketService
 {
     /**
+     * @param $serviceId
      * @param Supplier $supplier
+     * @return string
      */
-    public function save(Supplier $supplier);
-
-    /**
-     * Is the proposed supplier entity unique? The id of the supplier is not taken into account in this test.
-     *
-     * @param Supplier $supplier
-     *
-     * @return bool
-     */
-    public function isUnique(Supplier $supplier);
-
-    /**
-     * @return Supplier[]
-     */
-    public function findAll();
-
-    /**
-     * @param int $id
-     *
-     * @return Supplier|null
-     */
-    public function findById($id);
+    public function getTicketIdForService($serviceId, Supplier $supplier)
+    {
+        // For now return an uuid, later in the project an integration with Jira should be implemented.
+        return (string) Uuid::uuid1();
+    }
 }

--- a/tests/unit/Infrastructure/DashboardBundle/CommandHandler/Service/CreateServiceCommandHandlerTest.php
+++ b/tests/unit/Infrastructure/DashboardBundle/CommandHandler/Service/CreateServiceCommandHandlerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\DashboardBundle\CommandHandler\Supplier;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Surfnet\ServiceProviderDashboard\Application\Command\Service\CreateServiceCommand;
+use Surfnet\ServiceProviderDashboard\Application\CommandHandler\Service\CreateServiceCommandHandler;
+use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Supplier;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\ServiceRepository;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Command\Supplier\SelectSupplierCommand;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\CommandHandler\Supplier\SelectSupplierCommandHandler;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AdminSwitcherService;
+
+class CreateServiceCommandHandlerTest extends MockeryTestCase
+{
+    /** @var CreateServiceCommandHandler */
+    private $commandHandler;
+
+    /** @var ServiceRepository|m\MockInterface */
+    private $repository;
+
+    public function setUp()
+    {
+        $this->repository = m::mock(ServiceRepository::class);
+        $this->commandHandler = new CreateServiceCommandHandler($this->repository);
+    }
+
+    /**
+     * @test
+     * @group CommandHandler
+     */
+    public function it_should_handle_a_create_service_command()
+    {
+        $command = new CreateServiceCommand(
+            'd3d21618-b643-4b73-a971-bf735dd46481',
+            m::mock(Supplier::class),
+            '3500b012-b1ab-48d6-b3b1-2932a3db4c79'
+        );
+
+        $this->repository->shouldReceive('isUnique')->with('d3d21618-b643-4b73-a971-bf735dd46481')->andReturn(true);
+        $this->repository->shouldReceive('save');
+
+        $this->commandHandler->handle($command);
+    }
+
+    /**
+     * @test
+     * @group CommandHandler
+     *
+     * @expectedException \Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException
+     * @expectedExceptionMessage The id that was generated for the Service was not unique, please try again
+     */
+    public function it_should_reject_an_existing_id_collision()
+    {
+        $command = new CreateServiceCommand(
+            'd3d21618-b643-4b73-a971-bf735dd46481',
+            m::mock(Supplier::class),
+            '3500b012-b1ab-48d6-b3b1-2932a3db4c79'
+        );
+
+        $this->repository->shouldReceive('isUnique')->with('d3d21618-b643-4b73-a971-bf735dd46481')->andReturn(false);
+
+        $this->commandHandler->handle($command);
+    }
+}

--- a/tests/unit/Infrastructure/DashboardBundle/Service/AdminSwitcherServiceTest.php
+++ b/tests/unit/Infrastructure/DashboardBundle/Service/AdminSwitcherServiceTest.php
@@ -20,14 +20,15 @@ namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\DashboardBu
 
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Supplier;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\ServiceRepository;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\SupplierRepository;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AdminSwitcherService;
 use Symfony\Component\HttpFoundation\Session\Session;
 
 class AdminSwitcherServiceTest extends MockeryTestCase
 {
-    /** @var SupplierRepository|m\MockInterface */
+    /** @var ServiceRepository|m\MockInterface */
     private $repository;
 
     /** @var Session|m\MockInterface */
@@ -48,17 +49,17 @@ class AdminSwitcherServiceTest extends MockeryTestCase
     {
         $this->repository->shouldReceive('findAll')
             ->andReturn([
-                m::mock(Supplier::class)
+                m::mock(Service::class)
                     ->shouldReceive('getId')
                     ->andReturn('c')->getMock()
                     ->shouldReceive('getName')
                     ->andReturn('C')->getMock(),
-                m::mock(Supplier::class)
+                m::mock(Service::class)
                     ->shouldReceive('getId')
                     ->andReturn('a')->getMock()
                     ->shouldReceive('getName')
                     ->andReturn('A')->getMock(),
-                m::mock(Supplier::class)
+                m::mock(Service::class)
                     ->shouldReceive('getId')
                     ->andReturn('b')->getMock()
                     ->shouldReceive('getName')

--- a/tests/webtests/CreateServiceTest.php
+++ b/tests/webtests/CreateServiceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Webtests;
+
+use Mockery as m;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Supplier;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\ServiceRepository;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\SupplierRepository;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+class CreateServiceTest extends WebTestCase
+{
+    private $client;
+
+    /**
+     * @var SupplierRepository
+     */
+    private $supplierRepository;
+    /**
+     * @var ServiceRepository
+     */
+    private $serviceRepository;
+
+    public function setUp()
+    {
+        $this->client = static::createClient();
+        $this->supplierRepository = $this->client->getContainer()->get('surfnet.dashboard.repository.supplier');
+        $this->supplierRepository->clear();
+
+        $this->serviceRepository = $this->client->getContainer()->get('surfnet.dashboard.repository.service');
+        $this->serviceRepository->clear();
+
+        $supplier = m::mock(Supplier::class)->makePartial();
+        $supplier->setName('test1');
+        $supplier->shouldReceive('getId')->andReturn(1);
+
+        $this->supplierRepository->save($supplier);
+
+        $this->client->getContainer()->get('dashboard.service.admin_switcher')->setSelectedSupplier(1);
+    }
+
+    public function test_switcher_remembers_selected_supplier()
+    {
+
+        $this->client->request('GET', '/service/create');
+
+        $this->assertTrue(
+            $this->client->getResponse() instanceof RedirectResponse,
+            'Expecting a redirect response after creating as Service'
+        );
+
+        $this->client->followRedirect();
+
+        // One Service has been created
+        $records = $this->serviceRepository->findAll();
+        $this->assertCount(1, $records);
+        /** @var Service $service */
+        $service = $records[0];
+
+        // The Id and TicketNumber fields are Uuids
+        $this->assertNotEmpty($service->getId());
+        $this->assertNotEmpty($service->getTicketNumber());
+
+        $this->assertEquals(Service::ENVIRONMENT_CONNECT, $service->getEnvironment());
+        $this->assertEquals(Service::STATE_DRAFT, $service->getStatus());
+        $this->assertEquals('1', $service->getSupplier()->getId());
+        $this->assertEquals('test1', $service->getSupplier()->getName());
+    }
+}

--- a/tests/webtests/Repository/InMemoryServiceRepository.php
+++ b/tests/webtests/Repository/InMemoryServiceRepository.php
@@ -19,33 +19,16 @@
 namespace Surfnet\ServiceProviderDashboard\Webtests\Repository;
 
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Supplier;
-use Surfnet\ServiceProviderDashboard\Domain\Repository\SupplierRepository as SupplierRepositoryInterface;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\ServiceRepository as SupplierRepositoryInterface;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\ServiceRepository;
 
-class InMemorySupplierRepository implements SupplierRepositoryInterface
+class InMemoryServiceRepository implements ServiceRepository
 {
     private static $memory = [];
 
     public function clear()
     {
         self:$memory = [];
-    }
-
-    /**
-     * @param Supplier $supplier
-     */
-    public function save(Supplier $supplier)
-    {
-        self::$memory[] = $supplier;
-    }
-
-    /**
-     * @param Supplier $supplier
-     * @return bool
-     */
-    public function isUnique(Supplier $supplier)
-    {
-        return true;
     }
 
     /**
@@ -57,19 +40,27 @@ class InMemorySupplierRepository implements SupplierRepositoryInterface
     }
 
     /**
+     * @param Service $service
+     */
+    public function save(Service $service)
+    {
+        self::$memory[] = $service;
+    }
+
+    /**
      * @param int $id
      *
-     * @return Supplier|null
+     * @return bool
      */
-    public function findById($id)
+    public function isUnique($id)
     {
-        $allSuppliers = $this->findAll();
-        foreach ($allSuppliers as $supplier) {
-            if ($supplier->getId() == $id) {
-                return $supplier;
+        $allServices = $this->findAll();
+        foreach ($allServices as $service) {
+            if ($service->getId() == $id) {
+                return false;
             }
         }
 
-        return null;
+        return true;
     }
 }

--- a/tests/webtests/Resources/config/services.yml
+++ b/tests/webtests/Resources/config/services.yml
@@ -3,3 +3,6 @@
 services:
   surfnet.dashboard.repository.supplier:
     class: Surfnet\ServiceProviderDashboard\Webtests\Repository\InMemorySupplierRepository
+
+  surfnet.dashboard.repository.service:
+    class: Surfnet\ServiceProviderDashboard\Webtests\Repository\InMemoryServiceRepository


### PR DESCRIPTION
When visiting the `/service/create` route, a new service will be created for the currently active Supplier.

Only the mandatory data is set on the Supplier:
* Id
* Ticket number (a bogus uuid is generated as a stand in for the ticket number that is to be set)
* Supplier Id

The contents of #25 have been included in this PR.

This is is one in a series of pull requests that will implement the feature described in [pivotal #150962638](https://www.pivotaltracker.com/story/show/150962638).

Previous ticket: #25 
