### PR TITLE
Fix broken translation loading

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -12,7 +12,6 @@ class AppKernel extends Kernel
             new Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle(),
             new Knp\Bundle\MenuBundle\KnpMenuBundle(),
             new League\Tactician\Bundle\TacticianBundle(),
-            new Lexik\Bundle\TranslationBundle\LexikTranslationBundle(),
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new Stfalcon\Bundle\TinymceBundle\StfalconTinymceBundle(),
             new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
@@ -25,6 +24,10 @@ class AppKernel extends Kernel
             new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
             new Symfony\Bundle\TwigBundle\TwigBundle(),
         ];
+
+        // The LexikTranslationBundle should be loaded *after* the
+        // FrameworkBundle so it can override the default translator.
+        $bundles[] = new Lexik\Bundle\TranslationBundle\LexikTranslationBundle();
 
         if (in_array($this->getEnvironment(), ['dev', 'test'], true)) {
             $bundles[] = new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle();


### PR DESCRIPTION
The lexik bundle should be registered after the framework bundle so
it can override the default translator.