### PR TITLE
Remove insignificant fields from Service edit form

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Service/EditServiceType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Service/EditServiceType.php
@@ -55,10 +55,6 @@ class EditServiceType extends AbstractType
                             'attr' => ['help' => 'service.edit.information.ticketNumber'],
                         ]
                     )
-                    ->add('archived')
-                    ->add('environment')
-                    ->add('status')
-                    ->add('janusId')
             )
             ->add(
                 $builder->create('metadata', FormType::class, ['inherit_data' => true])


### PR DESCRIPTION
The archived, environment, status and janusId fields have been removed
from the form type.