### PR TITLE
Return Form when publishing fails

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityEditController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityEditController.php
@@ -140,7 +140,10 @@ class EntityEditController extends Controller
                     case 'publishButton':
                         // Only trigger form validation on publish
                         if ($form->isValid()) {
-                            return $this->publishEntity($entity, $flashBag);
+                            $response = $this->publishEntity($entity, $flashBag);
+                            if ($response instanceof Response) {
+                                return $response;
+                            }
                         }
                         break;
                     default:


### PR DESCRIPTION
The application, prior to a refactoring, expected the return of a Response. in the case of
a failing Manage interaction no Response object is returned as we
show a flash message on the form.