### PR TITLE
Set the MetadataUrl by default on import

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/LoadMetadataCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/LoadMetadataCommandHandler.php
@@ -89,9 +89,9 @@ class LoadMetadataCommandHandler implements CommandHandler
         $this->mapContacts($entity, $metadata);
         $this->mapAttributes($entity, $metadata);
 
-        // By default set the entityId as the metadataUrl but only when the metadataUrl is not set yet.
-        if (!empty($entity->getMetadataUrl())) {
-            $entity->setMetadataUrl($entity->getEntityId());
+        // By default set the import url as the metadataUrl but only when the metadataUrl is not set yet.
+        if (!empty($entity->getMetadataUrl()) && $command->isUrlSet()) {
+            $entity->setMetadataUrl($entity->getImportUrl());
         }
 
         $this->entityRepository->save($entity);


### PR DESCRIPTION
**Review notes**
This will set the metadata url field (in the entity edit form) with the entity id. But only when the metadata url field has not been set before.

Reviewers, is this what we want? Or am I solving a non issue?