### PR TITLE
Overwrite form values during metadata import

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/LoadMetadataCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/LoadMetadataCommandHandler.php
@@ -163,10 +163,8 @@ class LoadMetadataCommandHandler implements CommandHandler
     private function map(array $map, Entity $entity, Metadata $metadata)
     {
         foreach ($map as $metadataFieldName => $entityMethods) {
-            $getter = $entityMethods[0];
             $setter = $entityMethods[1];
-            // Only update the value on the entity if the user didn't set it previously
-            if (!is_null($metadata->$metadataFieldName) && empty(call_user_func([$entity, $getter]))) {
+            if (!is_null($metadata->$metadataFieldName)) {
                 call_user_func([$entity, $setter], $metadata->$metadataFieldName);
             }
         }

--- a/tests/webtests/EditEntityTest.php
+++ b/tests/webtests/EditEntityTest.php
@@ -157,12 +157,12 @@ class EditEntityTest extends WebTestCase
 
         $entity = $this->getEntityRepository()->findById($this->entityId);
 
-        // Should not have overwritten existing fields
-        $this->assertEquals('SP1', $entity->getNameEn());
+        // Should have overwritten existing fields
+        $this->assertEquals('DNEN', $entity->getNameEn());
 
         // Administrative contact is also an existing field in the fixture
         $this->assertInstanceOf(Contact::class, $entity->getAdministrativeContact());
-        $this->assertEquals('John', $entity->getAdministrativeContact()->getFirstName());
+        $this->assertEquals('Test2', $entity->getAdministrativeContact()->getFirstName());
 
         $this->assertInstanceOf(Contact::class, $entity->getTechnicalContact());
         $this->assertEquals('Test', $entity->getTechnicalContact()->getFirstName());
@@ -199,8 +199,7 @@ class EditEntityTest extends WebTestCase
 
         $entity = $this->getEntityRepository()->findById($this->entityId);
 
-        // Explicitly not set with the value in post!
-        $this->assertEquals('SP1', $entity->getNameEn());
+        $this->assertEquals('DNEN', $entity->getNameEn());
 
         $this->assertNull($entity->getCommonNameAttribute());
         $this->assertNull($entity->getUidAttribute());
@@ -235,12 +234,12 @@ class EditEntityTest extends WebTestCase
 
         $entity = $this->getEntityRepository()->findById($this->entityId);
 
-        // Should not have overwritten existing fields
-        $this->assertEquals('SP1', $entity->getNameEn());
+        // Should have overwritten existing fields
+        $this->assertEquals('DNEN', $entity->getNameEn());
 
         // Administrative contact is also an existing field in the fixture
         $this->assertInstanceOf(Contact::class, $entity->getAdministrativeContact());
-        $this->assertEquals('John', $entity->getAdministrativeContact()->getFirstName());
+        $this->assertEquals('Test2', $entity->getAdministrativeContact()->getFirstName());
 
         $this->assertInstanceOf(Contact::class, $entity->getTechnicalContact());
         $this->assertEquals('Test', $entity->getTechnicalContact()->getFirstName());


### PR DESCRIPTION
**Notes**
Previously these changes where not overwritten as they where entered
by the end user. With this change the imported data is always leading.
No additional checks are performed, the metadata is overwritten with the
newly imported data.

**Checklist**
- [x] Tests have been written
- [x] Travis build is passing
- [x] Git history is clean
- [x] ~Migrations are provided (if applicable)~
- [x] ~Documentation was updated (if applicable)~
- [x] Issue in Pivotal is updated