### PR TITLE
Allow regular users to use the service switcher

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/ServiceService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/ServiceService.php
@@ -41,7 +41,7 @@ class ServiceService
      * Format: [ '<service id>' => '<service display name>' ]
      * @return array
      */
-    public function getServiceNames()
+    public function getServiceNamesById()
     {
         $options = [];
 

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Contact.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Contact.php
@@ -60,12 +60,12 @@ class Contact
     private $emailAddress;
 
     /**
-     * @var Service
+     * @var Service[]
      *
-     * @ORM\ManyToOne(targetEntity="Service", inversedBy="contacts")
+     * @ORM\ManyToMany(targetEntity="Service", inversedBy="contacts")
      * @ORM\JoinColumn(nullable=false)
      */
-    private $service;
+    private $services;
 
     /**
      * @param string $nameId
@@ -118,22 +118,34 @@ class Contact
     }
 
     /**
-     * @param Service $service
+     * @param Service[] $services
      *
      * @return Contact
      */
-    public function setService(Service $service)
+    public function setServices(array $services)
     {
-        $this->service = $service;
+        $this->services = $services;
 
         return $this;
     }
 
     /**
-     * @return Service
+     * @param Service $service
+     *
+     * @return Contact
      */
-    public function getService()
+    public function addService(Service $service)
     {
-        return $this->service;
+        $this->services[] = $service;
+
+        return $this;
+    }
+
+    /**
+     * @return Service[]
+     */
+    public function getServices()
+    {
+        return $this->services;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
@@ -43,7 +43,7 @@ class Service
     /**
      * @var string
      *
-     * @ORM\Column(type="guid", unique=true)
+     * @ORM\Column(type="guid")
      */
     private $guid;
 
@@ -64,7 +64,7 @@ class Service
     /**
      * @var \Doctrine\Common\Collections\ArrayCollection
      *
-     * @ORM\OneToMany(targetEntity="Contact", mappedBy="service", cascade={"persist"}, orphanRemoval=true)
+     * @ORM\ManyToMany(targetEntity="Contact", mappedBy="services", cascade={"persist"}, orphanRemoval=true)
      */
     private $contacts;
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityListController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityListController.php
@@ -23,7 +23,6 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Surfnet\ServiceProviderDashboard\Application\Service\EntityService;
-use Surfnet\ServiceProviderDashboard\Application\Service\ServiceService;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AuthorizationService;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
@@ -40,23 +39,13 @@ class EntityListController extends Controller
     private $entityService;
 
     /**
-     * @var ServiceService
-     */
-    private $serviceService;
-
-    /**
      * @param AuthorizationService $authorizationService
      * @param EntityService $entityService
-     * @param ServiceService $serviceService
      */
-    public function __construct(
-        AuthorizationService $authorizationService,
-        EntityService $entityService,
-        ServiceService $serviceService
-    ) {
+    public function __construct(AuthorizationService $authorizationService, EntityService $entityService)
+    {
         $this->authorizationService = $authorizationService;
         $this->entityService = $entityService;
-        $this->serviceService = $serviceService;
     }
 
     /**
@@ -69,7 +58,7 @@ class EntityListController extends Controller
      */
     public function listAction()
     {
-        $serviceOptions = $this->serviceService->getServiceNames();
+        $serviceOptions = $this->authorizationService->getAllowedServiceNamesById();
 
         if (empty($serviceOptions)) {
             return $this->redirectToRoute('service_add');

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -118,7 +118,7 @@ class ServiceController extends Controller
         /** @var LoggerInterface $logger */
         $logger = $this->get('logger');
         $service = $this->serviceService->getServiceById(
-            $this->authorizationService->getSelectedServiceId()
+            $this->authorizationService->getActiveServiceId()
         );
 
         $command = new EditServiceCommand(
@@ -151,7 +151,7 @@ class ServiceController extends Controller
     /**
      * @Method("POST")
      * @Route("/service/select", name="select_service")
-     * @Security("has_role('ROLE_ADMINISTRATOR')")
+     * @Security("has_role('ROLE_USER')")
      */
     public function selectAction(Request $request)
     {

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Repository/ServiceRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Repository/ServiceRepository.php
@@ -40,38 +40,8 @@ class ServiceRepository extends DoctrineEntityRepository implements ServiceRepos
      */
     public function isUnique(Service $service)
     {
-        $this->isGuidUnique($service->getGuid(), $service->getId());
         $this->isTeamNameUnique($service->getTeamName(), $service->getId());
         return true;
-    }
-
-    /**
-     * @param string $guid
-     * @param null|int $id
-     * @throws InvalidArgumentException
-     */
-    private function isGuidUnique($guid, $id = null)
-    {
-        $qb = $this->createQueryBuilder('s')
-            ->where('s.guid = :guid')
-            ->setParameter('guid', $guid);
-
-        // When checking uniqueness of existing entity, exclude its own record from the results
-        if (!is_null($id)) {
-            $qb->andWhere('s.id != :id')
-                ->setParameter('id', $id);
-        }
-
-        $serviceExists = $qb->getQuery()->getOneOrNullResult();
-
-        if ($serviceExists) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'The Guid of the service should be unique. This Guid is taken by: "%s"',
-                    $serviceExists->getName()
-                )
-            );
-        }
     }
 
     /**
@@ -96,9 +66,8 @@ class ServiceRepository extends DoctrineEntityRepository implements ServiceRepos
         if ($serviceExists) {
             throw new InvalidArgumentException(
                 sprintf(
-                    'The teamname of the Service should be unique. This teamname is taken by: "%s" with Guid: "%s"',
-                    $serviceExists->getName(),
-                    $serviceExists->getGuid()
+                    'The teamname of the service should be unique. This teamname is taken by: "%s"',
+                    $serviceExists->getName()
                 )
             );
         }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/AuthorizationService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/AuthorizationService.php
@@ -18,11 +18,17 @@
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service;
 
 use RuntimeException;
+use Surfnet\ServiceProviderDashboard\Application\Service\ServiceService;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class AuthorizationService
 {
+    /**
+     * @var ServiceService
+     */
+    private $serviceService;
+
     /**
      * @var Session
      */
@@ -34,14 +40,97 @@ class AuthorizationService
     private $tokenStorage;
 
     public function __construct(
+        ServiceService $serviceService,
         Session $session,
         TokenStorageInterface $tokenStorage
     ) {
+        $this->serviceService = $serviceService;
         $this->session = $session;
         $this->tokenStorage = $tokenStorage;
     }
 
     /**
+     * @return bool
+     */
+    public function isLoggedIn()
+    {
+        $token = $this->tokenStorage->getToken();
+        if (!$token) {
+            return false;
+        }
+
+        return (bool) $token->getUser();
+    }
+
+    /**
+     * Is the logged-in user an administrator?
+     *
+     * @return bool
+     */
+    public function isAdministrator()
+    {
+        if (!$this->isLoggedIn()) {
+            return false;
+        }
+
+        return $this->tokenStorage->getToken()->hasRole('ROLE_ADMINISTRATOR');
+    }
+
+    /**
+     * Does the user have access to a single supplier, or select a supplier in the swithcer?
+     *
+     * @return bool
+     */
+    public function hasActiveServiceId()
+    {
+        if (!$this->isLoggedIn()) {
+            return false;
+        }
+
+        $activeServiceId = $this->getActiveServiceId();
+
+        return !empty($activeServiceId);
+    }
+
+    /**
+     * Get the service the user is currently working on.
+     *
+     * The service can be active in two ways:
+     *
+     * - the user has access to only one service, the switcher is not shown
+     *    and the service is always "active"
+     *
+     * - the user has access to multiple services and the user selected one
+     *   service from the switcher
+     *
+     * @return string
+     */
+    public function getActiveServiceId()
+    {
+        $token = $this->tokenStorage->getToken();
+        if (!$token) {
+            throw new RuntimeException(
+                'No authentication token found in session'
+            );
+        }
+
+        if (!$this->hasSelectedServiceId()) {
+            $allowedServices = $this->getAllowedServiceNamesById();
+
+            // If there a user has access to only service - always use it.
+            if (count($allowedServices) === 1) {
+                $this->setSelectedServiceId(
+                    array_keys($allowedServices)[0]
+                );
+            }
+        }
+
+        return $this->getSelectedServiceId();
+    }
+
+    /**
+     * Explicitly select a service for users that have access to multiple services.
+     *
      * @param string $serviceId
      *
      * @return AuthorizationService
@@ -54,14 +143,40 @@ class AuthorizationService
     }
 
     /**
+     * Get the service selected in the service switcher.
+     *
      * @return string
      */
     public function getSelectedServiceId()
     {
-        return $this->session->get('selected_service_id');
+        $serviceId = $this->session->get('selected_service_id');
+
+        if ($serviceId && !$this->hasAccessToService($serviceId)) {
+            throw new RuntimeException(
+                sprintf('User is not granted access to service with ID %d', $serviceId)
+            );
+        }
+
+        return $serviceId;
     }
 
-    public function getActiveServiceId()
+    /**
+     * Did the user select a service in the switcher?
+     *
+     * @return bool
+     */
+    public function hasSelectedServiceId()
+    {
+        return $this->session->has('selected_service_id');
+    }
+
+
+    /**
+     * Get all service names keyed by ID the user has access to.
+     *
+     * @return array
+     */
+    public function getAllowedServiceNamesById()
     {
         $token = $this->tokenStorage->getToken();
         if (!$token) {
@@ -70,8 +185,10 @@ class AuthorizationService
             );
         }
 
+        $serviceNames = $this->serviceService->getServiceNamesById();
+
         if ($token->hasRole('ROLE_ADMINISTRATOR')) {
-            return $this->getSelectedServiceId();
+            return $serviceNames;
         }
 
         $contact = $token->getUser()->getContact();
@@ -81,13 +198,30 @@ class AuthorizationService
             );
         }
 
-        $service = $contact->getService();
-        if (!$service) {
-            throw new RuntimeException(
-                'No service found for authenticated user'
-            );
-        }
+        return array_filter(
+            $serviceNames,
+            function ($id) use ($contact) {
+                foreach ($contact->getServices() as $service) {
+                    if ($service->getId() === $id) {
+                        return true;
+                    }
+                }
 
-        return $contact->getService()->getId();
+                return false;
+            },
+            ARRAY_FILTER_USE_KEY
+        );
+    }
+
+    /**
+     * @param string $serviceId
+     */
+    private function hasAccessToService($serviceId)
+    {
+        $allowedServiceIds = array_keys(
+            $this->getAllowedServiceNamesById()
+        );
+
+        return in_array($serviceId, $allowedServiceIds);
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Security/Authentication/Provider/SamlProvider.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Security/Authentication/Provider/SamlProvider.php
@@ -103,7 +103,7 @@ class SamlProvider implements AuthenticationProviderInterface
         }
 
         if ($role === 'ROLE_USER') {
-            $this->assignServiceToContact($contact, $teamNames);
+            $this->assignServicesToContact($contact, $teamNames);
             $this->contacts->save($contact);
         }
 
@@ -119,7 +119,7 @@ class SamlProvider implements AuthenticationProviderInterface
      * @param Contact $contact
      * @param array $teamNames
      */
-    private function assignServiceToContact(Contact $contact, $teamNames)
+    private function assignServicesToContact(Contact $contact, $teamNames)
     {
         $services = $this->services->findByTeamNames($teamNames);
 
@@ -132,20 +132,11 @@ class SamlProvider implements AuthenticationProviderInterface
             throw new RuntimeException(
                 'You do not have access to a service'
             );
-        } elseif (count($services) > 1) {
-            $this->logger->warning(sprintf(
-                'User is member of multiple teams ("%s"), matching more than one services in the dashboard - not supported.',
-                implode(', ', $teamNames)
-            ));
-
-            throw new RuntimeException(
-                'You are assigned multiple services: this is not supported'
-            );
         }
 
-        $contact->setService(
-            reset($services)
-        );
+        foreach ($services as $service) {
+            $contact->addService($service);
+        }
     }
 
     public function supports(TokenInterface $token)

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Security/Authentication/Token/SamlToken.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Security/Authentication/Token/SamlToken.php
@@ -64,7 +64,13 @@ class SamlToken extends AbstractToken
             return false;
         }
 
-        return $contact->getService()->getId() === $service->getId();
+        foreach ($contact->getServices() as $grantedService) {
+            if ($grantedService->getId() === $service->getId()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/integration/Application/CommandHandler/Service/CreateServiceCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Service/CreateServiceCommandHandlerTest.php
@@ -64,8 +64,7 @@ class CreateServiceCommandHandlerTest extends MockeryTestCase
 
     /**
      * @expectedException \Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The Guid of the new service should be unique.
-     *                           This teamname is taken by: HZ with Guid: 30dd879c-ee2f-11db-8314-0800200c9a66
+     * @expectedExceptionMessage This teamname is taken by: HZ with Guid: 30dd879c-ee2f-11db-8314-0800200c9a66
      * @group CommandHandler
      */
     public function test_it_rejects_non_unique_create_service_command()
@@ -79,7 +78,7 @@ class CreateServiceCommandHandlerTest extends MockeryTestCase
             ->shouldReceive('isUnique')
             ->andThrow(
                 InvalidArgumentException::class,
-                'The Guid of the new service should be unique. This teamname is taken by: HZ with Guid: 30dd879c-ee2f-11db-8314-0800200c9a66'
+                'This teamname is taken by: HZ with Guid: 30dd879c-ee2f-11db-8314-0800200c9a66'
             )
             ->once();
         $this->commandHandler->handle($command);

--- a/tests/integration/Application/CommandHandler/Service/EditServiceCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Service/EditServiceCommandHandlerTest.php
@@ -91,8 +91,7 @@ class EditServiceCommandHandlerTest extends MockeryTestCase
 
     /**
      * @expectedException \Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The Guid of the new Service should be unique.
-     *                           This teamname is taken by: HZ with Guid: 30dd879c-ee2f-11db-8314-0800200c9a66
+     * @expectedExceptionMessage This teamname is taken by: HZ with Guid: 30dd879c-ee2f-11db-8314-0800200c9a66
      * @group CommandHandler
      */
     public function test_it_rejects_non_unique_edit_service_command()
@@ -108,7 +107,7 @@ class EditServiceCommandHandlerTest extends MockeryTestCase
             ->shouldReceive('isUnique')
             ->andThrow(
                 InvalidArgumentException::class,
-                'The Guid of the new Service should be unique. This teamname is taken by: HZ with Guid: 30dd879c-ee2f-11db-8314-0800200c9a66'
+                'This teamname is taken by: HZ with Guid: 30dd879c-ee2f-11db-8314-0800200c9a66'
             )
             ->once();
         $this->commandHandler->handle($command);

--- a/tests/unit/Application/Service/ServiceServiceTest.php
+++ b/tests/unit/Application/Service/ServiceServiceTest.php
@@ -65,7 +65,7 @@ class ServiceServiceTest extends MockeryTestCase
                 'b' => 'B',
                 'c' => 'C',
             ],
-            $this->service->getServiceNames()
+            $this->service->getServiceNamesById()
         );
     }
 }

--- a/tests/webtests/CreateServiceTest.php
+++ b/tests/webtests/CreateServiceTest.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Webtests;
 
+use Ramsey\Uuid\Uuid;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
@@ -59,17 +60,15 @@ class CreateServiceTest extends WebTestCase
         $this->assertEquals('This is not a valid UUID.', $nodes->first()->text());
     }
 
-    public function test_it_rejects_duplicate_guids()
+    public function test_it_rejects_duplicate_teamnames()
     {
         $this->logIn('ROLE_ADMINISTRATOR');
 
-        $existingGuid = $this->getServiceRepository()->findByName('SURFnet')->getGuid();
-
         $formData = [
             'dashboard_bundle_service_type' => [
-                'guid' => $existingGuid,
+                'guid' => Uuid::uuid4(),
                 'name' => 'The A Team',
-                'teamName' => 'team-a',
+                'teamName' => 'urn:collab:org:surf.nl',
             ]
         ];
 
@@ -84,7 +83,7 @@ class CreateServiceTest extends WebTestCase
         $nodes = $crawler->filter('.page-container .message.error');
 
         $this->assertEquals(
-            'The Guid of the service should be unique. This Guid is taken by: "SURFnet"',
+            'The teamname of the service should be unique. This teamname is taken by: "SURFnet"',
             trim($nodes->first()->text())
         );
     }

--- a/tests/webtests/EditEntityTest.php
+++ b/tests/webtests/EditEntityTest.php
@@ -64,7 +64,7 @@ class EditEntityTest extends WebTestCase
 
         $surfNetEntityId = $surfNet->getEntities()->first()->getId();
 
-        $this->logIn('ROLE_USER', $ibuildings);
+        $this->logIn('ROLE_USER', [$ibuildings]);
 
         $this->client->request('GET', "/entity/edit/{$surfNetEntityId}");
         $this->assertEquals(403, $this->client->getResponse()->getStatusCode());

--- a/tests/webtests/IdentityHeaderTest.php
+++ b/tests/webtests/IdentityHeaderTest.php
@@ -59,7 +59,6 @@ class IdentityHeaderTest extends WebTestCase
         $crawler = $this->client->request('GET', '/');
 
         $this->assertCount(1, $crawler->filter('.navigation ul li:contains("Add new service")'));
-        $this->assertCount(1, $crawler->filter('.navigation ul li:contains("Edit service")'));
         $this->assertCount(1, $crawler->filter('.navigation ul li:contains("Translations")'));
     }
 }

--- a/tests/webtests/WebTestCase.php
+++ b/tests/webtests/WebTestCase.php
@@ -81,17 +81,21 @@ class WebTestCase extends SymfonyWebTestCase
         return $this->client->getContainer()->get('doctrine')->getManager();
     }
 
-    protected function logIn($role = 'ROLE_ADMINISTRATOR', Service $service = null)
+    /**
+     * @param string $role
+     * @param Service[] $services
+     */
+    protected function logIn($role = 'ROLE_ADMINISTRATOR', array $services = [])
     {
         $session = $this->client->getContainer()->get('session');
 
         $contact = new Contact('webtest:nameid:johndoe', 'johndoe@localhost', 'John Doe');
 
-        if (!$service) {
-            $service = new Service();
+        if (empty($services)) {
+            $services[] = new Service();
         }
 
-        $contact->setService($service);
+        $contact->setServices($services);
 
         $authenticatedToken = new SamlToken([$role]);
         $authenticatedToken->setUser(


### PR DESCRIPTION
The switcher is no longer exclusively for administrators. Instead of
showing all services in the database (administrator behaviour) the
switcher is shown when users have access to more than one services.

- [x] Drop the migration in favor of a schema drop/create solution
- [x] The Guid field for a service is no longer required
- [x] Don't forget to mention to Bart, the schema needs to be dropped & created to fix schema changes for this PR. 