### PR TITLE
Don't use WYSIWYG editor for keys ending in .help

### DIFF
--- a/app/js/components/translation_ui.js
+++ b/app/js/components/translation_ui.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
     function initTinyMceTextarea(event) {
         var targetRow = $(event.target).parents('tr');
-        if (targetRow.find('td:contains(".help"),td:contains(".html"),td:contains(".information.")').length) {
+        if (targetRow.find('td:contains(".html"),td:contains(".information.")').length) {
             var textarea = targetRow.find('textarea');
             if (!textarea.hasClass('tinymce')) {
                 textarea.addClass('tinymce');


### PR DESCRIPTION
We use .html and .information as suffix for WYSIWYG messages. .help is
not in use so can be safely removed. This prevents accidental match on
'page.header.help'.