### PR TITLE
Support dashboard without suppliers or selected supplier

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceListController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceListController.php
@@ -23,8 +23,9 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AdminSwitcherService;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\SamlServiceService;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
-class ServiceListController
+class ServiceListController extends Controller
 {
     /**
      * @var AdminSwitcherService
@@ -37,7 +38,8 @@ class ServiceListController
     private $samlServiceService;
 
     /**
-     * @param CommandBus $commandBus
+     * @param AdminSwitcherService $adminSwitcherService
+     * @param SamlServiceService $samlServiceService
      */
     public function __construct(AdminSwitcherService $adminSwitcherService, SamlServiceService $samlServiceService)
     {
@@ -49,13 +51,22 @@ class ServiceListController
      * @Method("GET")
      * @Route("/", name="service_list")
      * @Template()
+     *
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse|array
      */
     public function listAction()
     {
+        $supplierOptions = $this->adminSwitcherService->getSupplierOptions();
+
+        if (empty($supplierOptions)) {
+            return $this->redirectToRoute('supplier_add');
+        }
+
+        $selectedSupplierId = $this->adminSwitcherService->getSelectedSupplier();
+
         return [
-            'service_list' => $this->samlServiceService->getServiceListForSupplier(
-                $this->adminSwitcherService->getSelectedSupplier()
-            )
+            'no_supplier_selected' => empty($selectedSupplierId),
+            'service_list' => $this->samlServiceService->getServiceListForSupplier($selectedSupplierId),
         ];
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -1,5 +1,6 @@
 service.list.title: Services
 service.list.empty: There are no services configured
+service.list.no_supplier_selected: Please select a supplier
 service.list.service: Service
 service.list.entity_id: Entity ID
 service.list.primary_contact: Primary contact

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/ServiceList/list.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/ServiceList/list.html.twig
@@ -2,7 +2,9 @@
 
 {% block page_heading %}{{ 'service.list.title'|trans }}{%endblock%}
 {% block body %}
-    {% if service_list.services is empty %}
+    {% if no_supplier_selected %}
+        {{ 'service.list.no_supplier_selected'|trans }}
+    {% elseif service_list.services is empty %}
         {{ 'service.list.empty'|trans }}
     {% else %}
     <table>

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/TwigExtension/admin_switcher.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/TwigExtension/admin_switcher.html.twig
@@ -1,7 +1,8 @@
 <form action="{{ path('select_supplier') }}" method="POST">
     <select name="supplier" id="admin-switcher">
+        <option value=""></option>
     {% for supplier_id,supplier_name in suppliers %}
-        <option value="{{ supplier_id }}" {{ supplier_id == selected_supplier ? 'selected' : '' }}>{{ supplier_name }}</option>
+        <option value="{{ supplier_id }}"{{ supplier_id == selected_supplier ? ' selected' : '' }}>{{ supplier_name }}</option>
     {% endfor %}
     </select>
     <noscript>

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/ViewObject/Service.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/ViewObject/Service.php
@@ -67,7 +67,7 @@ class Service
         }
 
         return new self(
-            $service->getId(),
+            $service->getEntityId(),
             $service->getNameEn(),
             $formattedContact,
             $service->getEnvironment()

--- a/tests/webtests/AdminSwitcherTest.php
+++ b/tests/webtests/AdminSwitcherTest.php
@@ -29,7 +29,7 @@ class AdminSwitcherTest extends WebTestCase
     private $client;
 
     /**
-     * @var SupplierRepository
+     * @var Surfnet\ServiceProviderDashboard\WebTests\Repository\InMemorySupplierRepository
      */
     private $repository;
 
@@ -55,7 +55,7 @@ class AdminSwitcherTest extends WebTestCase
     {
         $this->client->getCookieJar()->clear();
 
-        $crawler = $this->client->request('GET', '/');
+        $crawler = $this->client->request('GET', '/supplier/create');
 
         $this->assertEmpty(
             $crawler->filter('select#admin-switcher option:selected')
@@ -66,20 +66,21 @@ class AdminSwitcherTest extends WebTestCase
     {
         $this->client->getCookieJar()->clear();
 
-        $crawler = $this->client->request('GET', '/');
+        $crawler = $this->client->request('GET', '/supplier/create');
         $options = $crawler->filter('select#admin-switcher option');
 
-        $this->assertCount(2, $options, 'Expecting 2 suppliers in admin switcher');
+        $this->assertCount(3, $options, 'Expecting 2 suppliers in admin switcher (excluding empty option)');
 
-        $this->assertEquals('test1', $options->eq(0)->text());
-        $this->assertEquals('test2', $options->eq(1)->text());
+        $this->assertEquals('', $options->eq(0)->text());
+        $this->assertEquals('test1', $options->eq(1)->text());
+        $this->assertEquals('test2', $options->eq(2)->text());
     }
 
     public function test_switcher_remembers_selected_supplier()
     {
         $this->client->getCookieJar()->clear();
 
-        $crawler = $this->client->request('GET', '/');
+        $crawler = $this->client->request('GET', '/supplier/create');
         $form = $crawler->filter('.admin-switcher')
             ->selectButton('Select')
             ->form();

--- a/tests/webtests/Repository/InMemoryServiceRepository.php
+++ b/tests/webtests/Repository/InMemoryServiceRepository.php
@@ -28,7 +28,7 @@ class InMemoryServiceRepository implements ServiceRepository
 
     public function clear()
     {
-        self:$memory = [];
+        self::$memory = [];
     }
 
     /**
@@ -89,7 +89,7 @@ class InMemoryServiceRepository implements ServiceRepository
         $result = [];
 
         foreach ($allServices as $service) {
-            if ($service->getId() == $supplierId) {
+            if ($service->getSupplier()->getId() === $supplierId) {
                 $result[] = $service;
             }
         }

--- a/tests/webtests/ServiceListTest.php
+++ b/tests/webtests/ServiceListTest.php
@@ -18,18 +18,104 @@
 
 namespace Surfnet\ServiceProviderDashboard\Webtests;
 
+use Mockery as m;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Supplier;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class ServiceListTest extends WebTestCase
 {
+    private $client;
+
+    /**
+     * @var Surfnet\ServiceProviderDashboard\Webtests\Repository\InMemorySupplierRepository
+     */
+    private $suppliers;
+
+    /**
+     * @var Surfnet\ServiceProviderDashboard\Webtests\Repository\InMemoryServiceRepository
+     */
+    private $services;
+
+    public function setUp()
+    {
+        $this->client = static::createClient();
+        $this->suppliers = $this->client->getContainer()->get('surfnet.dashboard.repository.supplier');
+        $this->services = $this->client->getContainer()->get('surfnet.dashboard.repository.service');
+        $this->suppliers->clear();
+        $this->services->clear();
+
+        $supplier1 = m::mock(Supplier::class)->makePartial();
+        $supplier1->setName('test1');
+        $supplier1->shouldReceive('getId')->andReturn('test1');
+
+        $supplier2 = m::mock(Supplier::class)->makePartial();
+        $supplier2->setName('test2');
+        $supplier2->shouldReceive('getId')->andReturn('test2');
+
+        $this->suppliers->save($supplier1);
+        $this->suppliers->save($supplier2);
+
+        $service1 = new Service();
+        $service1->setId(1);
+        $service1->setSupplier($supplier1);
+        $service1->setNameEn('Service1');
+        $service1->setEntityId('service-1');
+        $service1->setEnvironment('connect');
+
+        $service2 = new Service();
+        $service2->setId(2);
+        $service2->setSupplier($supplier1);
+        $service2->setNameEn('Service2');
+        $service2->setEntityId('service-2');
+        $service2->setEnvironment('connect');
+
+        $this->services->save($service1);
+        $this->services->save($service2);
+    }
+
     public function test_entity_list()
     {
-        $client = static::createClient();
+        $switcherService = $this->client->getContainer()->get('dashboard.service.admin_switcher');
+        $switcherService->setSelectedSupplier('test1');
 
-        $crawler = $client->request('GET', '/');
+        $crawler = $this->client->request('GET', '/');
 
         $pageTitle = $crawler->filter('.page-container h1');
 
         $this->assertEquals('Services', $pageTitle->text());
+        $this->assertCount(3, $crawler->filter('table tr'), 'Expecting three rows (including header)');
+
+        $row = $crawler->filter('table tr')->eq(1);
+        $this->assertEquals('Service1', $row->filter('td')->eq(0)->text(), 'Name not found in service list');
+        $this->assertEquals('service-1', $row->filter('td')->eq(1)->text(), 'Entity ID not found in service list');
+        $this->assertEquals('connect', $row->filter('td')->eq(3)->text(), 'Environment not found in service list');
+    }
+
+    public function test_entity_list_redirects_to_supplier_add_when_no_supplier_exists()
+    {
+        $this->client->getCookieJar()->clear();
+        $this->suppliers->clear();
+
+        $crawler = $this->client->request('GET', '/');
+        $response = $this->client->getResponse();
+
+        $this->assertTrue(
+            $response instanceof RedirectResponse,
+            'Expecting a redirect response after selecting a supplier'
+        );
+
+        $this->assertRegExp('#supplier/create$#', $response->headers->get('location'));
+    }
+
+    public function test_entity_list_shows_message_when_no_supplier_selected()
+    {
+        $this->client->getCookieJar()->clear();
+
+        $crawler = $this->client->request('GET', '/');
+        $response = $this->client->getResponse();
+
+        $this->assertContains('Please select a supplier', $response->getContent());
     }
 }


### PR DESCRIPTION
This commit implements two use cases:

 - there are no suppliers created yet: redirect to supplier/create
 - no supplier is selected: show a message in the service list

Tests are added for above use cases and for the service list.