### PR TITLE
Add privacy questions for Services

### DIFF
--- a/app/DoctrineMigrations/Version20171026075111.php
+++ b/app/DoctrineMigrations/Version20171026075111.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20171026075111 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE privacy_questions (id INT AUTO_INCREMENT NOT NULL, service_id INT NOT NULL, what_data LONGTEXT DEFAULT NULL, access_data LONGTEXT DEFAULT NULL, country LONGTEXT DEFAULT NULL, security_measures LONGTEXT DEFAULT NULL, certification TINYINT(1) DEFAULT NULL, certification_location VARCHAR(255) DEFAULT NULL, certification_valid_from DATE DEFAULT NULL, certification_valid_to DATE DEFAULT NULL, surfmarket_dpa_agreement TINYINT(1) DEFAULT NULL, surfnet_dpa_agreement TINYINT(1) DEFAULT NULL, sn_dpa_why_not LONGTEXT DEFAULT NULL, privacy_policy TINYINT(1) DEFAULT NULL, privacy_policy_url VARCHAR(255) DEFAULT NULL, other_info LONGTEXT DEFAULT NULL, UNIQUE INDEX UNIQ_FE704F20ED5CA9E6 (service_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE privacy_questions ADD CONSTRAINT FK_FE704F20ED5CA9E6 FOREIGN KEY (service_id) REFERENCES service (id)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP TABLE privacy_questions');
+    }
+}

--- a/app/Resources/views/form/fields.html.twig
+++ b/app/Resources/views/form/fields.html.twig
@@ -57,3 +57,27 @@
         </ul>
     {%- endif -%}
 {%- endblock form_errors -%}
+
+{%- block textarea_widget -%}
+    {{ block('help_block') }}
+    <textarea {{ block('widget_attributes') }}>{{ value }}</textarea>
+{%- endblock textarea_widget -%}
+
+{%- block checkbox_widget -%}
+    {{ block('help_block') }}
+    <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
+{%- endblock checkbox_widget -%}
+
+{%- block datetime_widget -%}
+    {{ block('help_block') }}
+    {% if widget == 'single_text' %}
+        {{- block('form_widget_simple') -}}
+    {%- else -%}
+        <div {{ block('widget_container_attributes') }}>
+            {{- form_errors(form.date) -}}
+            {{- form_errors(form.time) -}}
+            {{- form_widget(form.date) -}}
+            {{- form_widget(form.time) -}}
+        </div>
+    {%- endif -%}
+{%- endblock datetime_widget -%}

--- a/docs/ubiquitous_language.md
+++ b/docs/ubiquitous_language.md
@@ -5,3 +5,4 @@
 |Contact|Contactpersoon|A user of the SP Dashboard. The contact always is a member of the Supplier's Team.|
 |Entity|Entiteit|The SAML entity configuration(s) for a Supplier.|
 |Service|Dienst|A service has multiple SAML entities (multi-tennant services or test/prod entities). Services can have several Contacts.|
+|Privacy question|Privacy vragen|The privacy questions also known as GDPR questions are filled in by the Service. And are saved in Manage alongside the Entity metadata.|

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/PrivacyQuestions/PrivacyQuestionsCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/PrivacyQuestions/PrivacyQuestionsCommand.php
@@ -1,0 +1,386 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Command\PrivacyQuestions;
+
+use Surfnet\ServiceProviderDashboard\Application\Command\Command;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+
+/**
+ * @SuppressWarnings(PHPMD.TooManyFields)
+ * @SuppressWarnings(PHPMD.ExcessivePublicCount)
+ */
+class PrivacyQuestionsCommand implements Command
+{
+    const MODE_CREATE = 0;
+
+    const MODE_EDIT = 1;
+
+    /**
+     * @var int
+     */
+    private $mode;
+    
+    /**
+     * @var Service
+     */
+    private $service;
+
+    /**
+     * @var string
+     */
+    private $whatData;
+
+    /**
+     * @var string
+     */
+    private $accessData;
+
+    /**
+     * @var string
+     */
+    private $country;
+
+    /**
+     * @var string
+     */
+    private $securityMeasures;
+
+    /**
+     * @var bool
+     */
+    private $certification;
+
+    /**
+     * @var string
+     */
+    private $certificationLocation;
+
+    /**
+     * @var string
+     */
+    private $certificationValidFrom;
+
+    /**
+     * @var string
+     */
+    private $certificationValidTo;
+
+    /**
+     * @var bool
+     */
+    private $surfmarketDpaAgreement;
+
+    /**
+     * @var bool
+     */
+    private $surfnetDpaAgreement;
+
+    /**
+     * @var string
+     */
+    private $snDpaWhyNot;
+
+    /**
+     * @var string
+     */
+    private $privacyPolicy;
+
+    /**
+     * @var string
+     */
+    private $privacyPolicyUrl;
+
+    /**
+     * @var string
+     */
+    private $otherInfo;
+
+    /**
+     * @param string $whatData
+     */
+    public function setWhatData($whatData)
+    {
+        $this->whatData = $whatData;
+    }
+
+    /**
+     * @param string $accessData
+     */
+    public function setAccessData($accessData)
+    {
+        $this->accessData = $accessData;
+    }
+
+    /**
+     * @param string $country
+     */
+    public function setCountry($country)
+    {
+        $this->country = $country;
+    }
+
+    /**
+     * @param string $securityMeasures
+     */
+    public function setSecurityMeasures($securityMeasures)
+    {
+        $this->securityMeasures = $securityMeasures;
+    }
+
+    /**
+     * @param bool $certification
+     */
+    public function setCertification($certification)
+    {
+        $this->certification = $certification;
+    }
+
+    /**
+     * @param string $certificationLocation
+     */
+    public function setCertificationLocation($certificationLocation)
+    {
+        $this->certificationLocation = $certificationLocation;
+    }
+
+    /**
+     * @param string $certificationValidFrom
+     */
+    public function setCertificationValidFrom($certificationValidFrom)
+    {
+        $this->certificationValidFrom = $certificationValidFrom;
+    }
+
+    /**
+     * @param string $certificationValidTo
+     */
+    public function setCertificationValidTo($certificationValidTo)
+    {
+        $this->certificationValidTo = $certificationValidTo;
+    }
+
+    /**
+     * @param bool $surfmarketDpaAgreement
+     */
+    public function setSurfmarketDpaAgreement($surfmarketDpaAgreement)
+    {
+        $this->surfmarketDpaAgreement = $surfmarketDpaAgreement;
+    }
+
+    /**
+     * @param bool $surfnetDpaAgreement
+     */
+    public function setSurfnetDpaAgreement($surfnetDpaAgreement)
+    {
+        $this->surfnetDpaAgreement = $surfnetDpaAgreement;
+    }
+
+    /**
+     * @param string $snDpaWhyNot
+     */
+    public function setSnDpaWhyNot($snDpaWhyNot)
+    {
+        $this->snDpaWhyNot = $snDpaWhyNot;
+    }
+
+    /**
+     * @param string $privacyPolicy
+     */
+    public function setPrivacyPolicy($privacyPolicy)
+    {
+        $this->privacyPolicy = $privacyPolicy;
+    }
+
+    /**
+     * @param string $privacyPolicyUrl
+     */
+    public function setPrivacyPolicyUrl($privacyPolicyUrl)
+    {
+        $this->privacyPolicyUrl = $privacyPolicyUrl;
+    }
+
+    /**
+     * @param string $otherInfo
+     */
+    public function setOtherInfo($otherInfo)
+    {
+        $this->otherInfo = $otherInfo;
+    }
+
+    /**
+     * @return string
+     */
+    public function getWhatData()
+    {
+        return $this->whatData;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAccessData()
+    {
+        return $this->accessData;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCountry()
+    {
+        return $this->country;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSecurityMeasures()
+    {
+        return $this->securityMeasures;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isCertification()
+    {
+        return $this->certification;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCertificationLocation()
+    {
+        return $this->certificationLocation;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCertificationValidFrom()
+    {
+        return $this->certificationValidFrom;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCertificationValidTo()
+    {
+        return $this->certificationValidTo;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSurfmarketDpaAgreement()
+    {
+        return $this->surfmarketDpaAgreement;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSurfnetDpaAgreement()
+    {
+        return $this->surfnetDpaAgreement;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSnDpaWhyNot()
+    {
+        return $this->snDpaWhyNot;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPrivacyPolicy()
+    {
+        return $this->privacyPolicy;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPrivacyPolicyUrl()
+    {
+        return $this->privacyPolicyUrl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOtherInfo()
+    {
+        return $this->otherInfo;
+    }
+
+    /**
+     * @return Service
+     */
+    public function getService()
+    {
+        return $this->service;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMode()
+    {
+        return $this->mode;
+    }
+
+    public static function fromService(Service $service)
+    {
+        $command = new self;
+        $command->service = $service;
+        $command->mode = self::MODE_CREATE;
+
+        return $command;
+    }
+
+    public static function fromQuestions(PrivacyQuestions $questions)
+    {
+        $command = new self;
+        $command->accessData = $questions->getAccessData();
+        $command->certification = $questions->isCertified();
+        $command->certificationLocation = $questions->getCertificationLocation();
+        $command->certificationValidFrom = $questions->getCertificationValidFrom();
+        $command->certificationValidTo = $questions->getCertificationValidTo();
+        $command->country = $questions->getCountry();
+        $command->mode = self::MODE_CREATE;
+        $command->otherInfo = $questions->getOtherInfo();
+        $command->privacyPolicy = $questions->getPrivacyPolicy();
+        $command->privacyPolicyUrl = $questions->getPrivacyPolicyUrl();
+        $command->securityMeasures = $questions->getSecurityMeasures();
+        $command->service = $questions->getService();
+        $command->snDpaWhyNot = $questions->getSnDpaWhyNot();
+        $command->surfmarketDpaAgreement = $questions->isSurfmarketDpaAgreement();
+        $command->surfnetDpaAgreement = $questions->isSurfnetDpaAgreement();
+        $command->whatData = $questions->getWhatData();
+
+        return $command;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/PrivacyQuestions/PrivacyQuestionsCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/PrivacyQuestions/PrivacyQuestionsCommand.php
@@ -355,8 +355,9 @@ class PrivacyQuestionsCommand implements Command
     public static function fromService(Service $service)
     {
         $command = new self;
-        $command->service = $service;
         $command->mode = self::MODE_CREATE;
+
+        $command->service = $service;
 
         return $command;
     }
@@ -364,13 +365,14 @@ class PrivacyQuestionsCommand implements Command
     public static function fromQuestions(PrivacyQuestions $questions)
     {
         $command = new self;
+        $command->mode = self::MODE_EDIT;
+
         $command->accessData = $questions->getAccessData();
         $command->certification = $questions->isCertified();
         $command->certificationLocation = $questions->getCertificationLocation();
         $command->certificationValidFrom = $questions->getCertificationValidFrom();
         $command->certificationValidTo = $questions->getCertificationValidTo();
         $command->country = $questions->getCountry();
-        $command->mode = self::MODE_CREATE;
         $command->otherInfo = $questions->getOtherInfo();
         $command->privacyPolicy = $questions->getPrivacyPolicy();
         $command->privacyPolicyUrl = $questions->getPrivacyPolicyUrl();

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/PrivacyQuestions/PrivacyQuestionsCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/PrivacyQuestions/PrivacyQuestionsCommand.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Command\PrivacyQuestions;
 
+use DateTime;
 use Surfnet\ServiceProviderDashboard\Application\Command\Command;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
@@ -73,12 +74,12 @@ class PrivacyQuestionsCommand implements Command
     private $certificationLocation;
 
     /**
-     * @var string
+     * @var DateTime
      */
     private $certificationValidFrom;
 
     /**
-     * @var string
+     * @var DateTime
      */
     private $certificationValidTo;
 
@@ -161,17 +162,17 @@ class PrivacyQuestionsCommand implements Command
     }
 
     /**
-     * @param string $certificationValidFrom
+     * @param DateTime $certificationValidFrom
      */
-    public function setCertificationValidFrom($certificationValidFrom)
+    public function setCertificationValidFrom(DateTime $certificationValidFrom = null)
     {
         $this->certificationValidFrom = $certificationValidFrom;
     }
 
     /**
-     * @param string $certificationValidTo
+     * @param DateTime $certificationValidTo
      */
-    public function setCertificationValidTo($certificationValidTo)
+    public function setCertificationValidTo(DateTime $certificationValidTo = null)
     {
         $this->certificationValidTo = $certificationValidTo;
     }
@@ -273,7 +274,7 @@ class PrivacyQuestionsCommand implements Command
     }
 
     /**
-     * @return string
+     * @return DateTime
      */
     public function getCertificationValidFrom()
     {
@@ -281,7 +282,7 @@ class PrivacyQuestionsCommand implements Command
     }
 
     /**
-     * @return string
+     * @return DateTime
      */
     public function getCertificationValidTo()
     {
@@ -358,6 +359,12 @@ class PrivacyQuestionsCommand implements Command
         $command->mode = self::MODE_CREATE;
 
         $command->service = $service;
+
+        $validFrom = new DateTime('-2 years');
+        $validTo = new DateTime('+1 years');
+
+        $command->certificationValidFrom = $validFrom;
+        $command->certificationValidTo = $validTo;
 
         return $command;
     }

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/PrivacyQuestions/PrivacyQuestionsCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/PrivacyQuestions/PrivacyQuestionsCommandHandler.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\CommandHandler\PrivacyQuestions;
+
+use Psr\Log\LoggerInterface;
+use Surfnet\ServiceProviderDashboard\Application\Command\PrivacyQuestions\PrivacyQuestionsCommand;
+use Surfnet\ServiceProviderDashboard\Application\CommandHandler\CommandHandler;
+use Surfnet\ServiceProviderDashboard\Application\Exception\EntityNotFoundException;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\PrivacyQuestionsRepository;
+
+class PrivacyQuestionsCommandHandler implements CommandHandler
+{
+    /**
+     * @var PrivacyQuestionsRepository
+     */
+    private $repository;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(PrivacyQuestionsRepository $repository, LoggerInterface $logger)
+    {
+        $this->repository = $repository;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param PrivacyQuestionsCommand $command
+     * @throws EntityNotFoundException
+     */
+    public function handle(PrivacyQuestionsCommand $command)
+    {
+        $service = $command->getService();
+
+        switch ($command->getMode()) {
+            case PrivacyQuestionsCommand::MODE_EDIT:
+                // Fetch an existing entity
+                $questions = $this->repository->findByService($service);
+                if (is_null($questions)) {
+                    $this->logger->error(
+                        sprintf('Unable to fetch the privacy questions for "%s"', $service->getName())
+                    );
+                    throw new EntityNotFoundException("Unable to find privacy question");
+                }
+                break;
+            default:
+            case PrivacyQuestionsCommand::MODE_CREATE:
+                // Create a new entity
+                $questions = new PrivacyQuestions();
+                break;
+        }
+
+        $this->setDataFromCommand($command, $questions);
+        $this->repository->save($questions);
+    }
+
+    private function setDataFromCommand(PrivacyQuestionsCommand $command, PrivacyQuestions $questions)
+    {
+        $questions->setService($command->getService());
+        $questions->setAccessData($command->getAccessData());
+        $questions->setCertification($command->isCertification());
+        $questions->setCertificationLocation($command->getCertificationLocation());
+        $questions->setCertificationValidFrom($command->getCertificationValidFrom());
+        $questions->setCertificationValidTo($command->getCertificationValidTo());
+        $questions->setCountry($command->getCountry());
+        $questions->setOtherInfo($command->getOtherInfo());
+        $questions->setPrivacyPolicy($command->getPrivacyPolicy());
+        $questions->setPrivacyPolicyUrl($command->getPrivacyPolicyUrl());
+        $questions->setSecurityMeasures($command->getSecurityMeasures());
+        $questions->setSnDpaWhyNot($command->getSnDpaWhyNot());
+        $questions->setSurfmarketDpaAgreement($command->isSurfmarketDpaAgreement());
+        $questions->setSurfnetDpaAgreement($command->isSurfnetDpaAgreement());
+        $questions->setWhatData($command->getWhatData());
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/PrivacyQuestions.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/PrivacyQuestions.php
@@ -1,0 +1,258 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Domain\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(
+ *     repositoryClass="Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\PrivacyQuestionsRepository"
+ * )
+ * @SuppressWarnings(PHPMD.UnusedPrivateField Fields of this class are not yet used, remove this once they are used)
+ * @SuppressWarnings(PHPMD.TooManyFields)
+ */
+class PrivacyQuestions
+{
+    /**
+     * @var int
+     *
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var string
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $whatData;
+
+    /**
+     * @var string
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $accessData;
+
+    /**
+     * @var string
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $country;
+
+    /**
+     * @var string
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $securityMeasures;
+
+    /**
+     * @var bool
+     * @ORM\Column(type="boolean", nullable=true)
+     */
+    private $certification;
+
+    /**
+     * Where can an institution find/request the certificate?
+     * @var string
+     * @ORM\Column(type="string", nullable=true)
+     */
+    private $certificationLocation;
+
+    /**
+     * @var string
+     * @ORM\Column(type="date", nullable=true)
+     */
+    private $certificationValidFrom;
+
+    /**
+     * @var string
+     * @ORM\Column(type="date", nullable=true)
+     */
+    private $certificationValidTo;
+
+    /**
+     * @var bool
+     * @ORM\Column(type="boolean", nullable=true)
+     */
+    private $surfmarketDpaAgreement;
+
+    /**
+     * @var bool
+     * @ORM\Column(type="boolean", nullable=true)
+     */
+    private $surfnetDpaAgreement;
+
+    /**
+     * @var string
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $snDpaWhyNot;
+
+    /**
+     * @var string
+     * @ORM\Column(type="boolean", nullable=true)
+     */
+    private $privacyPolicy;
+
+    /**
+     * @var string
+     * @ORM\Column(type="string", nullable=true)
+     */
+    private $privacyPolicyUrl;
+
+    /**
+     * @var string
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $otherInfo;
+
+    /**
+     * @var Service
+     *
+     * @ORM\OneToOne(targetEntity="Service", inversedBy="privacyQuestions")
+     * @ORM\JoinColumn(nullable=false)
+     */
+    private $service;
+
+    public function setService(Service $service)
+    {
+        $this->service = $service;
+    }
+
+    /**
+     * @return string
+     */
+    public function getWhatData()
+    {
+        return $this->whatData;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAccessData()
+    {
+        return $this->accessData;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCountry()
+    {
+        return $this->country;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSecurityMeasures()
+    {
+        return $this->securityMeasures;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isCertified()
+    {
+        return $this->certification;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCertificationLocation()
+    {
+        return $this->certificationLocation;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCertificationValidFrom()
+    {
+        return $this->certificationValidFrom;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCertificationValidTo()
+    {
+        return $this->certificationValidTo;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSurfmarketDpaAgreement()
+    {
+        return $this->surfmarketDpaAgreement;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSurfnetDpaAgreement()
+    {
+        return $this->surfnetDpaAgreement;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSnDpaWhyNot()
+    {
+        return $this->snDpaWhyNot;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPrivacyPolicy()
+    {
+        return $this->privacyPolicy;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPrivacyPolicyUrl()
+    {
+        return $this->privacyPolicyUrl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOtherInfo()
+    {
+        return $this->otherInfo;
+    }
+
+    /**
+     * @return Service
+     */
+    public function getService()
+    {
+        return $this->service;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/PrivacyQuestions.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/PrivacyQuestions.php
@@ -24,8 +24,8 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity(
  *     repositoryClass="Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\PrivacyQuestionsRepository"
  * )
- * @SuppressWarnings(PHPMD.UnusedPrivateField Fields of this class are not yet used, remove this once they are used)
  * @SuppressWarnings(PHPMD.TooManyFields)
+ * @SuppressWarnings(PHPMD.UnusedPrivateField)
  */
 class PrivacyQuestions
 {
@@ -262,5 +262,109 @@ class PrivacyQuestions
     public function getService()
     {
         return $this->service;
+    }
+
+    /**
+     * @param string $whatData
+     */
+    public function setWhatData($whatData)
+    {
+        $this->whatData = $whatData;
+    }
+
+    /**
+     * @param string $accessData
+     */
+    public function setAccessData($accessData)
+    {
+        $this->accessData = $accessData;
+    }
+
+    /**
+     * @param string $securityMeasures
+     */
+    public function setSecurityMeasures($securityMeasures)
+    {
+        $this->securityMeasures = $securityMeasures;
+    }
+
+    /**
+     * @param bool $certification
+     */
+    public function setCertification($certification)
+    {
+        $this->certification = $certification;
+    }
+
+    /**
+     * @param string $certificationLocation
+     */
+    public function setCertificationLocation($certificationLocation)
+    {
+        $this->certificationLocation = $certificationLocation;
+    }
+
+    /**
+     * @param string $certificationValidFrom
+     */
+    public function setCertificationValidFrom($certificationValidFrom)
+    {
+        $this->certificationValidFrom = $certificationValidFrom;
+    }
+
+    /**
+     * @param string $certificationValidTo
+     */
+    public function setCertificationValidTo($certificationValidTo)
+    {
+        $this->certificationValidTo = $certificationValidTo;
+    }
+
+    /**
+     * @param bool $surfmarketDpaAgreement
+     */
+    public function setSurfmarketDpaAgreement($surfmarketDpaAgreement)
+    {
+        $this->surfmarketDpaAgreement = $surfmarketDpaAgreement;
+    }
+
+    /**
+     * @param bool $surfnetDpaAgreement
+     */
+    public function setSurfnetDpaAgreement($surfnetDpaAgreement)
+    {
+        $this->surfnetDpaAgreement = $surfnetDpaAgreement;
+    }
+
+    /**
+     * @param string $snDpaWhyNot
+     */
+    public function setSnDpaWhyNot($snDpaWhyNot)
+    {
+        $this->snDpaWhyNot = $snDpaWhyNot;
+    }
+
+    /**
+     * @param string $privacyPolicy
+     */
+    public function setPrivacyPolicy($privacyPolicy)
+    {
+        $this->privacyPolicy = $privacyPolicy;
+    }
+
+    /**
+     * @param string $privacyPolicyUrl
+     */
+    public function setPrivacyPolicyUrl($privacyPolicyUrl)
+    {
+        $this->privacyPolicyUrl = $privacyPolicyUrl;
+    }
+
+    /**
+     * @param string $otherInfo
+     */
+    public function setOtherInfo($otherInfo)
+    {
+        $this->otherInfo = $otherInfo;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/PrivacyQuestions.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/PrivacyQuestions.php
@@ -137,6 +137,14 @@ class PrivacyQuestions
     }
 
     /**
+     * @param string $country
+     */
+    public function setCountry($country)
+    {
+        $this->country = $country;
+    }
+
+    /**
      * @return string
      */
     public function getWhatData()

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
@@ -20,7 +20,6 @@ namespace Surfnet\ServiceProviderDashboard\Domain\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @package Surfnet\ServiceProviderDashboard\Entity
@@ -74,6 +73,13 @@ class Service
      * @ORM\OneToMany(targetEntity="Entity", mappedBy="service", cascade={"persist"}, orphanRemoval=true)
      */
     private $entities;
+
+    /**
+     * @var privacyQuestions
+     *
+     * @ORM\OneToOne(targetEntity="PrivacyQuestions", mappedBy="service")
+     */
+    private $privacyQuestions;
 
     public function __construct()
     {
@@ -157,5 +163,13 @@ class Service
         $entity->setService($this);
 
         return $this;
+    }
+
+    /**
+     * @return PrivacyQuestions
+     */
+    public function getPrivacyQuestions()
+    {
+        return $this->privacyQuestions;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Repository/PrivacyQuestionsRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Repository/PrivacyQuestionsRepository.php
@@ -19,8 +19,15 @@
 namespace Surfnet\ServiceProviderDashboard\Domain\Repository;
 
 use Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 
 interface PrivacyQuestionsRepository
 {
     public function save(PrivacyQuestions $questions);
+
+    /**
+     * @param Service $service
+     * @return null|PrivacyQuestions
+     */
+    public function findByService(Service $service);
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Repository/PrivacyQuestionsRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Repository/PrivacyQuestionsRepository.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Domain\Repository;
+
+use Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions;
+
+interface PrivacyQuestionsRepository
+{
+    public function save(PrivacyQuestions $questions);
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/PrivacyQuestionsController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/PrivacyQuestionsController.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Controller;
+
+use League\Tactician\CommandBus;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Surfnet\ServiceProviderDashboard\Application\Command\PrivacyQuestions\CreatePrivacyQuestionsCommand;
+use Surfnet\ServiceProviderDashboard\Application\Service\ServiceService;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\CreatePrivacyQuestionsType;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AuthorizationService;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class PrivacyQuestionsController extends Controller
+{
+    /**
+     * @var CommandBus
+     */
+    private $commandBus;
+
+    /**
+     * @var AuthorizationService
+     */
+    private $authorizationService;
+
+    /**
+     * @var ServiceService
+     */
+    private $serviceService;
+
+    public function __construct(
+        CommandBus $commandBus,
+        ServiceService $serviceService,
+        AuthorizationService $authorizationService
+    ) {
+        $this->commandBus = $commandBus;
+        $this->serviceService = $serviceService;
+        $this->authorizationService = $authorizationService;
+    }
+
+    /**
+     * @Method({"GET"})
+     * @Route("/service/privacy", name="privacy_questions")
+     *
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse|Response
+     */
+    public function privacyAction()
+    {
+        $service = $this->serviceService->getServiceById(
+            $this->authorizationService->getActiveServiceId()
+        );
+
+        // Test if the questions have already been filled
+        if ($service->getPrivacyQuestions() instanceof PrivacyQuestions) {
+            return $this->forward('DashboardBundle:PrivacyQuestions:edit');
+        }
+        return $this->forward('DashboardBundle:PrivacyQuestions:create');
+    }
+
+    /**
+     * @Route("/service/privacy/create", name="privacy_questions_create")
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function createAction(Request $request)
+    {
+        $service = $this->serviceService->getServiceById(
+            $this->authorizationService->getActiveServiceId()
+        );
+
+        $command = CreatePrivacyQuestionsCommand::fromService($service);
+
+        $form = $this->createForm(CreatePrivacyQuestionsType::class, $command);
+        $form->handleRequest($request);
+
+        return $this->render('@Dashboard/Privacy/form.html.twig', array(
+            'form' => $form->createView(),
+        ));
+    }
+
+    /**
+     * @Route("/service/privacy/edit", name="privacy_questions_edit")
+     */
+    public function editAction()
+    {
+//        $service = $this->serviceService->getServiceById(
+//            $this->authorizationService->getActiveServiceId()
+//        );
+//        $questions = $service->getPrivacyQuestions();
+
+        return $this->render('@Dashboard/Privacy/form.html.twig');
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/PrivacyQuestionsController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/PrivacyQuestionsController.php
@@ -123,7 +123,7 @@ class PrivacyQuestionsController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            //$this->commandBus->handle($command);
+            $this->commandBus->handle($command);
             return $this->redirectToRoute('privacy_questions');
         }
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/PrivacyQuestions/PrivacyQuestionsFormBuilder.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/PrivacyQuestions/PrivacyQuestionsFormBuilder.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\PrivacyQuestions;
+
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class PrivacyQuestionsFormBuilder
+{
+    /**
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     */
+    public function buildForm(FormBuilderInterface $builder)
+    {
+        $builder->add(
+            'whatData',
+            TextareaType::class,
+            [
+                'label' => 'privacy.form.label.whatData',
+                'attr' => ['help' => 'privacy.information.whatData'],
+            ]
+        );
+
+        $builder->add(
+            'accessData',
+            TextareaType::class,
+            [
+                'label' => 'privacy.form.label.accessData',
+                'attr' => ['help' => 'privacy.information.accessData'],
+            ]
+        );
+
+        $builder->add(
+            'country',
+            TextareaType::class,
+            [
+                'label' => 'privacy.form.label.country',
+                'attr' => ['help' => 'privacy.information.country'],
+            ]
+        );
+
+        $builder->add(
+            'securityMeasures',
+            TextareaType::class,
+            [
+                'label' => 'privacy.form.label.securityMeasures',
+                'attr' => ['help' => 'privacy.information.securityMeasures'],
+            ]
+        );
+
+        $builder->add(
+            'certification',
+            CheckboxType::class,
+            [
+                'label' => 'privacy.form.label.certification',
+                'attr' => ['help' => 'privacy.information.certification'],
+            ]
+        );
+
+        $builder->add(
+            'certificationLocation',
+            TextareaType::class,
+            [
+                'label' => 'privacy.form.label.certificationLocation',
+                'attr' => ['help' => 'privacy.information.certificationLocation'],
+            ]
+        );
+
+        $builder->add(
+            'certificationValidFrom',
+            DateType::class,
+            [
+                'label' => 'privacy.form.label.certificationValidFrom',
+            ]
+        );
+
+        $builder->add(
+            'certificationValidTo',
+            DateType::class,
+            [
+                'label' => 'privacy.form.label.certificationValidTo',
+            ]
+        );
+
+        $builder->add(
+            'surfmarketDpaAgreement',
+            CheckboxType::class,
+            [
+                'label' => 'privacy.form.label.surfmarketDpaAgreement',
+                'attr' => ['help' => 'privacy.information.surfmarketDpaAgreement'],
+            ]
+        );
+
+        $builder->add(
+            'surfnetDpaAgreement',
+            CheckboxType::class,
+            [
+                'label' => 'privacy.form.label.surfnetDpaAgreement',
+                'attr' => ['help' => 'privacy.information.surfnetDpaAgreement'],
+            ]
+        );
+
+        $builder->add(
+            'snDpaWhyNot',
+            TextareaType::class,
+            [
+                'label' => 'privacy.form.label.snDpaWhyNot',
+                'attr' => ['help' => 'privacy.information.snDpaWhyNot'],
+            ]
+        );
+
+        $builder->add(
+            'privacyPolicy',
+            CheckboxType::class,
+            [
+                'label' => 'privacy.form.label.privacyPolicy',
+                'attr' => ['help' => 'privacy.information.privacyPolicy'],
+            ]
+        );
+
+        $builder->add(
+            'privacyPolicyUrl',
+            UrlType::class,
+            [
+                'label' => 'privacy.form.label.privacyPolicyUrl',
+                'attr' => ['help' => 'privacy.information.privacyPolicyUrl'],
+            ]
+        );
+
+        $builder->add(
+            'otherInfo',
+            TextareaType::class,
+            [
+                'label' => 'privacy.form.label.otherInfo',
+                'attr' => ['help' => 'privacy.information.otherInfo'],
+            ]
+        );
+
+        $builder->add('save', SubmitType::class, ['attr' => ['class'=>'button']]);
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/PrivacyQuestions/PrivacyQuestionsFormBuilder.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/PrivacyQuestions/PrivacyQuestionsFormBuilder.php
@@ -22,7 +22,7 @@ use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
-use Symfony\Component\Form\Extension\Core\Type\UrlType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class PrivacyQuestionsFormBuilder
@@ -91,6 +91,7 @@ class PrivacyQuestionsFormBuilder
             DateType::class,
             [
                 'label' => 'privacy.form.label.certificationValidFrom',
+                'widget' => 'single_text',
             ]
         );
 
@@ -99,6 +100,7 @@ class PrivacyQuestionsFormBuilder
             DateType::class,
             [
                 'label' => 'privacy.form.label.certificationValidTo',
+                'widget' => 'single_text',
             ]
         );
 
@@ -140,7 +142,7 @@ class PrivacyQuestionsFormBuilder
 
         $builder->add(
             'privacyPolicyUrl',
-            UrlType::class,
+            TextType::class,
             [
                 'label' => 'privacy.form.label.privacyPolicyUrl',
                 'attr' => ['help' => 'privacy.information.privacyPolicyUrl'],

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/PrivacyQuestions/PrivacyQuestionsType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/PrivacyQuestions/PrivacyQuestionsType.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\PrivacyQuestions;
+
+use Surfnet\ServiceProviderDashboard\Application\Command\PrivacyQuestions\PrivacyQuestionsCommand;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class PrivacyQuestionsType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builderHelper = new PrivacyQuestionsFormBuilder();
+        $builderHelper->buildForm($builder);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => PrivacyQuestionsCommand::class,
+        ));
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'dashboard_bundle_privacy_questions_type';
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Menu/Builder.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Menu/Builder.php
@@ -43,6 +43,10 @@ class Builder
             $menu->addChild('Add new entity', array(
                 'route' => 'entity_add',
             ));
+
+            $menu->addChild('GDPR questions', array(
+                'route' => 'privacy_questions',
+            ));
         }
 
         if ($this->authorizationService->isAdministrator()) {

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Menu/Builder.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Menu/Builder.php
@@ -44,7 +44,7 @@ class Builder
                 'route' => 'entity_add',
             ));
 
-            $menu->addChild('GDPR questions', array(
+            $menu->addChild('Privacy', array(
                 'route' => 'privacy_questions',
             ));
         }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Repository/PrivacyQuestionsRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Repository/PrivacyQuestionsRepository.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository;
+
+use Doctrine\ORM\EntityRepository as DoctrineEntityRepository;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\PrivacyQuestionsRepository as PrivacyQuestionsRepositoryInterface;
+
+class PrivacyQuestionsRepository extends DoctrineEntityRepository implements PrivacyQuestionsRepositoryInterface
+{
+    public function save(PrivacyQuestions $questions)
+    {
+        $this->_em->persist($questions);
+        $this->_em->flush($questions);
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Repository/PrivacyQuestionsRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Repository/PrivacyQuestionsRepository.php
@@ -20,6 +20,7 @@ namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Reposi
 
 use Doctrine\ORM\EntityRepository as DoctrineEntityRepository;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\PrivacyQuestionsRepository as PrivacyQuestionsRepositoryInterface;
 
 class PrivacyQuestionsRepository extends DoctrineEntityRepository implements PrivacyQuestionsRepositoryInterface
@@ -28,5 +29,12 @@ class PrivacyQuestionsRepository extends DoctrineEntityRepository implements Pri
     {
         $this->_em->persist($questions);
         $this->_em->flush($questions);
+    }
+
+    public function findByService(Service $service)
+    {
+        return parent::findOneBy([
+            'service' => $service,
+        ]);
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -106,6 +106,11 @@ services:
         factory: ['@doctrine', 'getRepository']
         arguments: [Surfnet\ServiceProviderDashboard\Domain\Entity\Entity]
 
+    surfnet.dashboard.repository.privacy_questions:
+        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\PrivacyQuestionsRepository
+        factory: ['@doctrine', 'getRepository']
+        arguments: [Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions]
+
     surfnet.dashboard.repository.service:
         class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\ServiceRepository
         factory: ['@doctrine', 'getRepository']

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -46,6 +46,12 @@ services:
         tags:
             - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Entity\LoadMetadataCommand }
 
+    surfnet.dashboard.command_handler.privacy_questions:
+        class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\PrivacyQuestions\PrivacyQuestionsCommandHandler
+        public: true
+        tags:
+            - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\PrivacyQuestions\PrivacyQuestionsCommand }
+
     surfnet.dashboard.command_handler.publish_entity:
         class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\PublishEntityCommandHandler
         public: true

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -111,5 +111,31 @@ entity.published.text.html: "Thanks for publishing \"%entityName%\" to our test 
 entity.published.title: "Successfully published the Entity"
 privacy.edit.title: GDPR related questions
 privacy.edit.introduction.html: "<p><strong>Pellentesque habitant morbi tristique</strong> senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. <em>Aenean ultricies mi vitae est.</em> Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, <code>commodo vitae</code>, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. <a href=\"#\">Donec non enim</a> in turpis pulvinar facilisis. Ut felis.</p>"
+privacy.form.label.accessData: What (kind of) data is processed?
+privacy.form.label.certification: "Can you supply a Third Party Memorandum? If not: skip to question 9"
+privacy.form.label.certificationFrom: Valid from:
+privacy.form.label.certificationLocation: Where can an institution find/request it?
+privacy.form.label.certificationTo: Valid to:
+privacy.form.label.country: In what country is the data stored?
+privacy.form.label.otherInfo: Other data privacy and security information
+privacy.form.label.privacyPolicy: "Do you publish your privacy policy? If not: skip to question 14"
+privacy.form.label.privacyPolicyUrl: What is the URL?
+privacy.form.label.securityMeasures: What security measures have you taken?
+privacy.form.label.snDpaWhyNot: What articles pose a problem & why?
+privacy.form.label.surfmarketDpaAgreement: "Did you agree a DPA with SURFmarket? If yes: skip to question 12"
+privacy.form.label.surfnetDpaAgreement: Are you willing to sign the SURF model DPA? If “Yes” skip to question 12
+privacy.form.label.whatData: What (kind of) data is processed?
+privacy.information.accessData: Specify which organizations, including your own, and per organization what roles / (groups of) individuals have access to the data (including backups etc). Explain why they need access, and what access exactly each one has (like read only of certain specified data).
+privacy.information.certification: Is there an active valid certification, like ISO27001, ISO27002, ISAE3402 etc?
+privacy.information.certificationLocation: Where can an institution find (URL) or requestion the certifications and third party memorandum?
+privacy.information.country: In what country/countries is the data stored (including copies etc)
+privacy.information.otherInfo: What other information do you want to share regarding data security, privacy etc?
+privacy.information.privacyPolicy: Do you publish you a privacy policy online?
+privacy.information.privacyPolicyUrl: What is the URL to your privacy policy
+privacy.information.securityMeasures: What security measures have you taken (remember the encryption during transport and storage)?
+privacy.information.snDpaWhyNot: What items of the SURF model Data Processing Agreement would you want to discuss with an institution, and what is your problem with those articles / those items?
+privacy.information.surfmarketDpaAgreement: Did you agree a Data Processing Agreement with SURFmarket?
+privacy.information.surfnetDpaAgreement: Are you willing to sign the model SURF Data Processing Agreement?
+privacy.information.whatData: Describe what (kind of) data is processed in the service, and pay specific attention to possible processing of personal data.
 service.create.title: Add new service
 service.edit.title: Edit service

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -109,5 +109,7 @@ entity.edit.information.eduPersonTargetedIDAttribute: Text should be set in web 
 entity.edit.information.comments: Text should be set in web translations
 entity.published.text.html: "Thanks for publishing \"%entityName%\" to our test environment."
 entity.published.title: "Successfully published the Entity"
+privacy.edit.title: GDPR related questions
+privacy.edit.introduction.html: "<p><strong>Pellentesque habitant morbi tristique</strong> senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. <em>Aenean ultricies mi vitae est.</em> Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, <code>commodo vitae</code>, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. <a href=\"#\">Donec non enim</a> in turpis pulvinar facilisis. Ut felis.</p>"
 service.create.title: Add new service
 service.edit.title: Edit service

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Privacy/form.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Privacy/form.html.twig
@@ -1,4 +1,4 @@
-{#{% form_theme form 'form/fields.html.twig' %}#}
+{% form_theme form 'form/fields.html.twig' %}
 
 {% extends '::base.html.twig' %}
 
@@ -6,7 +6,18 @@
     <h1>{% block page_heading %}{{ 'privacy.edit.title'|trans }}{%endblock%}</h1>
 
     <div class="fieldset card">
+
+        {% for message in app.flashes('error') %}
+            <div class="message error">
+                {{ message }}
+            </div>
+        {% endfor %}
+
         <div class="wysiwyg">{{ 'privacy.edit.introduction.html'|trans|raw }}</div>
+    </div>
+
+    <div class="fieldset card">
+        {{ form(form, {'attr': {'novalidate': 'novalidate'}}) }}
     </div>
 
 {% endblock %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Privacy/form.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Privacy/form.html.twig
@@ -1,0 +1,12 @@
+{#{% form_theme form 'form/fields.html.twig' %}#}
+
+{% extends '::base.html.twig' %}
+
+{% block body_container %}
+    <h1>{% block page_heading %}{{ 'privacy.edit.title'|trans }}{%endblock%}</h1>
+
+    <div class="fieldset card">
+        <div class="wysiwyg">{{ 'privacy.edit.introduction.html'|trans|raw }}</div>
+    </div>
+
+{% endblock %}

--- a/tests/unit/Infrastructure/DashboardBundle/CommandHandler/PrivacyQuestions/PrivacyQuestionsCommandHandlerTest.php
+++ b/tests/unit/Infrastructure/DashboardBundle/CommandHandler/PrivacyQuestions/PrivacyQuestionsCommandHandlerTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\DashboardBundle\CommandHandler\Entity;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+use Psr\Log\LoggerInterface;
+use Surfnet\ServiceProviderDashboard\Application\Command\PrivacyQuestions\PrivacyQuestionsCommand;
+use Surfnet\ServiceProviderDashboard\Application\CommandHandler\PrivacyQuestions\PrivacyQuestionsCommandHandler;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\PrivacyQuestionsRepository;
+
+class PrivacyQuestionsCommandHandlerTest extends MockeryTestCase
+{
+    /**
+     * @var PrivacyQuestionsCommandHandler
+     */
+    private $commandHandler;
+
+    /**
+     * @var PrivacyQuestionsRepository|m\MockInterface
+     */
+    private $repository;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function setUp()
+    {
+        $this->repository = m::mock(PrivacyQuestionsRepository::class);
+        $this->logger = m::mock(LoggerInterface::class);
+        $this->commandHandler = new PrivacyQuestionsCommandHandler($this->repository, $this->logger);
+    }
+
+    public function test_it_can_save_a_new_privacy_questions()
+    {
+        $service = m::mock(Service::class);
+        $command = PrivacyQuestionsCommand::fromService($service);
+
+        $this->repository
+            ->shouldReceive('save')
+            ->once();
+
+        $this->commandHandler->handle($command);
+    }
+
+    public function test_it_can_save_an_existing_privacy_questions()
+    {
+        $service = m::mock(Service::class);
+
+        $questions = m::mock(PrivacyQuestions::class)
+            ->makePartial();
+
+        $questions->shouldReceive('getService')
+            ->andReturn($service);
+
+        $command = PrivacyQuestionsCommand::fromQuestions($questions);
+
+        $this->repository
+            ->shouldReceive('findByService')
+            ->with($service)
+            ->andReturn($questions)
+            ->once();
+
+        $this->repository
+            ->shouldReceive('save')
+            ->once();
+
+        $this->commandHandler->handle($command);
+    }
+
+    /**
+     * @expectedException \Surfnet\ServiceProviderDashboard\Application\Exception\EntityNotFoundException
+     * @expectedExceptionMessage Unable to find privacy question
+     */
+    public function test_it_throws_exception_when_questions_entity_not_found()
+    {
+        $service = m::mock(Service::class);
+
+        $questions = m::mock(PrivacyQuestions::class)
+            ->makePartial();
+
+        $questions
+            ->shouldReceive('getService')
+            ->andReturn($service);
+
+        $command = PrivacyQuestionsCommand::fromQuestions($questions);
+
+        $service
+            ->shouldReceive('getName')
+            ->andReturn('Foobar');
+
+        $this->repository
+            ->shouldReceive('findByService')
+            ->with($service)
+            ->andReturn(null)
+            ->once();
+
+        $this->logger
+            ->shouldReceive('error')
+            ->with('Unable to fetch the privacy questions for "Foobar"');
+
+        $this->commandHandler->handle($command);
+    }
+}

--- a/tests/webtests/CreatePrivacyQuestionsTest.php
+++ b/tests/webtests/CreatePrivacyQuestionsTest.php
@@ -25,16 +25,14 @@ class CreatePrivacyQuestionsTest extends WebTestCase
         $this->loadFixtures();
 
         $serviceRepository = $this->getServiceRepository();
+        $service = $serviceRepository->findByName('SURFnet');
 
-        $this->logIn(
-            'ROLE_USER',
-            [
-                $serviceRepository->findByName('SURFnet'),
-            ]
-        );
+        $this->logIn('ROLE_USER', [$service]);
 
         $crawler = $this->client->request('GET', '/service/privacy');
 
         $this->assertEquals('GDPR related questions', $crawler->filter('h1')->first()->text());
+        $formRows = $crawler->filter('div.form-row');
+        $this->assertCount(14, $formRows);
     }
 }

--- a/tests/webtests/CreatePrivacyQuestionsTest.php
+++ b/tests/webtests/CreatePrivacyQuestionsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Webtests;
+
+class CreatePrivacyQuestionsTest extends WebTestCase
+{
+    public function test_it_can_display_the_form()
+    {
+        $this->loadFixtures();
+
+        $serviceRepository = $this->getServiceRepository();
+
+        $this->logIn(
+            'ROLE_USER',
+            [
+                $serviceRepository->findByName('SURFnet'),
+            ]
+        );
+
+        $crawler = $this->client->request('GET', '/service/privacy');
+
+        $this->assertEquals('GDPR related questions', $crawler->filter('h1')->first()->text());
+    }
+}

--- a/tests/webtests/CreatePrivacyQuestionsTest.php
+++ b/tests/webtests/CreatePrivacyQuestionsTest.php
@@ -18,7 +18,6 @@
 
 namespace Surfnet\ServiceProviderDashboard\Webtests;
 
-use Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class CreatePrivacyQuestionsTest extends WebTestCase
@@ -59,11 +58,7 @@ class CreatePrivacyQuestionsTest extends WebTestCase
                 'accessData' => 'Some data will be accessed',
                 'country' => 'The Netherlands',
                 'certification' => true,
-                'certificationValidTo' => [
-                    'year' => 2022,
-                    'month' => 12,
-                    'day' => 31,
-                ],
+                'certificationValidTo' => '2018-12-31',
                 'privacyPolicyUrl' => 'http://example.org/privacy',
             ],
         ];
@@ -88,27 +83,8 @@ class CreatePrivacyQuestionsTest extends WebTestCase
         );
 
         $this->assertEquals(
-            2022,
-            $crawler
-                ->filter('#dashboard_bundle_privacy_questions_type_certificationValidTo_year option:selected')
-                ->first()
-                ->text()
-        );
-
-        $this->assertEquals(
-            'Dec',
-            $crawler
-                ->filter('select#dashboard_bundle_privacy_questions_type_certificationValidTo_month option:selected')
-                ->first()
-                ->text()
-        );
-
-        $this->assertEquals(
-            31,
-            $crawler
-                ->filter('select#dashboard_bundle_privacy_questions_type_certificationValidTo_day option:selected')
-                ->first()
-                ->text()
+            '2018-12-31',
+            $crawler->filter('#dashboard_bundle_privacy_questions_type_certificationValidTo')->attr('value')
         );
     }
 }

--- a/tests/webtests/EditPrivacyQuestionsTest.php
+++ b/tests/webtests/EditPrivacyQuestionsTest.php
@@ -75,11 +75,7 @@ class EditPrivacyQuestionsTest extends WebTestCase
                 'accessData' => 'Some data will be accessed',
                 'country' => 'The Netherlands',
                 'certification' => true,
-                'certificationValidTo' => [
-                    'year' => 2022,
-                    'month' => 12,
-                    'day' => 31,
-                ],
+                'certificationValidTo' => '2018-12-31',
                 'privacyPolicyUrl' => 'http://example.org/privacy',
             ],
         ];
@@ -104,27 +100,8 @@ class EditPrivacyQuestionsTest extends WebTestCase
         );
 
         $this->assertEquals(
-            2022,
-            $crawler
-                ->filter('#dashboard_bundle_privacy_questions_type_certificationValidTo_year option:selected')
-                ->first()
-                ->text()
-        );
-
-        $this->assertEquals(
-            'Dec',
-            $crawler
-                ->filter('select#dashboard_bundle_privacy_questions_type_certificationValidTo_month option:selected')
-                ->first()
-                ->text()
-        );
-
-        $this->assertEquals(
-            31,
-            $crawler
-                ->filter('select#dashboard_bundle_privacy_questions_type_certificationValidTo_day option:selected')
-                ->first()
-                ->text()
+            '2018-12-31',
+            $crawler->filter('#dashboard_bundle_privacy_questions_type_certificationValidTo')->attr('value')
         );
     }
 }

--- a/tests/webtests/EditPrivacyQuestionsTest.php
+++ b/tests/webtests/EditPrivacyQuestionsTest.php
@@ -19,6 +19,7 @@
 namespace Surfnet\ServiceProviderDashboard\Webtests;
 
 use Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class EditPrivacyQuestionsTest extends WebTestCase
 {
@@ -45,5 +46,85 @@ class EditPrivacyQuestionsTest extends WebTestCase
 
         $this->assertCount(14, $formRows);
         $this->assertEquals('Nederland', $formRows->eq(2)->filter('textarea')->text());
+    }
+
+    public function test_it_can_submit_the_form()
+    {
+        $this->loadFixtures();
+
+        $serviceRepository = $this->getServiceRepository();
+        $service = $serviceRepository->findByName('SURFnet');
+
+        $questions = new PrivacyQuestions();
+        $questions->setService($service);
+        $questions->setCountry('Nederland');
+
+        $repo = $this->client->getContainer()->get('surfnet.dashboard.repository.privacy_questions');
+        $repo->save($questions);
+
+        $this->logIn('ROLE_USER', [$service]);
+
+        $crawler = $this->client->request('GET', '/service/privacy');
+
+        $form = $crawler
+            ->selectButton('Save')
+            ->form();
+
+        $formData = [
+            'dashboard_bundle_privacy_questions_type' => [
+                'accessData' => 'Some data will be accessed',
+                'country' => 'The Netherlands',
+                'certification' => true,
+                'certificationValidTo' => [
+                    'year' => 2022,
+                    'month' => 12,
+                    'day' => 31,
+                ],
+                'privacyPolicyUrl' => 'http://example.org/privacy',
+            ],
+        ];
+
+        $this->client->submit($form, $formData);
+
+        $this->assertTrue($this->client->getResponse() instanceof RedirectResponse);
+
+        $crawler = $this->client->followRedirect();
+
+        $formRows = $crawler->filter('div.form-row');
+        $this->assertCount(14, $formRows);
+
+        $this->assertEquals(
+            'Some data will be accessed',
+            $crawler->filter('#dashboard_bundle_privacy_questions_type_accessData')->text()
+        );
+
+        $this->assertEquals(
+            'The Netherlands',
+            $crawler->filter('#dashboard_bundle_privacy_questions_type_country')->text()
+        );
+
+        $this->assertEquals(
+            2022,
+            $crawler
+                ->filter('#dashboard_bundle_privacy_questions_type_certificationValidTo_year option:selected')
+                ->first()
+                ->text()
+        );
+
+        $this->assertEquals(
+            'Dec',
+            $crawler
+                ->filter('select#dashboard_bundle_privacy_questions_type_certificationValidTo_month option:selected')
+                ->first()
+                ->text()
+        );
+
+        $this->assertEquals(
+            31,
+            $crawler
+                ->filter('select#dashboard_bundle_privacy_questions_type_certificationValidTo_day option:selected')
+                ->first()
+                ->text()
+        );
     }
 }

--- a/tests/webtests/EditPrivacyQuestionsTest.php
+++ b/tests/webtests/EditPrivacyQuestionsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Webtests;
+
+class EditPrivacyQuestionsTest extends WebTestCase
+{
+    public function test_it_can_display_the_form()
+    {
+        $this->loadFixtures();
+
+        $serviceRepository = $this->getServiceRepository();
+
+        $this->logIn(
+            'ROLE_USER',
+            [
+                $serviceRepository->findByName('SURFnet'),
+            ]
+        );
+
+        $crawler = $this->client->request('GET', '/service/privacy');
+
+        $this->assertEquals('GDPR related questions', $crawler->filter('h1')->first()->text());
+    }
+}


### PR DESCRIPTION
This PR will add the Privacy questions to the SP Dashboard. A migration was added to update the database schema. Some styling effort was undertaken.

Todo in next PR
 - Publish to Manage
 - Add admin feature to toggle the privacy questions for a given Service