### PR TITLE
Add translation interface

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -20,6 +20,7 @@ class AppKernel extends Kernel
             new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\DashboardBundle(),
             new League\Tactician\Bundle\TacticianBundle(),
+            new Lexik\Bundle\TranslationBundle\LexikTranslationBundle(),
         ];
 
         if (in_array($this->getEnvironment(), ['dev', 'test'], true)) {

--- a/app/DoctrineMigrations/Version20171004104623.php
+++ b/app/DoctrineMigrations/Version20171004104623.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20171004104623 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE lexik_translation_file (id INT AUTO_INCREMENT NOT NULL, domain VARCHAR(255) NOT NULL, locale VARCHAR(10) NOT NULL, extention VARCHAR(10) NOT NULL, path VARCHAR(255) NOT NULL, hash VARCHAR(255) NOT NULL, UNIQUE INDEX hash_idx (hash), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE lexik_trans_unit (id INT AUTO_INCREMENT NOT NULL, key_name VARCHAR(255) NOT NULL, domain VARCHAR(255) NOT NULL, created_at DATETIME DEFAULT NULL, updated_at DATETIME DEFAULT NULL, UNIQUE INDEX key_domain_idx (key_name, domain), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE lexik_trans_unit_translations (id INT AUTO_INCREMENT NOT NULL, file_id INT DEFAULT NULL, trans_unit_id INT DEFAULT NULL, locale VARCHAR(10) NOT NULL, content LONGTEXT NOT NULL, created_at DATETIME DEFAULT NULL, updated_at DATETIME DEFAULT NULL, INDEX IDX_B0AA394493CB796C (file_id), INDEX IDX_B0AA3944C3C583C9 (trans_unit_id), UNIQUE INDEX trans_unit_locale_idx (trans_unit_id, locale), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE lexik_trans_unit_translations ADD CONSTRAINT FK_B0AA394493CB796C FOREIGN KEY (file_id) REFERENCES lexik_translation_file (id)');
+        $this->addSql('ALTER TABLE lexik_trans_unit_translations ADD CONSTRAINT FK_B0AA3944C3C583C9 FOREIGN KEY (trans_unit_id) REFERENCES lexik_trans_unit (id)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE lexik_trans_unit_translations DROP FOREIGN KEY FK_B0AA394493CB796C');
+        $this->addSql('ALTER TABLE lexik_trans_unit_translations DROP FOREIGN KEY FK_B0AA3944C3C583C9');
+        $this->addSql('DROP TABLE lexik_translation_file');
+        $this->addSql('DROP TABLE lexik_trans_unit');
+        $this->addSql('DROP TABLE lexik_trans_unit_translations');
+    }
+}

--- a/app/Resources/translations/messages.en.yml
+++ b/app/Resources/translations/messages.en.yml
@@ -1,0 +1,4 @@
+page.header.help: Help
+page.header.logout: Logout
+page.header.privacy: Privacy
+page.header.contact: Contact

--- a/app/Resources/views/Translation/layout.html.twig
+++ b/app/Resources/views/Translation/layout.html.twig
@@ -1,0 +1,32 @@
+{% extends '::base.html.twig' %}
+
+{% block body_container %}
+    {% block lexik_stylesheets %}
+        <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
+            <link rel="stylesheet" href="{{ asset('bundles/lexiktranslation/ng-table/ng-table.min.css') }}">
+    {% endblock %}
+    {% block lexik_flash_message %}
+        <div class="container">
+            <div class="row">
+                <div class="col-md-12">
+                    {% set flashes = app.session.flashbag.all() %}
+                    {% if flashes | length > 0 %}
+                        {% for type, messages in flashes %}
+                            {% for message in messages %}
+                                <div class="alert alert-{{ type }}">{{ message }}</div>
+                            {% endfor %}
+                        {% endfor %}
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    {% endblock lexik_flash_message %}
+
+    {% block lexik_content '' %}
+
+    {% block lexik_javascript_footer %}
+        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.5.9/angular.min.js"></script>
+        <script src="{{ asset('bundles/lexiktranslation/ng-table/ng-table.min.js') }}"></script>
+    {% endblock %}
+{% endblock %}

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -31,9 +31,9 @@
                         </a>
                     </li>
                     <li>
-                        <a href="https://wiki.surfnet.nl/" target="_blank">Help</a>
+                        <a href="https://wiki.surfnet.nl/" target="_blank">{{ 'page.header.help'|trans }}</a>
                     </li>
-                    <li class="border-left"><a>Logout</a></li>
+                    <li class="border-left"><a>{{ 'page.header.logout'|trans }}</a></li>
                     <li class="admin-switcher">
                         {{ admin_switcher() }}
                     </li>
@@ -59,8 +59,8 @@
         </div>
         <div class="footer">
             <div class="footer-inner">
-                <span><a href="/" target="_blank">Privacy</a></span>
-                <span><a href="/" target="_blank">Contact</a></span>
+                <span><a href="/" target="_blank">{{ 'page.header.privacy'|trans }}</a></span>
+                <span><a href="/" target="_blank">{{ 'page.header.contact'|trans }}</a></span>
             </div>
         </div>
         {% block javascripts %}

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -53,9 +53,11 @@
                     </span>
                 </section>
             </div>
+            {% block body_container %}
             <div class="card">
                 {% block body %}{% endblock %}
             </div>
+            {% endblock %}
         </div>
         <div class="footer">
             <div class="footer-inner">

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -10,7 +10,7 @@ parameters:
 
 framework:
     #esi: ~
-    #translator: { fallbacks: ['%locale%'] }
+    translator: { fallbacks: ['%locale%'] }
     secret: '%secret%'
     router:
         resource: '%kernel.root_dir%/config/routing.yml'
@@ -81,3 +81,12 @@ stof_doctrine_extensions:
     orm:
         default:
             timestampable: true
+
+lexik_translation:
+    fallback_locale: [en] # (required) default locale(s) to use
+    managed_locales: [en] # (required) locales that the bundle has to manage
+    grid_input_type: textarea
+    grid_toggle_similar: true
+    resources_registration:
+        type: all
+        managed_locales_only: true

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -90,3 +90,4 @@ lexik_translation:
     resources_registration:
         type: all
         managed_locales_only: true
+    base_layout: "::Translation/layout.html.twig"

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,2 +1,6 @@
 dashboard:
     resource: '@DashboardBundle/Resources/config/routing.yml'
+
+lexik_translation_edition:
+    resource: "@LexikTranslationBundle/Resources/config/routing.yml"
+    prefix:   /translations

--- a/build.xml
+++ b/build.xml
@@ -113,4 +113,13 @@
             <arg line="--end-point=http://security.sensiolabs.org/check_lock" />
         </exec>
     </target>
+
+    <target name="import-translations">
+        <exec executable="bin/console" failonerror="true">
+            <arg line="lexik:translations:import" />
+        </exec>
+        <exec executable="bin/console" failonerror="true">
+            <arg line="lexik:translations:import DashboardBundle" />
+        </exec>
+    </target>
 </project>

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "doctrine/orm": "^2.5",
         "knplabs/knp-menu-bundle": "^2.1",
         "league/tactician-bundle": "^0.4.1",
+        "lexik/translation-bundle": "~4.0",
         "ramsey/uuid": "^3.7",
         "sensio/framework-extra-bundle": "^3.0",
         "stof/doctrine-extensions-bundle": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "158fc9b03cc988c7993732c3dae37fdc",
+    "content-hash": "f6e97a89a5a1e2cbacd74b6226011214",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -1384,6 +1384,72 @@
                 "tactician"
             ],
             "time": "2016-04-21T08:00:01+00:00"
+        },
+        {
+            "name": "lexik/translation-bundle",
+            "version": "v4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lexik/LexikTranslationBundle.git",
+                "reference": "a1df6797fe435861b1d6e7e1b0fb5a033a8ac5ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lexik/LexikTranslationBundle/zipball/a1df6797fe435861b1d6e7e1b0fb5a033a8ac5ed",
+                "reference": "a1df6797fe435861b1d6e7e1b0fb5a033a8ac5ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0",
+                "symfony/framework-bundle": "~2.8|~3.0"
+            },
+            "require-dev": {
+                "doctrine/data-fixtures": "~1.1",
+                "doctrine/doctrine-bundle": "~1.2",
+                "doctrine/mongodb-odm-bundle": "~3.0",
+                "doctrine/orm": "^2.2.3",
+                "phpunit/phpunit": "^5.7",
+                "propel/propel-bundle": "~1.5|3.0.0-alpha1@dev"
+            },
+            "suggest": {
+                "doctrine/mongodb-odm-bundle": "~3.0",
+                "doctrine/orm": ">=2.4",
+                "propel/propel-bundle": "~1.5"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Lexik\\Bundle\\TranslationBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dev Lexik",
+                    "email": "dev@lexik.fr"
+                },
+                {
+                    "name": "Cedric Girard",
+                    "email": "c.girard@lexik.fr"
+                }
+            ],
+            "description": "This bundle allows to import translation files content into the database and provide a GUI to edit translations.",
+            "homepage": "https://github.com/lexik/LexikTranslationBundle",
+            "keywords": [
+                "Symfony2",
+                "bundle",
+                "i18n",
+                "translation"
+            ],
+            "time": "2017-09-13T13:00:53+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,3 +4,4 @@
 2. [Testing](testing.md)
 3. [Ubiquitous language](ubiquitous_language.md)
 3. [Frontend tooling](frontend_tooling.md)
+3. [Translations](translations.md)

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,0 +1,12 @@
+# Translations
+
+The dashboard only supports the english language. Translations are
+used to allow administrators to modify messages. The [Lexik translation bundle](https://github.com/lexik/LexikTranslationBundle/)
+is used to provide the translation interface (/translations).
+
+Default translations can be found in the Resources/translations folder
+in app/ and each bundle.
+
+To import the default translations into the lexik database, run the
+`import-translations` ant target. This should be done after each
+deployment.

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Menu/Builder.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Menu/Builder.php
@@ -36,6 +36,10 @@ class Builder implements ContainerAwareInterface
             'route' => 'supplier_add',
         ));
 
+        $menu->addChild('Translations', array(
+            'route' => 'lexik_translation_overview',
+        ));
+
         return $menu;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -1,0 +1,1 @@
+supplier.create.title: Add new supplier

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Supplier/create.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Supplier/create.html.twig
@@ -2,7 +2,7 @@
 
 {% block body %}
 
-    <h2>Create a new Supplier</h2>
+    <h2>{{ 'supplier.create.title'|trans }}</h2>
 
     {% for message in app.flashes('error') %}
         <div class="message error">


### PR DESCRIPTION
See docs/translations.md:

 - default translations are stored in yml files inside Resources/translations
 - the translation interface allows overriding the default translations
 - a new ant target can be used to import new translations after deployment