### PR TITLE
Show error message when user has no access to service

### DIFF
--- a/app/scss/components/service_switcher.scss
+++ b/app/scss/components/service_switcher.scss
@@ -9,3 +9,8 @@ li.service-switcher {
     display: none;
   }
 }
+
+ul.team-names {
+  list-style: inside;
+}
+

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Resources/translations/messages.en.yml
@@ -3,3 +3,6 @@ saml_authn_failed.text.authn_failed: "Sign in unsuccessful. Please try again."
 saml_authn_failed.button.try_again: "Retry to sign-in"
 saml_precondition_not_met.title: "Sign in"
 saml_precondition_not_met.text.precondition_not_met: "You are not authorised to log in."
+saml_unknown_service.title: Service unknown
+saml_unknown_service.no_service.text: You have been granted access to one or more services, but those services are not yet provisioned in the dashboard. You are member of the following teams:
+saml_unknown_service.no_teams.text: You have successfully logged in, but you have not been granted access to one or more services.

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Resources/views/Exception/unknownService.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Resources/views/Exception/unknownService.html.twig
@@ -1,0 +1,26 @@
+{% extends '::base.html.twig' %}
+
+{% block page_heading %}{{ 'saml_unknown_service.title'|trans }}{% endblock %}
+
+{% block body %}
+    <h2>{{ block('page_title') }}</h2>
+
+    {% if teamNames is not empty %}
+        <p>{{ 'saml_unknown_service.no_service.text'|trans }}</p>
+        <br/>
+        <ul class="team-names">
+            {% for teamName in teamNames  %}
+                <li>{{ teamName }}</li>
+            {% endfor %}
+        </ul>
+    {% else %}
+        <p>{{ 'saml_unknown_service.no_teams.text'|trans }}</p>
+    {% endif %}
+
+    <br/>
+
+    <a class="btn btn-primary" href="{{ path('entity_list') }}">
+        {{ 'saml_authn_failed.button.try_again'|trans }}
+    </a>
+
+{% endblock %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Security/Authentication/Provider/SamlProvider.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Security/Authentication/Provider/SamlProvider.php
@@ -26,6 +26,7 @@ use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\ContactRepository;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\ServiceRepository;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Token\SamlToken;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Exception\UnknownServiceException;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Identity;
 use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -129,7 +130,8 @@ class SamlProvider implements AuthenticationProviderInterface
                 implode(', ', $teamNames)
             ));
 
-            throw new RuntimeException(
+            throw new UnknownServiceException(
+                $teamNames,
                 'You do not have access to a service'
             );
         }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Security/Exception/UnknownServiceException.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Security/Exception/UnknownServiceException.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Exception;
+
+class UnknownServiceException extends RuntimeException
+{
+    private $teamNames = [];
+
+    public function __construct(array $teamNames, $message = "")
+    {
+        parent::__construct($message, 400, null);
+
+        $this->teamNames = $teamNames;
+    }
+
+    /**
+     * Get all team names the user has access to
+     *
+     * @return array
+     */
+    public function getTeamNames()
+    {
+        return $this->teamNames;
+    }
+}


### PR DESCRIPTION
Instead of showing a generic 'something went wrong' message, we show a
speficic error page for these two situations:

 - the user is not member of any teams (empty isMemberOf attribute)
 - the user is member of one or more teams, but no service in the
   dashboard matches any of the teams

Additionally, the templates for the 'authnfaild' and
'preconditionnotmet' exceptions were rendered using the wrong path,
resulting in a twig error. This has been fixed as well.