### PR TITLE
Add the Service edit form

### DIFF
--- a/app/Resources/views/form/fields.html.twig
+++ b/app/Resources/views/form/fields.html.twig
@@ -1,0 +1,8 @@
+{%- block form_widget_simple -%}
+    {%- set type = type|default('text') -%}
+    {% for attrname,attrvalue in attr %}
+        {% if attrname == 'help' %}
+            <span class="help-block" data-help-text="{{ attrvalue|trans }}">?</span>{% endif %}
+    {% endfor %}
+    <input type="{{ type }}" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
+{%- endblock form_widget_simple -%}

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/EditServiceCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/EditServiceCommand.php
@@ -435,14 +435,6 @@ class EditServiceCommand implements Command
     }
 
     /**
-     * @return string
-     */
-    public function getTicketNo()
-    {
-        return $this->ticketNo;
-    }
-
-    /**
      * @param string $ticketNo
      */
     public function setTicketNo($ticketNo)

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/EditServiceCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/EditServiceCommand.php
@@ -1,0 +1,980 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Command\Service;
+
+use Surfnet\ServiceProviderDashboard\Application\Command\Command;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Supplier;
+use Surfnet\ServiceProviderDashboard\Domain\Model\Attribute;
+use Surfnet\ServiceProviderDashboard\Domain\Model\Contact;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @SuppressWarnings(PHPMD.TooManyFields)
+ * @SuppressWarnings(PHPMD.ExcessivePublicCount)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ */
+class EditServiceCommand implements Command
+{
+    /**
+     * @var string
+     * @Assert\NotBlank
+     * @Assert\Uuid
+     */
+    private $id;
+
+    /**
+     * @var Supplier
+     * @Assert\NotNull
+     */
+    private $supplier;
+
+    /**
+     * @var string
+     * @Assert\NotBlank
+     */
+    private $ticketNumber;
+
+    /**
+     * @var bool
+     */
+    private $archived = false;
+
+    /**
+     * @var string
+     */
+    private $environment = Service::ENVIRONMENT_CONNECT;
+
+    /**
+     * @var int
+     */
+    private $status = Service::STATE_DRAFT;
+
+    /**
+     * @var string
+     */
+    private $janusId;
+
+    /**
+     * Metadata URL that import last happened from.
+     *
+     * @var string
+     */
+    private $importUrl;
+
+    /**
+     * @var string
+     */
+    private $metadataUrl;
+
+    /**
+     * SAML XML Metadata for entity.
+     *
+     * Imported from metadataurl.
+     *
+     * @var string
+     */
+    private $metadataXml;
+
+    /**
+     * @var string
+     */
+    private $acsLocation;
+
+    /**
+     * @var string
+     */
+    private $entityId;
+
+    /**
+     * @var string
+     */
+    private $certificate;
+
+    /**
+     * @var string
+     */
+    private $logoUrl;
+
+    /**
+     * @var string
+     */
+    private $nameNl;
+
+    /**
+     * @var string
+     */
+    private $nameEn;
+
+    /**
+     * @var string
+     */
+    private $descriptionNl;
+
+    /**
+     * @var string
+     */
+    private $descriptionEn;
+
+    /**
+     * @var string
+     */
+    private $applicationUrl;
+
+    /**
+     * @var string
+     */
+    private $eulaUrl;
+
+    /**
+     * @var ContactPerson
+     */
+    private $administrativeContact;
+
+    /**
+     * @var ContactPerson
+     */
+    private $technicalContact;
+
+    /**
+     * @var ContactPerson
+     */
+    private $supportContact;
+
+    /**
+     * @var Attribute
+     */
+    private $givenNameAttribute;
+
+    /**
+     * @var Attribute
+     */
+    private $surNameAttribute;
+
+    /**
+     * @var Attribute
+     */
+    private $commonNameAttribute;
+
+    /**
+     * @var Attribute
+     */
+    private $displayNameAttribute;
+
+    /**
+     * @var Attribute
+     */
+    private $emailAddressAttribute;
+
+    /**
+     * @var Attribute
+     */
+    private $organizationAttribute;
+
+    /**
+     * @var Attribute
+     */
+    private $organizationTypeAttribute;
+
+    /**
+     * @var Attribute
+     */
+    private $affiliationAttribute;
+
+    /**
+     * @var Attribute
+     */
+    private $entitlementAttribute;
+
+    /**
+     * @var Attribute
+     */
+    private $principleNameAttribute;
+
+    /**
+     * @var Attribute
+     */
+    private $uidAttribute;
+
+    /**
+     * @var Attribute
+     */
+    private $preferredLanguageAttribute;
+
+    /**
+     * @var Attribute
+     */
+    private $personalCodeAttribute;
+
+    /**
+     * @var Attribute
+     */
+    private $scopedAffiliationAttribute;
+
+    /**
+     * @var Attribute
+     */
+    private $eduPersonTargetedIDAttribute;
+
+    /**
+     * @var string
+     */
+    private $comments;
+
+    /**
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     *
+     * @param string $id
+     * @param Supplier $supplier
+     * @param string $ticketNumber
+     * @param bool $archived
+     * @param string $environment
+     * @param int $status
+     * @param string $janusId
+     * @param string $importUrl
+     * @param string $metadataUrl
+     * @param string $metadataXml
+     * @param string $acsLocation
+     * @param string $entityId
+     * @param string $certificate
+     * @param string $logoUrl
+     * @param string $nameNl
+     * @param string $nameEn
+     * @param string $descriptionNl
+     * @param string $descriptionEn
+     * @param string $applicationUrl
+     * @param string $eulaUrl
+     * @param Contact $administrativeContact
+     * @param Contact $technicalContact
+     * @param Contact $supportContact
+     * @param Attribute $givenNameAttribute
+     * @param Attribute $surNameAttribute
+     * @param Attribute $commonNameAttribute
+     * @param Attribute $displayNameAttribute
+     * @param Attribute $emailAddressAttribute
+     * @param Attribute $organizationAttribute
+     * @param Attribute $organizationTypeAttribute
+     * @param Attribute $affiliationAttribute
+     * @param Attribute $entitlementAttribute
+     * @param Attribute $principleNameAttribute
+     * @param Attribute $uidAttribute
+     * @param Attribute $preferredLanguageAttribute
+     * @param Attribute $personalCodeAttribute
+     * @param Attribute $scopedAffiliationAttribute
+     * @param Attribute $eduPersonTargetedIDAttribute
+     * @param string $comments
+     */
+    public function __construct(
+        $id,
+        Supplier $supplier,
+        $ticketNumber,
+        $archived,
+        $environment,
+        $status,
+        $janusId,
+        $importUrl,
+        $metadataUrl,
+        $metadataXml,
+        $acsLocation,
+        $entityId,
+        $certificate,
+        $logoUrl,
+        $nameNl,
+        $nameEn,
+        $descriptionNl,
+        $descriptionEn,
+        $applicationUrl,
+        $eulaUrl,
+        $administrativeContact,
+        $technicalContact,
+        $supportContact,
+        $givenNameAttribute,
+        $surNameAttribute,
+        $commonNameAttribute,
+        $displayNameAttribute,
+        $emailAddressAttribute,
+        $organizationAttribute,
+        $organizationTypeAttribute,
+        $affiliationAttribute,
+        $entitlementAttribute,
+        $principleNameAttribute,
+        $uidAttribute,
+        $preferredLanguageAttribute,
+        $personalCodeAttribute,
+        $scopedAffiliationAttribute,
+        $eduPersonTargetedIDAttribute,
+        $comments
+    ) {
+        $this->id = $id;
+        $this->supplier = $supplier;
+        $this->ticketNumber = $ticketNumber;
+        $this->archived = $archived;
+        $this->environment = $environment;
+        $this->status = $status;
+        $this->janusId = $janusId;
+        $this->importUrl = $importUrl;
+        $this->metadataUrl = $metadataUrl;
+        $this->metadataXml = $metadataXml;
+        $this->acsLocation = $acsLocation;
+        $this->entityId = $entityId;
+        $this->certificate = $certificate;
+        $this->logoUrl = $logoUrl;
+        $this->nameNl = $nameNl;
+        $this->nameEn = $nameEn;
+        $this->descriptionNl = $descriptionNl;
+        $this->descriptionEn = $descriptionEn;
+        $this->applicationUrl = $applicationUrl;
+        $this->eulaUrl = $eulaUrl;
+        $this->administrativeContact = $administrativeContact;
+        $this->technicalContact = $technicalContact;
+        $this->supportContact = $supportContact;
+        $this->givenNameAttribute = $givenNameAttribute;
+        $this->surNameAttribute = $surNameAttribute;
+        $this->commonNameAttribute = $commonNameAttribute;
+        $this->displayNameAttribute = $displayNameAttribute;
+        $this->emailAddressAttribute = $emailAddressAttribute;
+        $this->organizationAttribute = $organizationAttribute;
+        $this->organizationTypeAttribute = $organizationTypeAttribute;
+        $this->affiliationAttribute = $affiliationAttribute;
+        $this->entitlementAttribute = $entitlementAttribute;
+        $this->principleNameAttribute = $principleNameAttribute;
+        $this->uidAttribute = $uidAttribute;
+        $this->preferredLanguageAttribute = $preferredLanguageAttribute;
+        $this->personalCodeAttribute = $personalCodeAttribute;
+        $this->scopedAffiliationAttribute = $scopedAffiliationAttribute;
+        $this->eduPersonTargetedIDAttribute = $eduPersonTargetedIDAttribute;
+        $this->comments = $comments;
+    }
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return Supplier
+     */
+    public function getSupplier()
+    {
+        return $this->supplier;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTicketNumber()
+    {
+        return $this->ticketNumber;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isArchived()
+    {
+        return $this->archived;
+    }
+
+    /**
+     * @param bool $archived
+     */
+    public function setArchived($archived)
+    {
+        $this->archived = $archived;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEnvironment()
+    {
+        return $this->environment;
+    }
+
+    /**
+     * @param string $environment
+     */
+    public function setEnvironment($environment)
+    {
+        $this->environment = $environment;
+    }
+
+    /**
+     * @return int
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    /**
+     * @param int $status
+     */
+    public function setStatus($status)
+    {
+        $this->status = $status;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTicketNo()
+    {
+        return $this->ticketNo;
+    }
+
+    /**
+     * @param string $ticketNo
+     */
+    public function setTicketNo($ticketNo)
+    {
+        $this->ticketNo = $ticketNo;
+    }
+
+    /**
+     * @return string
+     */
+    public function getJanusId()
+    {
+        return $this->janusId;
+    }
+
+    /**
+     * @param string $janusId
+     */
+    public function setJanusId($janusId)
+    {
+        $this->janusId = $janusId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getImportUrl()
+    {
+        return $this->importUrl;
+    }
+
+    /**
+     * @param string $importUrl
+     */
+    public function setImportUrl($importUrl)
+    {
+        $this->importUrl = $importUrl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMetadataUrl()
+    {
+        return $this->metadataUrl;
+    }
+
+    /**
+     * @param string $metadataUrl
+     */
+    public function setMetadataUrl($metadataUrl)
+    {
+        $this->metadataUrl = $metadataUrl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMetadataXml()
+    {
+        return $this->metadataXml;
+    }
+
+    /**
+     * @param string $metadataXml
+     */
+    public function setMetadataXml($metadataXml)
+    {
+        $this->metadataXml = $metadataXml;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAcsLocation()
+    {
+        return $this->acsLocation;
+    }
+
+    /**
+     * @param string $acsLocation
+     */
+    public function setAcsLocation($acsLocation)
+    {
+        $this->acsLocation = $acsLocation;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEntityId()
+    {
+        return $this->entityId;
+    }
+
+    /**
+     * @param string $entityId
+     */
+    public function setEntityId($entityId)
+    {
+        $this->entityId = $entityId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCertificate()
+    {
+        return $this->certificate;
+    }
+
+    /**
+     * @param string $certificate
+     */
+    public function setCertificate($certificate)
+    {
+        $this->certificate = $certificate;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLogoUrl()
+    {
+        return $this->logoUrl;
+    }
+
+    /**
+     * @param string $logoUrl
+     */
+    public function setLogoUrl($logoUrl)
+    {
+        $this->logoUrl = $logoUrl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameNl()
+    {
+        return $this->nameNl;
+    }
+
+    /**
+     * @param string $nameNl
+     */
+    public function setNameNl($nameNl)
+    {
+        $this->nameNl = $nameNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameEn()
+    {
+        return $this->nameEn;
+    }
+
+    /**
+     * @param string $nameEn
+     */
+    public function setNameEn($nameEn)
+    {
+        $this->nameEn = $nameEn;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescriptionNl()
+    {
+        return $this->descriptionNl;
+    }
+
+    /**
+     * @param string $descriptionNl
+     */
+    public function setDescriptionNl($descriptionNl)
+    {
+        $this->descriptionNl = $descriptionNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescriptionEn()
+    {
+        return $this->descriptionEn;
+    }
+
+    /**
+     * @param string $descriptionEn
+     */
+    public function setDescriptionEn($descriptionEn)
+    {
+        $this->descriptionEn = $descriptionEn;
+    }
+
+    /**
+     * @return string
+     */
+    public function getApplicationUrl()
+    {
+        return $this->applicationUrl;
+    }
+
+    /**
+     * @param string $applicationUrl
+     */
+    public function setApplicationUrl($applicationUrl)
+    {
+        $this->applicationUrl = $applicationUrl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEulaUrl()
+    {
+        return $this->eulaUrl;
+    }
+
+    /**
+     * @param string $eulaUrl
+     */
+    public function setEulaUrl($eulaUrl)
+    {
+        $this->eulaUrl = $eulaUrl;
+    }
+
+    /**
+     * @return ContactPerson
+     */
+    public function getAdministrativeContact()
+    {
+        return $this->administrativeContact;
+    }
+
+    /**
+     * @param ContactPerson $administrativeContact
+     */
+    public function setAdministrativeContact($administrativeContact)
+    {
+        $this->administrativeContact = $administrativeContact;
+    }
+
+    /**
+     * @return ContactPerson
+     */
+    public function getTechnicalContact()
+    {
+        return $this->technicalContact;
+    }
+
+    /**
+     * @param ContactPerson $technicalContact
+     */
+    public function setTechnicalContact($technicalContact)
+    {
+        $this->technicalContact = $technicalContact;
+    }
+
+    /**
+     * @return ContactPerson
+     */
+    public function getSupportContact()
+    {
+        return $this->supportContact;
+    }
+
+    /**
+     * @param ContactPerson $supportContact
+     */
+    public function setSupportContact($supportContact)
+    {
+        $this->supportContact = $supportContact;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getGivenNameAttribute()
+    {
+        return $this->givenNameAttribute;
+    }
+
+    /**
+     * @param Attribute $givenNameAttribute
+     */
+    public function setGivenNameAttribute($givenNameAttribute)
+    {
+        $this->givenNameAttribute = $givenNameAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getSurNameAttribute()
+    {
+        return $this->surNameAttribute;
+    }
+
+    /**
+     * @param Attribute $surNameAttribute
+     */
+    public function setSurNameAttribute($surNameAttribute)
+    {
+        $this->surNameAttribute = $surNameAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getCommonNameAttribute()
+    {
+        return $this->commonNameAttribute;
+    }
+
+    /**
+     * @param Attribute $commonNameAttribute
+     */
+    public function setCommonNameAttribute($commonNameAttribute)
+    {
+        $this->commonNameAttribute = $commonNameAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getDisplayNameAttribute()
+    {
+        return $this->displayNameAttribute;
+    }
+
+    /**
+     * @param Attribute $displayNameAttribute
+     */
+    public function setDisplayNameAttribute($displayNameAttribute)
+    {
+        $this->displayNameAttribute = $displayNameAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getEmailAddressAttribute()
+    {
+        return $this->emailAddressAttribute;
+    }
+
+    /**
+     * @param Attribute $emailAddressAttribute
+     */
+    public function setEmailAddressAttribute($emailAddressAttribute)
+    {
+        $this->emailAddressAttribute = $emailAddressAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getOrganizationAttribute()
+    {
+        return $this->organizationAttribute;
+    }
+
+    /**
+     * @param Attribute $organizationAttribute
+     */
+    public function setOrganizationAttribute($organizationAttribute)
+    {
+        $this->organizationAttribute = $organizationAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getOrganizationTypeAttribute()
+    {
+        return $this->organizationTypeAttribute;
+    }
+
+    /**
+     * @param Attribute $organizationTypeAttribute
+     */
+    public function setOrganizationTypeAttribute($organizationTypeAttribute)
+    {
+        $this->organizationTypeAttribute = $organizationTypeAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getAffiliationAttribute()
+    {
+        return $this->affiliationAttribute;
+    }
+
+    /**
+     * @param Attribute $affiliationAttribute
+     */
+    public function setAffiliationAttribute($affiliationAttribute)
+    {
+        $this->affiliationAttribute = $affiliationAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getEntitlementAttribute()
+    {
+        return $this->entitlementAttribute;
+    }
+
+    /**
+     * @param Attribute $entitlementAttribute
+     */
+    public function setEntitlementAttribute($entitlementAttribute)
+    {
+        $this->entitlementAttribute = $entitlementAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getPrincipleNameAttribute()
+    {
+        return $this->principleNameAttribute;
+    }
+
+    /**
+     * @param Attribute $principleNameAttribute
+     */
+    public function setPrincipleNameAttribute($principleNameAttribute)
+    {
+        $this->principleNameAttribute = $principleNameAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getUidAttribute()
+    {
+        return $this->uidAttribute;
+    }
+
+    /**
+     * @param Attribute $uidAttribute
+     */
+    public function setUidAttribute($uidAttribute)
+    {
+        $this->uidAttribute = $uidAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getPreferredLanguageAttribute()
+    {
+        return $this->preferredLanguageAttribute;
+    }
+
+    /**
+     * @param Attribute $preferredLanguageAttribute
+     */
+    public function setPreferredLanguageAttribute($preferredLanguageAttribute)
+    {
+        $this->preferredLanguageAttribute = $preferredLanguageAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getPersonalCodeAttribute()
+    {
+        return $this->personalCodeAttribute;
+    }
+
+    /**
+     * @param Attribute $personalCodeAttribute
+     */
+    public function setPersonalCodeAttribute($personalCodeAttribute)
+    {
+        $this->personalCodeAttribute = $personalCodeAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getScopedAffiliationAttribute()
+    {
+        return $this->scopedAffiliationAttribute;
+    }
+
+    /**
+     * @param Attribute $scopedAffiliationAttribute
+     */
+    public function setScopedAffiliationAttribute($scopedAffiliationAttribute)
+    {
+        $this->scopedAffiliationAttribute = $scopedAffiliationAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getEduPersonTargetedIDAttribute()
+    {
+        return $this->eduPersonTargetedIDAttribute;
+    }
+
+    /**
+     * @param Attribute $eduPersonTargetedIDAttribute
+     */
+    public function setEduPersonTargetedIDAttribute($eduPersonTargetedIDAttribute)
+    {
+        $this->eduPersonTargetedIDAttribute = $eduPersonTargetedIDAttribute;
+    }
+
+    /**
+     * @return string
+     */
+    public function getComments()
+    {
+        return $this->comments;
+    }
+
+    /**
+     * @param string $comments
+     */
+    public function setComments($comments)
+    {
+        $this->comments = $comments;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/EditServiceCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/EditServiceCommandHandler.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\CommandHandler\Service;
+
+use Surfnet\ServiceProviderDashboard\Application\Command\Service\EditServiceCommand;
+use Surfnet\ServiceProviderDashboard\Application\CommandHandler\CommandHandler;
+use Surfnet\ServiceProviderDashboard\Application\Exception\EntityNotFoundException;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\ServiceRepository;
+
+class EditServiceCommandHandler implements CommandHandler
+{
+    /**
+     * @var ServiceRepository
+     */
+    private $repository;
+
+    /**
+     * @param ServiceRepository $repository
+     */
+    public function __construct(ServiceRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function handle(EditServiceCommand $command)
+    {
+        $service = $this->repository->findById($command->getId());
+
+        if (is_null($service)) {
+            throw new EntityNotFoundException('The requested Service cannot be found');
+        }
+
+        $service->setSupplier($command->getSupplier());
+        $service->setArchived($command->isArchived());
+        $service->setEnvironment($command->getEnvironment());
+        $service->setStatus($command->getStatus());
+        $service->setJanusId($command->getJanusId());
+        $service->setImportUrl($command->getImportUrl());
+        $service->setMetadataUrl($command->getMetadataUrl());
+        $service->setMetadataXml($command->getMetadataXml());
+        $service->setAcsLocation($command->getAcsLocation());
+        $service->setEntityId($command->getEntityId());
+        $service->setCertificate($command->getCertificate());
+        $service->setLogoUrl($command->getLogoUrl());
+        $service->setNameNl($command->getNameNl());
+        $service->setNameEn($command->getNameEn());
+        $service->setDescriptionNl($command->getDescriptionNl());
+        $service->setDescriptionEn($command->getDescriptionEn());
+        $service->setApplicationUrl($command->getApplicationUrl());
+        $service->setEulaUrl($command->getEulaUrl());
+        $service->setAdministrativeContact($command->getAdministrativeContact());
+        $service->setTechnicalContact($command->getTechnicalContact());
+        $service->setSupportContact($command->getSupportContact());
+        $service->setGivenNameAttribute($command->getGivenNameAttribute());
+        $service->setSurNameAttribute($command->getSurNameAttribute());
+        $service->setCommonNameAttribute($command->getCommonNameAttribute());
+        $service->setDisplayNameAttribute($command->getDisplayNameAttribute());
+        $service->setEmailAddressAttribute($command->getEmailAddressAttribute());
+        $service->setOrganizationAttribute($command->getOrganizationAttribute());
+        $service->setOrganizationTypeAttribute($command->getOrganizationTypeAttribute());
+        $service->setAffiliationAttribute($command->getAffiliationAttribute());
+        $service->setEntitlementAttribute($command->getEntitlementAttribute());
+        $service->setPrincipleNameAttribute($command->getPrincipleNameAttribute());
+        $service->setUidAttribute($command->getUidAttribute());
+        $service->setPreferredLanguageAttribute($command->getPreferredLanguageAttribute());
+        $service->setPersonalCodeAttribute($command->getPersonalCodeAttribute());
+        $service->setScopedAffiliationAttribute($command->getScopedAffiliationAttribute());
+        $service->setEduPersonTargetedIDAttribute($command->getEduPersonTargetedIDAttribute());
+        $service->setComments($command->getComments());
+
+        $this->repository->save($service);
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/Factory/ServiceCommandFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Factory/ServiceCommandFactory.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Factory;
+
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Application\Command\Service\EditServiceCommand;
+
+class ServiceCommandFactory
+{
+    public function build(Service $service)
+    {
+        return new EditServiceCommand(
+            $service->getId(),
+            $service->getSupplier(),
+            $service->getTicketNumber(),
+            $service->isArchived(),
+            $service->getEnvironment(),
+            $service->getStatus(),
+            $service->getJanusId(),
+            $service->getImportUrl(),
+            $service->getMetadataUrl(),
+            $service->getMetadataXml(),
+            $service->getAcsLocation(),
+            $service->getEntityId(),
+            $service->getCertificate(),
+            $service->getLogoUrl(),
+            $service->getNameNl(),
+            $service->getNameEn(),
+            $service->getDescriptionNl(),
+            $service->getDescriptionEn(),
+            $service->getApplicationUrl(),
+            $service->getEulaUrl(),
+            $service->getAdministrativeContact(),
+            $service->getTechnicalContact(),
+            $service->getSupportContact(),
+            $service->getGivenNameAttribute(),
+            $service->getSurNameAttribute(),
+            $service->getCommonNameAttribute(),
+            $service->getDisplayNameAttribute(),
+            $service->getEmailAddressAttribute(),
+            $service->getOrganizationAttribute(),
+            $service->getOrganizationTypeAttribute(),
+            $service->getAffiliationAttribute(),
+            $service->getEntitlementAttribute(),
+            $service->getPrincipleNameAttribute(),
+            $service->getUidAttribute(),
+            $service->getPreferredLanguageAttribute(),
+            $service->getPersonalCodeAttribute(),
+            $service->getScopedAffiliationAttribute(),
+            $service->getEduPersonTargetedIDAttribute(),
+            $service->getComments()
+        );
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
@@ -29,8 +29,9 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @ORM\Entity(repositoryClass="Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\ServiceRepository")
  *
- * @SuppressWarnings(PHPMD.UnusedPrivateField Fields of this class are not yet used, remove this once they are used)
  * @SuppressWarnings(PHPMD.TooManyFields)
+ * @SuppressWarnings(PHPMD.ExcessivePublicCount)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  */
 class Service
 {
@@ -321,9 +322,9 @@ class Service
     /**
      * @param string $ticketNumber
      */
-    public function setTicketNumber($ticketNo)
+    public function setTicketNumber($ticketNumber)
     {
-        $this->ticketNo = $ticketNo;
+        $this->ticketNo = $ticketNumber;
     }
 
     /**
@@ -364,5 +365,301 @@ class Service
     public function getEnvironment()
     {
         return $this->environment;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isArchived()
+    {
+        return $this->archived;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getCreated()
+    {
+        return $this->created;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getUpdated()
+    {
+        return $this->updated;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTicketNo()
+    {
+        return $this->ticketNo;
+    }
+
+    /**
+     * @return string
+     */
+    public function getJanusId()
+    {
+        return $this->janusId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getImportUrl()
+    {
+        return $this->importUrl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMetadataUrl()
+    {
+        return $this->metadataUrl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMetadataXml()
+    {
+        return $this->metadataXml;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAcsLocation()
+    {
+        return $this->acsLocation;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEntityId()
+    {
+        return $this->entityId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCertificate()
+    {
+        return $this->certificate;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLogoUrl()
+    {
+        return $this->logoUrl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameNl()
+    {
+        return $this->nameNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameEn()
+    {
+        return $this->nameEn;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescriptionNl()
+    {
+        return $this->descriptionNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescriptionEn()
+    {
+        return $this->descriptionEn;
+    }
+
+    /**
+     * @return string
+     */
+    public function getApplicationUrl()
+    {
+        return $this->applicationUrl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEulaUrl()
+    {
+        return $this->eulaUrl;
+    }
+
+    /**
+     * @return ContactPerson
+     */
+    public function getAdministrativeContact()
+    {
+        return $this->administrativeContact;
+    }
+
+    /**
+     * @return ContactPerson
+     */
+    public function getTechnicalContact()
+    {
+        return $this->technicalContact;
+    }
+
+    /**
+     * @return ContactPerson
+     */
+    public function getSupportContact()
+    {
+        return $this->supportContact;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getGivenNameAttribute()
+    {
+        return $this->givenNameAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getSurNameAttribute()
+    {
+        return $this->surNameAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getCommonNameAttribute()
+    {
+        return $this->commonNameAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getDisplayNameAttribute()
+    {
+        return $this->displayNameAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getEmailAddressAttribute()
+    {
+        return $this->emailAddressAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getOrganizationAttribute()
+    {
+        return $this->organizationAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getOrganizationTypeAttribute()
+    {
+        return $this->organizationTypeAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getAffiliationAttribute()
+    {
+        return $this->affiliationAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getEntitlementAttribute()
+    {
+        return $this->entitlementAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getPrincipleNameAttribute()
+    {
+        return $this->principleNameAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getUidAttribute()
+    {
+        return $this->uidAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getPreferredLanguageAttribute()
+    {
+        return $this->preferredLanguageAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getPersonalCodeAttribute()
+    {
+        return $this->personalCodeAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getScopedAffiliationAttribute()
+    {
+        return $this->scopedAffiliationAttribute;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getEduPersonTargetedIDAttribute()
+    {
+        return $this->eduPersonTargetedIDAttribute;
+    }
+
+    /**
+     * @return string
+     */
+    public function getComments()
+    {
+        return $this->comments;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
@@ -328,6 +328,294 @@ class Service
     }
 
     /**
+     * @param bool $archived
+     */
+    public function setArchived($archived)
+    {
+        $this->archived = $archived;
+    }
+
+    /**
+     * @param string $environment
+     */
+    public function setEnvironment($environment)
+    {
+        $this->environment = $environment;
+    }
+
+    /**
+     * @param int $status
+     */
+    public function setStatus($status)
+    {
+        $this->status = $status;
+    }
+
+    /**
+     * @param string $janusId
+     */
+    public function setJanusId($janusId)
+    {
+        $this->janusId = $janusId;
+    }
+
+    /**
+     * @param string $importUrl
+     */
+    public function setImportUrl($importUrl)
+    {
+        $this->importUrl = $importUrl;
+    }
+
+    /**
+     * @param string $metadataUrl
+     */
+    public function setMetadataUrl($metadataUrl)
+    {
+        $this->metadataUrl = $metadataUrl;
+    }
+
+    /**
+     * @param string $metadataXml
+     */
+    public function setMetadataXml($metadataXml)
+    {
+        $this->metadataXml = $metadataXml;
+    }
+
+    /**
+     * @param string $acsLocation
+     */
+    public function setAcsLocation($acsLocation)
+    {
+        $this->acsLocation = $acsLocation;
+    }
+
+    /**
+     * @param string $entityId
+     */
+    public function setEntityId($entityId)
+    {
+        $this->entityId = $entityId;
+    }
+
+    /**
+     * @param string $certificate
+     */
+    public function setCertificate($certificate)
+    {
+        $this->certificate = $certificate;
+    }
+
+    /**
+     * @param string $logoUrl
+     */
+    public function setLogoUrl($logoUrl)
+    {
+        $this->logoUrl = $logoUrl;
+    }
+
+    /**
+     * @param string $nameNl
+     */
+    public function setNameNl($nameNl)
+    {
+        $this->nameNl = $nameNl;
+    }
+
+    /**
+     * @param string $nameEn
+     */
+    public function setNameEn($nameEn)
+    {
+        $this->nameEn = $nameEn;
+    }
+
+    /**
+     * @param string $descriptionNl
+     */
+    public function setDescriptionNl($descriptionNl)
+    {
+        $this->descriptionNl = $descriptionNl;
+    }
+
+    /**
+     * @param string $descriptionEn
+     */
+    public function setDescriptionEn($descriptionEn)
+    {
+        $this->descriptionEn = $descriptionEn;
+    }
+
+    /**
+     * @param string $applicationUrl
+     */
+    public function setApplicationUrl($applicationUrl)
+    {
+        $this->applicationUrl = $applicationUrl;
+    }
+
+    /**
+     * @param string $eulaUrl
+     */
+    public function setEulaUrl($eulaUrl)
+    {
+        $this->eulaUrl = $eulaUrl;
+    }
+
+    /**
+     * @param ContactPerson $administrativeContact
+     */
+    public function setAdministrativeContact(ContactPerson $administrativeContact)
+    {
+        $this->administrativeContact = $administrativeContact;
+    }
+
+    /**
+     * @param ContactPerson $technicalContact
+     */
+    public function setTechnicalContact(ContactPerson $technicalContact)
+    {
+        $this->technicalContact = $technicalContact;
+    }
+
+    /**
+     * @param ContactPerson $supportContact
+     */
+    public function setSupportContact(ContactPerson $supportContact)
+    {
+        $this->supportContact = $supportContact;
+    }
+
+    /**
+     * @param Attribute $givenNameAttribute
+     */
+    public function setGivenNameAttribute(Attribute $givenNameAttribute)
+    {
+        $this->givenNameAttribute = $givenNameAttribute;
+    }
+
+    /**
+     * @param Attribute $surNameAttribute
+     */
+    public function setSurNameAttribute(Attribute $surNameAttribute)
+    {
+        $this->surNameAttribute = $surNameAttribute;
+    }
+
+    /**
+     * @param Attribute $commonNameAttribute
+     */
+    public function setCommonNameAttribute(Attribute $commonNameAttribute)
+    {
+        $this->commonNameAttribute = $commonNameAttribute;
+    }
+
+    /**
+     * @param Attribute $displayNameAttribute
+     */
+    public function setDisplayNameAttribute(Attribute $displayNameAttribute)
+    {
+        $this->displayNameAttribute = $displayNameAttribute;
+    }
+
+    /**
+     * @param Attribute $emailAddressAttribute
+     */
+    public function setEmailAddressAttribute(Attribute $emailAddressAttribute)
+    {
+        $this->emailAddressAttribute = $emailAddressAttribute;
+    }
+
+    /**
+     * @param Attribute $organizationAttribute
+     */
+    public function setOrganizationAttribute(Attribute $organizationAttribute)
+    {
+        $this->organizationAttribute = $organizationAttribute;
+    }
+
+    /**
+     * @param Attribute $organizationTypeAttribute
+     */
+    public function setOrganizationTypeAttribute(Attribute $organizationTypeAttribute)
+    {
+        $this->organizationTypeAttribute = $organizationTypeAttribute;
+    }
+
+    /**
+     * @param Attribute $affiliationAttribute
+     */
+    public function setAffiliationAttribute(Attribute $affiliationAttribute)
+    {
+        $this->affiliationAttribute = $affiliationAttribute;
+    }
+
+    /**
+     * @param Attribute $entitlementAttribute
+     */
+    public function setEntitlementAttribute(Attribute $entitlementAttribute)
+    {
+        $this->entitlementAttribute = $entitlementAttribute;
+    }
+
+    /**
+     * @param Attribute $principleNameAttribute
+     */
+    public function setPrincipleNameAttribute(Attribute $principleNameAttribute)
+    {
+        $this->principleNameAttribute = $principleNameAttribute;
+    }
+
+    /**
+     * @param Attribute $uidAttribute
+     */
+    public function setUidAttribute(Attribute $uidAttribute)
+    {
+        $this->uidAttribute = $uidAttribute;
+    }
+
+    /**
+     * @param Attribute $preferredLanguageAttribute
+     */
+    public function setPreferredLanguageAttribute(Attribute $preferredLanguageAttribute)
+    {
+        $this->preferredLanguageAttribute = $preferredLanguageAttribute;
+    }
+
+    /**
+     * @param Attribute $personalCodeAttribute
+     */
+    public function setPersonalCodeAttribute(Attribute $personalCodeAttribute)
+    {
+        $this->personalCodeAttribute = $personalCodeAttribute;
+    }
+
+    /**
+     * @param Attribute $scopedAffiliationAttribute
+     */
+    public function setScopedAffiliationAttribute(Attribute $scopedAffiliationAttribute)
+    {
+        $this->scopedAffiliationAttribute = $scopedAffiliationAttribute;
+    }
+
+    /**
+     * @param Attribute $eduPersonTargetedIDAttribute
+     */
+    public function setEduPersonTargetedIDAttribute(Attribute $eduPersonTargetedIDAttribute)
+    {
+        $this->eduPersonTargetedIDAttribute = $eduPersonTargetedIDAttribute;
+    }
+
+    /**
+     * @param string $comments
+     */
+    public function setComments($comments)
+    {
+        $this->comments = $comments;
+    }
+
+    /**
      * @return Supplier
      */
     public function getSupplier()
@@ -389,14 +677,6 @@ class Service
     public function getUpdated()
     {
         return $this->updated;
-    }
-
-    /**
-     * @return string
-     */
-    public function getTicketNo()
-    {
-        return $this->ticketNo;
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Repository/ServiceRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Repository/ServiceRepository.php
@@ -33,4 +33,11 @@ interface ServiceRepository
      * @return bool
      */
     public function isUnique($id);
+
+    /**
+     * @param int $id
+     *
+     * @return Service|null
+     */
+    public function findById($id);
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -111,20 +111,16 @@ class ServiceController extends Controller
 
         $form = $this->createForm(EditServiceType::class, $command);
         $form->handleRequest($request);
-//
 
-//
+        if ($form->isSubmitted() && $form->isValid()) {
+            try {
+                $this->commandBus->handle($command);
+                return $this->redirectToRoute('entity_list');
+            } catch (InvalidArgumentException $e) {
+                $this->addFlash('error', $e->getMessage());
+            }
+        }
 
-//
-//        if ($form->isSubmitted() && $form->isValid()) {
-//            try {
-//                $this->commandBus->handle($command);
-//                return $this->redirectToRoute('entity_list');
-//            } catch (InvalidArgumentException $e) {
-//                $this->addFlash('error', $e->getMessage());
-//            }
-//        }
-//
         return $this->render('DashboardBundle:Service:edit.html.twig', array(
             'form' => $form->createView(),
         ));

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -22,10 +22,12 @@ use League\Tactician\CommandBus;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Surfnet\ServiceProviderDashboard\Application\Command\Service\CreateServiceCommand;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service\EditServiceType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AdminSwitcherService;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\SamlServiceService;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\TicketService;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class ServiceController extends Controller
@@ -44,6 +46,7 @@ class ServiceController extends Controller
      * @var AdminSwitcherService
      */
     private $switcherService;
+
     /**
      * @var TicketService
      */
@@ -93,19 +96,25 @@ class ServiceController extends Controller
     /**
      * @Method({"GET", "POST"})
      * @Route("/service/edit/{serviceId}", name="service_edit")
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     *
+     * @param Request $request
+     * @param $serviceId
+     *
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
-    public function editAction($serviceId)
+    public function editAction(Request $request, $serviceId)
     {
-        return new Response($serviceId);
-//        // Todo: perform authorization check
-//        $this->get('session')->getFlashBag()->clear();
-//        /** @var LoggerInterface $logger */
-//        $command = new EditServiceCommand();
+
+        $service = $this->samlService->getServiceById($serviceId);
+
+        $command = $this->samlService->buildEditServiceCommand($service);
+
+        $form = $this->createForm(EditServiceType::class, $command);
+        $form->handleRequest($request);
 //
-//        $form = $this->createForm(ServiceType::class, $command);
+
 //
-//        $form->handleRequest($request);
+
 //
 //        if ($form->isSubmitted() && $form->isValid()) {
 //            try {
@@ -116,8 +125,8 @@ class ServiceController extends Controller
 //            }
 //        }
 //
-//        return $this->render('DashboardBundle:Service:edit.html.twig', array(
-//            'form' => $form->createView(),
-//        ));
+        return $this->render('DashboardBundle:Service:edit.html.twig', array(
+            'form' => $form->createView(),
+        ));
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Service/AttributeType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Service/AttributeType.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service;
+
+use Surfnet\ServiceProviderDashboard\Domain\Model\Attribute;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class AttributeType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('requested', CheckboxType::class);
+        $builder->add('motivation');
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => Attribute::class,
+        ));
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'dashboard_bundle_contact_type';
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Service/ContactType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Service/ContactType.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service;
+
+use Surfnet\ServiceProviderDashboard\Domain\Model\Contact;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ContactType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('firstName');
+        $builder->add('lastName');
+        $builder->add('email');
+        $builder->add('phone');
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => Contact::class,
+        ));
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'dashboard_bundle_contact_type';
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Service/EditServiceType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Service/EditServiceType.php
@@ -1,0 +1,272 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service;
+
+use Surfnet\ServiceProviderDashboard\Application\Command\Service\EditServiceCommand;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class EditServiceType extends AbstractType
+{
+    /**
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     *
+     * @param FormBuilderInterface $builder
+     * @param array $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add(
+                $builder->create(
+                    'general',
+                    FormType::class,
+                    [
+                        'inherit_data' => true,
+                        'label' => 'General information',
+                    ]
+                )
+                    ->add(
+                        'ticketNumber',
+                        TextType::class,
+                        [
+                            'disabled' => true,
+                            'attr' => ['help' => 'edit.service.ticketNumber'],
+                        ]
+                    )
+                    ->add('archived')
+                    ->add('environment')
+                    ->add('status')
+                    ->add('janusId')
+            )
+            ->add(
+                $builder->create('metadata', FormType::class, ['inherit_data' => true])
+                    ->add(
+                        'importUrl',
+                        TextType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.importUrl'],
+                        ]
+                    )
+                    ->add(
+                        'metadataUrl',
+                        TextType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.metadataUrl'],
+                        ]
+                    )
+                    ->add(
+                        'metadataXml',
+                        TextareaType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.metadataXml'],
+                        ]
+                    )
+                    ->add('acsLocation')
+                    ->add('entityId')
+                    ->add(
+                        'certificate',
+                        TextareaType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.certificate'],
+                        ]
+                    )
+                    ->add('logoUrl')
+                    ->add('nameNl')
+                    ->add(
+                        'descriptionNl',
+                        TextareaType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.descriptionNl'],
+                        ]
+                    )
+                    ->add('nameEn')
+                    ->add(
+                        'descriptionEn',
+                        TextareaType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.descriptionEn'],
+                        ]
+                    )
+                    ->add('applicationUrl')
+                    ->add('eulaUrl')
+            )
+            ->add(
+                $builder->create('contactInformation', FormType::class, ['inherit_data' => true])
+                    ->add(
+                        'administrativeContact',
+                        ContactType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.administrativeContact'],
+                        ]
+                    )
+                    ->add(
+                        'technicalContact',
+                        ContactType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.administrativeContact'],
+                        ]
+                    )
+                    ->add(
+                        'supportContact',
+                        ContactType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.supportContact'],
+                        ]
+                    )
+            )
+            ->add(
+                $builder->create('attributes', FormType::class, ['inherit_data' => true])
+                    ->add(
+                        'givenNameAttribute',
+                        AttributeType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.givenNameAttribute'],
+                        ]
+                    )
+                    ->add(
+                        'surNameAttribute',
+                        AttributeType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.surNameAttribute'],
+                        ]
+                    )
+                    ->add(
+                        'commonNameAttribute',
+                        AttributeType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.commonNameAttribute'],
+                        ]
+                    )
+                    ->add(
+                        'displayNameAttribute',
+                        AttributeType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.displayNameAttribute'],
+                        ]
+                    )
+                    ->add(
+                        'emailAddressAttribute',
+                        AttributeType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.emailAddressAttribute'],
+                        ]
+                    )
+                    ->add(
+                        'organizationAttribute',
+                        AttributeType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.organizationAttribute'],
+                        ]
+                    )
+                    ->add(
+                        'organizationTypeAttribute',
+                        AttributeType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.organizationTypeAttribute'],
+                        ]
+                    )
+                    ->add(
+                        'affiliationAttribute',
+                        AttributeType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.affiliationAttribute'],
+                        ]
+                    )
+                    ->add(
+                        'entitlementAttribute',
+                        AttributeType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.entitlementAttribute'],
+                        ]
+                    )
+                    ->add(
+                        'principleNameAttribute',
+                        AttributeType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.principleNameAttribute'],
+                        ]
+                    )
+                    ->add(
+                        'uidAttribute',
+                        AttributeType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.uidAttribute'],
+                        ]
+                    )
+                    ->add(
+                        'preferredLanguageAttribute',
+                        AttributeType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.preferredLanguageAttribute'],
+                        ]
+                    )
+                    ->add(
+                        'personalCodeAttribute',
+                        AttributeType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.personalCodeAttribute'],
+                        ]
+                    )
+                    ->add(
+                        'scopedAffiliationAttribute',
+                        AttributeType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.scopedAffiliationAttribute'],
+                        ]
+                    )
+                    ->add(
+                        'eduPersonTargetedIDAttribute',
+                        AttributeType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.eduPersonTargetedIDAttribute'],
+                        ]
+                    )
+            )
+            ->add(
+                $builder->create('comments', FormType::class, ['inherit_data' => true])
+                    ->add(
+                        'comments',
+                        TextareaType::class,
+                        [
+                            'attr' => ['help' => 'edit.service.comments'],
+                        ]
+                    )
+            )
+            ->add('save', SubmitType::class, ['attr' => ['class' => 'button']])
+            ->add('publish', SubmitType::class, ['attr' => ['class' => 'button']]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => EditServiceCommand::class,
+        ));
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'dashboard_bundle_edit_service_type';
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Menu/Builder.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Menu/Builder.php
@@ -32,6 +32,9 @@ class Builder implements ContainerAwareInterface
 
         $menu->addChild('Services', array('route' => 'entity_list'));
 
+        $menu->addChild('Add new service', array(
+            'route' => 'service_add',
+        ));
         $menu->addChild('Add new supplier', array(
             'route' => 'supplier_add',
         ));

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Repository/ServiceRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Repository/ServiceRepository.php
@@ -51,4 +51,13 @@ class ServiceRepository extends EntityRepository implements ServiceRepositoryInt
 
         return false;
     }
+
+    /**
+     * @param int $id
+     * @return Service|null
+     */
+    public function findById($id)
+    {
+        return $this->find($id);
+    }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -56,9 +56,15 @@ services:
 
   dashboard.service.saml_service:
     class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\SamlServiceService
+    arguments:
+      - '@surfnet.dashboard.repository.service'
+      - '@dashboard.factory.service'
 
   dashboard.service.ticket:
     class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\TicketService
+
+  dashboard.factory.service:
+    class: Surfnet\ServiceProviderDashboard\Application\Factory\ServiceCommandFactory
 
   surfnet.dashboard.command_handler.select_supplier:
     class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\CommandHandler\Supplier\SelectSupplierCommandHandler

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -32,6 +32,14 @@ services:
     tags:
       - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Service\CreateServiceCommand }
 
+  surfnet.dashboard.command_handler.edit_service:
+    class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Service\EditServiceCommandHandler
+    public: true
+    arguments:
+      - '@surfnet.dashboard.repository.service'
+    tags:
+      - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Service\EditServiceCommand }
+
   surfnet.dashboard.command_handler.create_supplier:
     class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Supplier\CreateSupplierCommandHandler
     public: true

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/edit.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/edit.html.twig
@@ -1,0 +1,43 @@
+{% form_theme form 'form/fields.html.twig' %}
+
+{% extends '::base.html.twig' %}
+
+{% block content %}
+
+    <h1>Service Provider registration form</h1>
+
+    {{ form_start(form, {'attr': {'novalidate': 'novalidate'}}) }}
+
+    <div class="fieldset card">
+        <h2>{{ 'general_title'|trans }}</h2>
+        <div>{{ 'general_text'|trans }}</div>
+        {{ form_widget(form.general) }}
+    </div>
+
+    <div class="fieldset card">
+        <h2>{{ 'metadata_title'|trans }}</h2>
+        <div>{{ 'metadata_text'|trans }}</div>
+        {{ form_widget(form.metadata) }}
+    </div>
+
+    <div class="fieldset card">
+        <h2>{{ 'contact_information_title'|trans }}</h2>
+        <div>{{ 'contact_information_text'|trans }}</div>
+        {{ form_widget(form.contactInformation) }}
+    </div>
+
+    <div class="fieldset card">
+        <h2>{{ 'attributes_title'|trans }}</h2>
+        <div>{{ 'attributes_text'|trans }}</div>
+        {{ form_widget(form.attributes) }}
+    </div>
+
+    <div class="fieldset card">
+        <h2>{{ 'comments_title'|trans }}</h2>
+        <div>{{ 'comments_text'|trans }}</div>
+        {{ form_widget(form.comments) }}
+    </div>
+
+    {{ form_end(form) }}
+
+{% endblock %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/edit.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/edit.html.twig
@@ -2,7 +2,7 @@
 
 {% extends '::base.html.twig' %}
 
-{% block content %}
+{% block body %}
 
     <h1>Service Provider registration form</h1>
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/SamlServiceService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/SamlServiceService.php
@@ -18,14 +18,59 @@
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service;
 
 use Ramsey\Uuid\Uuid;
+use Surfnet\ServiceProviderDashboard\Application\Command\Service\EditServiceCommand;
+use Surfnet\ServiceProviderDashboard\Application\Factory\ServiceCommandFactory;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\ServiceRepository;
 
 class SamlServiceService
 {
+
+    /**
+     * @var ServiceRepository
+     */
+    private $repository;
+
+    /**
+     * @var ServiceCommandFactory
+     */
+    private $factory;
+
+    /**
+     * @param ServiceRepository $repository
+     * @param ServiceCommandFactory $factory
+     */
+    public function __construct(ServiceRepository $repository, ServiceCommandFactory $factory)
+    {
+        $this->repository = $repository;
+        $this->factory = $factory;
+    }
+
     /**
      * @return string
      */
     public function createServiceId()
     {
         return (string) Uuid::uuid1();
+    }
+
+    /**
+     * @param $serviceId
+     *
+     * @return Service|null
+     */
+    public function getServiceById($serviceId)
+    {
+        return $this->repository->findById($serviceId);
+    }
+
+    /**
+     * @param Service $service
+     *
+     * @return EditServiceCommand
+     */
+    public function buildEditServiceCommand(Service $service)
+    {
+        return $this->factory->build($service);
     }
 }

--- a/tests/unit/Application/Factory/ServiceCommandFactoryTest.php
+++ b/tests/unit/Application/Factory/ServiceCommandFactoryTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Application\Factory;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Surfnet\ServiceProviderDashboard\Application\Command\Service\EditServiceCommand;
+use Surfnet\ServiceProviderDashboard\Application\Factory\ServiceCommandFactory;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Supplier;
+
+class ServiceCommandFactoryTest extends MockeryTestCase
+{
+
+    /**
+     * @var ServiceCommandFactory
+     */
+    private $factory;
+
+    public function setUp()
+    {
+        $this->factory = new ServiceCommandFactory();
+    }
+
+    /**
+     * @test
+     * @group Factory
+     */
+    public function it_can_build_a_command_from_an_entity()
+    {
+        /** @var Service $entity */
+        $entity = m::mock(Service::class)->makePartial();
+
+        $supplier = m::mock(Supplier::class);
+        $supplier->shouldReceive('getName')->andReturn('Ibuildings');
+
+        $entity->setSupplier($supplier);
+        $entity->setId('4e7d5872-3a58-4832-a0b4-d5df61d808f9');
+        $entity->setTicketNumber('0766b312-36b2-47f7-a7da-4704b5581192');
+
+        $command = $this->factory->build($entity);
+        $this->assertInstanceOf(EditServiceCommand::class, $command);
+        $this->assertEquals('4e7d5872-3a58-4832-a0b4-d5df61d808f9', $command->getId());
+        $this->assertEquals('0766b312-36b2-47f7-a7da-4704b5581192', $command->getTicketNumber());
+        $this->assertEquals('Ibuildings', $command->getSupplier()->getName());
+    }
+}

--- a/tests/webtests/CreateServiceTest.php
+++ b/tests/webtests/CreateServiceTest.php
@@ -74,7 +74,7 @@ class CreateServiceTest extends WebTestCase
         $records = $this->serviceRepository->findAll();
         $this->assertCount(1, $records);
         /** @var Service $service */
-        $service = $records[0];
+        $service = array_pop($records);
 
         // The Id and TicketNumber fields are Uuids
         $this->assertNotEmpty($service->getId());

--- a/tests/webtests/Repository/InMemoryServiceRepository.php
+++ b/tests/webtests/Repository/InMemoryServiceRepository.php
@@ -44,7 +44,7 @@ class InMemoryServiceRepository implements ServiceRepository
      */
     public function save(Service $service)
     {
-        self::$memory[] = $service;
+        self::$memory[$service->getId()] = $service;
     }
 
     /**
@@ -62,5 +62,19 @@ class InMemoryServiceRepository implements ServiceRepository
         }
 
         return true;
+    }
+
+    /**
+     * @param int $id
+     *
+     * @return Service|null
+     */
+    public function findById($id)
+    {
+        if (array_key_exists($id, self::$memory)) {
+            return self::$memory[$id];
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
In this PR the edit form was created for Services. Styling has not yet been taken into consideration. Rudimentary support for information popups was added.

The CreateService command was added, it is not yet covered by tests.

This is is one in a series of pull requests that will implement the feature described in [pivotal #150962638](https://www.pivotaltracker.com/story/show/150962638).

Previous PR #27