### PR TITLE
Add mailer functionality to SP Dashboard

### DIFF
--- a/ansible/roles/spdashboard/templates/parameters.yml.j2
+++ b/ansible/roles/spdashboard/templates/parameters.yml.j2
@@ -9,6 +9,9 @@ parameters:
     mailer_host: 127.0.0.1
     mailer_user: null
     mailer_password: null
+    mail_from: support@surfconext.nl
+    mail_receiver: support@surfconext.nl
+    mail_no_reply: no-reply@surfconext.nl
     secret: {{ spdashboard_symfony_secret }}
     administrator_team: {{ spdashboard_administrator_team }}
     metadata_url_timeout: 30

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -41,3 +41,8 @@ parameters:
     manage_test_host: 'https://manage.dev.support.surfconext.nl'
     manage_test_username: sp-dashboard
     manage_test_password: secret
+
+    # Mail default settings
+    mail_from: support@surfconext.nl
+    mail_receiver: support@surfconext.nl
+    mail_no_reply: no-reply@surfconext.nl

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Mail/MailCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Mail/MailCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Command\Mail;
+
+use Surfnet\ServiceProviderDashboard\Application\Command\Command;
+use Surfnet\ServiceProviderDashboard\Domain\Mailer\Message;
+
+interface MailCommand extends Command
+{
+    /**
+     * @return Message
+     */
+    public function getMessage();
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Mail/PublishToProductionMailCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Mail/PublishToProductionMailCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Command\Mail;
+
+use DateTime;
+use Surfnet\ServiceProviderDashboard\Application\Command\Command;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Domain\Mailer\Message;
+
+class PublishToProductionMailCommand implements MailCommand
+{
+    /**
+     * @var Message
+     */
+    private $message;
+
+    /**
+     * PublishToProductionMailCommand constructor.
+     * @param Message $message
+     */
+    public function __construct(Message $message)
+    {
+        $this->message = $message;
+    }
+
+
+    /**
+     * @return Message
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Mail/SendMailCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Mail/SendMailCommandHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\CommandHandler\Mail;
+
+use Surfnet\ServiceProviderDashboard\Application\Command\Mail\MailCommand;
+use Surfnet\ServiceProviderDashboard\Application\CommandHandler\CommandHandler;
+use Surfnet\ServiceProviderDashboard\Domain\Mailer\Mailer;
+
+class SendMailCommandHandler implements CommandHandler
+{
+    /**
+     * @var Mailer
+     */
+    private $mailer;
+
+    public function __construct(Mailer $mailer)
+    {
+        $this->mailer = $mailer;
+    }
+
+    public function handle(MailCommand $command)
+    {
+        $this->mailer->send($command->getMessage());
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Mailer/Mailer.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Mailer/Mailer.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Domain\Mailer;
+
+interface Mailer
+{
+    public function send(Message $message);
+}

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Mailer/Message.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Mailer/Message.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Domain\Mailer;
+
+/**
+ * Implement this interface to create a message that can be sent by the Mailer.
+ *
+ * This interface is compatible with Swift Mailers message but only implements
+ * the minimal features to send a simple mail message.
+ */
+interface Message
+{
+    public function setTo($addresses, $name = null);
+
+    public function setFrom($addresses, $name = null);
+
+    public function setBody($body, $contentType = null);
+
+    public function getHeaders();
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityMetadataController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityMetadataController.php
@@ -59,7 +59,7 @@ class EntityMetadataController extends Controller
     }
 
     /**
-     * @Route("/entity/metadata/{entityId}", name="service_metadata")
+     * @Route("/entity/metadata/{entityId}", name="entity_metadata")
      *
      * @param int $entityId
      *

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Factory/MailMessageFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Factory/MailMessageFactory.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Factory;
+
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Mailer\Message;
+use Symfony\Component\Templating\EngineInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * The mail message factory builds mail messages. These messages are set with a translatable title and their message
+ * is based on a twig template.
+ *
+ * The sender and receiver can be configured in the parameters.yml
+ */
+class MailMessageFactory
+{
+    /**
+     * @var string
+     */
+    private $sender;
+
+    /**
+     * @var string
+     */
+    private $receiver;
+
+    /**
+     * @var string
+     */
+    private $noReply;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var EngineInterface
+     */
+    private $templating;
+
+    /**
+     * @param string $sender
+     * @param string $receiver
+     * @param string $noReply
+     * @param TranslatorInterface $translator
+     * @param EngineInterface $templating
+     */
+    public function __construct(
+        $sender,
+        $receiver,
+        $noReply,
+        TranslatorInterface $translator,
+        EngineInterface $templating
+    ) {
+        $this->sender = $sender;
+        $this->receiver = $receiver;
+        $this->noReply = $noReply;
+        $this->translator = $translator;
+        $this->templating = $templating;
+    }
+
+    public function buildPublishToProductionMessage(Entity $entity)
+    {
+        $message = $this->createNewMessage();
+        $message->setSubject(
+            $this->translator->trans(
+                'mail.confirmation.publish_production.subject',
+                ['%entityId%' => $entity->getEntityId()]
+            )
+        );
+
+        $template = $this->renderView(
+            '@Dashboard/Mail/published.html.twig',
+            ['entity' => $entity]
+        );
+
+        $message->setBody($template, 'text/html');
+
+        return $message;
+    }
+
+    private function createNewMessage()
+    {
+        $message = Message::newInstance();
+
+        $headers = $message->getHeaders();
+        $headers->addTextHeader('Auto-Submitted', 'auto-generated');
+        # TODO: see https://github.com/swiftmailer/swiftmailer/issues/705
+        $message->setReturnPath($this->noReply);
+        $message->setFrom($this->sender);
+        $message->setTo($this->receiver);
+
+        return $message;
+    }
+
+    private function renderView($view, array $parameters = array())
+    {
+        return $this->templating->render($view, $parameters);
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Mailer/Mailer.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Mailer/Mailer.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Mailer;
+
+use Surfnet\ServiceProviderDashboard\Domain\Mailer\Mailer as MailerInterface;
+use Surfnet\ServiceProviderDashboard\Domain\Mailer\Message as MessageInterface;
+use Swift_Mailer;
+
+/**
+ * A very thin wrapper around the Swift_Mailer.
+ */
+class Mailer implements MailerInterface
+{
+    /**
+     * @var Swift_Mailer
+     */
+    private $swiftMailer;
+
+    public function __construct(Swift_Mailer $mailer)
+    {
+        $this->swiftMailer = $mailer;
+    }
+
+    public function send(MessageInterface $message)
+    {
+        $this->swiftMailer->send($message);
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Mailer/Message.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Mailer/Message.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Mailer;
+
+use Surfnet\ServiceProviderDashboard\Domain\Mailer\Message as MessageInterface;
+use Swift_Message;
+
+class Message extends Swift_Message implements MessageInterface
+{
+    public function __construct($subject = null, $body = null, $contentType = null, $charset = null)
+    {
+        parent::__construct($subject, $body, $contentType, $charset);
+    }
+
+    public static function newInstance($subject = null, $body = null, $contentType = null, $charset = null)
+    {
+        return new self($subject, $body, $contentType, $charset);
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -46,6 +46,13 @@ services:
         tags:
             - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Entity\LoadMetadataCommand }
 
+    surfnet.dashboard.command_handler.mailer:
+        class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Mail\SendMailCommandHandler
+        public: true
+        arguments: ['@surfnet.dashboard.mailer']
+        tags:
+            - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Mail\PublishToProductionMailCommand }
+
     surfnet.dashboard.command_handler.privacy_questions:
         class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\PrivacyQuestions\PrivacyQuestionsCommandHandler
         public: true
@@ -66,6 +73,20 @@ services:
 
     surfnet.dashboard.factory.entity:
         class: Surfnet\ServiceProviderDashboard\Application\Factory\EntityCommandFactory
+
+    surfnet.dashboard.mailer:
+        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Mailer\Mailer
+        arguments: ['@mailer']
+
+    surfnet.dashboard.mailer_factory:
+        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Factory\MailMessageFactory
+        arguments:
+            - '%mail_from%'
+            - '%mail_receiver%'
+            - '%mail_no_reply%'
+            - '@translator'
+            - '@templating'
+
 
     surfnet.dashboard.menu.builder:
         class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Menu\Builder

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -142,3 +142,4 @@ privacy.information.surfnetDpaAgreement: Are you willing to sign the model SURF 
 privacy.information.whatData: Describe what (kind of) data is processed in the service, and pay specific attention to possible processing of personal data.
 service.create.title: Add new service
 service.edit.title: Edit service
+mail.confirmation.publish_production.subject: 'Production connection has been requested (%entityId%)'

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Mail/published.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Mail/published.html.twig
@@ -1,0 +1,19 @@
+Hi,<br/>
+
+<p>
+    A {{ entity.environment }} SP Dashboard registration has just been finished. <br />
+
+    Link to Metadata:
+    <a href="{{ url('entity_metadata', {entityId: entity.id} ) }}">
+        {{ url('entity_metadata', {entityId: entity.id} ) }}
+    </a>
+</p>
+
+
+<p>
+    Kind regards,
+</p>
+
+<p>
+    SURFconext
+</p>

--- a/tests/integration/Application/CommandHandler/SendMailCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/SendMailCommandHandlerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Integration\Application\CommandHandler;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery\Mock;
+use Surfnet\ServiceProviderDashboard\Application\Command\Mail\PublishToProductionMailCommand;
+use Surfnet\ServiceProviderDashboard\Application\CommandHandler\Mail\SendMailCommandHandler;
+use Surfnet\ServiceProviderDashboard\Domain\Mailer\Mailer;
+use Surfnet\ServiceProviderDashboard\Domain\Mailer\Message;
+
+class SendMailCommandHandlerTest extends MockeryTestCase
+{
+    /**
+     * @var SendMailCommandHandler
+     */
+    private $commandHandler;
+
+    /**
+     * @var Mailer|Mock
+     */
+    private $mailer;
+
+    public function setUp()
+    {
+        $this->mailer = m::mock(Mailer::class);
+        $this->commandHandler = new SendMailCommandHandler($this->mailer);
+    }
+
+    /**
+     * @group CommandHandler
+     */
+    public function test_it_can_send_a_message()
+    {
+        $command = new PublishToProductionMailCommand(m::mock(Message::class));
+
+        $this->mailer
+            ->shouldReceive('send')
+            ->once();
+
+        $this->commandHandler->handle($command);
+    }
+}

--- a/tests/unit/Application/CommandHandler/Entity/CreateEntityCommandHandlerTest.php
+++ b/tests/unit/Application/CommandHandler/Entity/CreateEntityCommandHandlerTest.php
@@ -16,21 +16,16 @@
  * limitations under the License.
  */
 
-namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\DashboardBundle\CommandHandler\Entity;
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Application\CommandHandler\Entity;
 
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
-use Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\CreateEntityCommandHandler;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\CreateEntityCommand;
-use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\CreateEntityCommandHandler;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityRepository;
-use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\CommandHandler\Service\SelectServiceCommandHandler;
-use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Command\Service\SelectServiceCommand;
-use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AuthorizationService;
 
-class CreateServiceCommandHandlerTest extends MockeryTestCase
+class CreateEntityCommandHandlerTest extends MockeryTestCase
 {
     /** @var CreateEntityCommandHandler */
     private $commandHandler;

--- a/tests/unit/Application/CommandHandler/PrivacyQuestions/PrivacyQuestionsCommandHandlerTest.php
+++ b/tests/unit/Application/CommandHandler/PrivacyQuestions/PrivacyQuestionsCommandHandlerTest.php
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\DashboardBundle\CommandHandler\Entity;
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Application\CommandHandler\PrivacyQuestions;
 
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;

--- a/tests/unit/Infrastructure/DashboardBundle/Factory/MailMessageFactoryTest.php
+++ b/tests/unit/Infrastructure/DashboardBundle/Factory/MailMessageFactoryTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\DashboardBundle\Mailer;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Factory\MailMessageFactory;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Mailer\Message;
+use Symfony\Component\Templating\EngineInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class MailMessageFactoryTest extends MockeryTestCase
+{
+    /**
+     * @var EngineInterface|Mock
+     */
+    private $templateEngine;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var MailMessageFactory
+     */
+    private $factory;
+
+    protected function setUp()
+    {
+        $this->templateEngine = m::mock(EngineInterface::class);
+        $this->translator = m::mock(TranslatorInterface::class);
+
+        $this->factory = new MailMessageFactory(
+            'john@example.com',
+            'doe@example.com',
+            'no-reply@example.com',
+            $this->translator,
+            $this->templateEngine
+        );
+    }
+
+    public function test_build_publish_to_production_message()
+    {
+        $entity = m::mock(Entity::class);
+        $entity
+            ->shouldReceive('getEntityId')
+            ->once()
+            ->andReturn('1123132-1231231-12312312123');
+
+        $this->translator
+            ->shouldReceive('trans');
+
+        $this->templateEngine
+            ->shouldReceive('render');
+
+        $message = $this->factory->buildPublishToProductionMessage($entity);
+        $this->assertInstanceOf(Message::class, $message);
+    }
+}

--- a/tests/unit/Infrastructure/DashboardBundle/Mailer/MailerTest.php
+++ b/tests/unit/Infrastructure/DashboardBundle/Mailer/MailerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\DashboardBundle\Mailer;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Mailer\Mailer;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Mailer\Message;
+use Swift_Mailer;
+
+class MailerTest extends MockeryTestCase
+{
+    public function test_sending_of_message_message()
+    {
+        $message = m::mock(Message::class);
+
+        $swiftMailer = m::mock(Swift_Mailer::class);
+        $swiftMailer
+            ->shouldReceive('send')
+            ->with($message)
+            ->once();
+        $mailer = new Mailer($swiftMailer);
+        $mailer->send($message);
+    }
+}


### PR DESCRIPTION
**Review notes**
Using the MailCommandHandler, messages can be sent to the servicedesk. Each mail should be encapsulated in a MailCommand. Who in turn encapsulates a Message (Swift Mailer Message).

The provided PublishToProductionMailCommand can be executed easily (if you'd like to test this feature IRL) by adding the following code in a controller action of your choise (preferably an action with access to an `Entity`).

```
$messageFactory =  $this->get('surfnet.dashboard.mailer_factory');
$message = $messageFactory->buildPublishToProductionMessage($entity);
$mailCommand = new PublishToProductionMailCommand($message);
$this->commandBus->handle($mailCommand);
```

The message sent is caught by Mailcatcher: http://spdashboard.dev.support.surfconext.nl:1080/
- [x] Tests have been written
- [x] Travis build is passing
- [x] Git history is clean
- [x] ~Migrations are provided (if applicable)~
- [x] ~Documentation was updated (if applicable)~
- [x] Issue in Pivotal is updated