### PR TITLE
Change attribute friendly names to conform to manage expectations

### DIFF
--- a/app/Resources/metadata/attributes.json
+++ b/app/Resources/metadata/attributes.json
@@ -2,7 +2,7 @@
   {
     "id": "displayName",
     "getterName": "getDisplayNameAttribute",
-    "friendlyName": "Display name",
+    "friendlyName": "displayName",
     "urns": [
       "urn:mace:dir:attribute-def:displayName",
       "urn:oid:2.16.840.1.113730.3.1.241"
@@ -11,7 +11,7 @@
   {
     "id": "affiliation",
     "getterName": "getAffiliationAttribute",
-    "friendlyName": "Affiliation",
+    "friendlyName": "eduPersonAffiliation",
     "urns": [
       "urn:mace:dir:attribute-def:eduPersonAffiliation",
       "urn:oid:1.3.6.1.4.1.5923.1.1.1.1"
@@ -20,7 +20,7 @@
   {
     "id": "scopedaffiliation",
     "getterName": "getScopedAffiliationAttribute",
-    "friendlyName": "ScopedAffiliation",
+    "friendlyName": "eduPersonScopedAffiliation",
     "urns": [
       "urn:mace:dir:attribute-def:eduPersonScopedAffiliation",
       "urn:oid:1.3.6.1.4.1.5923.1.1.1.9"
@@ -29,7 +29,7 @@
   {
     "id": "emailAddress",
     "getterName": "getEmailAddressAttribute",
-    "friendlyName": "Email address",
+    "friendlyName": "mail",
     "urns": [
       "urn:mace:dir:attribute-def:mail",
       "urn:oid:0.9.2342.19200300.100.1.3"
@@ -38,7 +38,7 @@
   {
     "id": "commonName",
     "getterName": "getCommonNameAttribute",
-    "friendlyName": "Common name",
+    "friendlyName": "cn",
     "urns": [
       "urn:mace:dir:attribute-def:cn",
       "urn:oid:2.5.4.3"
@@ -47,7 +47,7 @@
   {
     "id": "organization",
     "getterName": "getOrganizationAttribute",
-    "friendlyName": "Organization",
+    "friendlyName": "schacHomeOrganization",
     "urns": [
       "urn:mace:terena.org:attribute-def:schacHomeOrganization",
       "urn:oid:1.3.6.1.4.1.25178.1.2.9"
@@ -56,7 +56,7 @@
   {
     "id": "organizationType",
     "getterName": "getOrganizationTypeAttribute",
-    "friendlyName": "Organization Type",
+    "friendlyName": "shacHomeOrganizationType",
     "urns": [
       "urn:mace:terena.org:attribute-def:schacHomeOrganizationType",
       "urn:oid:1.3.6.1.4.1.25178.1.2.10"
@@ -65,7 +65,7 @@
   {
     "id": "surName",
     "getterName": "getSurNameAttribute",
-    "friendlyName": "Surname",
+    "friendlyName": "sn",
     "urns": [
       "urn:mace:dir:attribute-def:sn",
       "urn:oid:2.5.4.4"
@@ -74,7 +74,7 @@
   {
     "id": "givenName",
     "getterName": "getGivenNameAttribute",
-    "friendlyName": "Given name",
+    "friendlyName": "givenName",
     "urns": [
       "urn:mace:dir:attribute-def:givenName",
       "urn:oid:2.5.4.42"
@@ -83,7 +83,7 @@
   {
     "id": "entitlement",
     "getterName": "getEntitlementAttribute",
-    "friendlyName": "Entitlement",
+    "friendlyName": "eduPersonEntitlement",
     "urns": [
       "urn:mace:dir:attribute-def:eduPersonEntitlement",
       "urn:oid:1.3.6.1.4.1.5923.1.1.1.7"
@@ -101,7 +101,7 @@
   {
     "id": "principleName",
     "getterName": "getPrincipleNameAttribute",
-    "friendlyName": "PrincipalName",
+    "friendlyName": "eduPersonPrincipalName",
     "urns": [
       "urn:mace:dir:attribute-def:eduPersonPrincipalName",
       "urn:oid:1.3.6.1.4.1.5923.1.1.1.6"
@@ -119,7 +119,7 @@
   {
     "id": "personalCode",
     "getterName": "getPersonalCodeAttribute",
-    "friendlyName": "Employee\/student number",
+    "friendlyName": "schacPersonalUniqueCode",
     "urns": [
       "urn:schac:attribute-def:schacPersonalUniqueCode",
       "urn:oid:1.3.6.1.4.1.1466.155.121.1.15"


### PR DESCRIPTION
Manage expects the friendly name of a requested attribute to be the
last part of the mace urn. For example:

 - urn:mace:dir:attribute-def:mail -> mail
 - urn:mace:dir:attribute-def:cn -> cn

See: https://github.com/OpenConext/OpenConext-manage/blob/f349da47e1ec83a1f1f399999e13e5e2ef4e47ef/manage-server/src/main/java/manage/format/MetaDataFeedParser.java#L285