### PR TITLE
Use 'mdui' namespace alias in metadata XML

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Legacy/Metadata/Generator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Legacy/Metadata/Generator.php
@@ -99,52 +99,52 @@ class Generator implements GeneratorInterface
     private function generateUi(SimpleXMLElement $xml, Entity $entity)
     {
         $extensions = $this->setNode($xml, 'md:Extensions', null, array(), array('md' => self::NS_SAML), array(), 0);
-        $ui = $this->setNode($extensions, 'ui:UIInfo', null, array(), array('ui' => self::NS_UI));
+        $ui = $this->setNode($extensions, 'mdui:UIInfo', null, array(), array('mdui' => self::NS_UI));
 
         $this->generateLogo($ui, $entity);
 
         $this->setNode(
             $ui,
-            'ui:Description',
+            'mdui:Description',
             $entity->getDescriptionEn(),
             array('xml:lang' => 'en'),
-            array('ui' => self::NS_UI),
+            array('mdui' => self::NS_UI),
             array('xml' => self::NS_LANG)
         );
 
         $this->setNode(
             $ui,
-            'ui:Description',
+            'mdui:Description',
             $entity->getDescriptionNl(),
             array('xml:lang' => 'nl'),
-            array('ui' => self::NS_UI),
+            array('mdui' => self::NS_UI),
             array('xml' => self::NS_LANG)
         );
 
         $this->setNode(
             $ui,
-            'ui:DisplayName',
+            'mdui:DisplayName',
             $entity->getNameEn(),
             array('xml:lang' => 'en'),
-            array('ui' => self::NS_UI),
+            array('mdui' => self::NS_UI),
             array('xml' => self::NS_LANG)
         );
 
         $this->setNode(
             $ui,
-            'ui:DisplayName',
+            'mdui:DisplayName',
             $entity->getNameNl(),
             array('xml:lang' => 'nl'),
-            array('ui' => self::NS_UI),
+            array('mdui' => self::NS_UI),
             array('xml' => self::NS_LANG)
         );
 
         $this->setNode(
             $ui,
-            'ui:InformationURL',
+            'mdui:InformationURL',
             $entity->getApplicationUrl(),
             array('xml:lang' => 'en'),
-            array('ui' => self::NS_UI),
+            array('mdui' => self::NS_UI),
             array('xml' => self::NS_LANG)
         );
     }
@@ -157,17 +157,17 @@ class Generator implements GeneratorInterface
     {
         $logo = $entity->getLogoUrl();
         if (empty($logo)) {
-            $this->removeNode($xml, 'ui:Logo', array(), array('ui' => self::NS_UI));
+            $this->removeNode($xml, 'mdui:Logo', array(), array('mdui' => self::NS_UI));
 
             return;
         }
 
         $node = $this->setNode(
             $xml,
-            'ui:Logo',
+            'mdui:Logo',
             $logo,
             array(),
-            array('ui' => self::NS_UI)
+            array('mdui' => self::NS_UI)
         );
 
         $logoData = @getimagesize($logo);

--- a/tests/unit/Legacy/Metadata/GeneratorTest.php
+++ b/tests/unit/Legacy/Metadata/GeneratorTest.php
@@ -195,12 +195,12 @@ class GeneratorTest extends MockeryTestCase
 
         $xml = $this->generator->generate($service);
 
-        $this->assertContains('<ui:DisplayName xml:lang="nl">UNAMENL</ui:DisplayName>', $xml);
-        $this->assertContains('<ui:DisplayName xml:lang="en">UNAMEEN</ui:DisplayName>', $xml);
-        $this->assertContains('<ui:Description xml:lang="nl">UPDATEDDESCRNL</ui:Description>', $xml);
-        $this->assertContains('<ui:Description xml:lang="en">UPDATEDDESCREN</ui:Description>', $xml);
-        $this->assertContains('<ui:InformationURL xml:lang="en">http://www.google.nl</ui:InformationURL>', $xml);
-        $this->assertContains('<ui:Logo>http://www.google.com</ui:Logo>', $xml);
+        $this->assertContains('<mdui:DisplayName xml:lang="nl">UNAMENL</mdui:DisplayName>', $xml);
+        $this->assertContains('<mdui:DisplayName xml:lang="en">UNAMEEN</mdui:DisplayName>', $xml);
+        $this->assertContains('<mdui:Description xml:lang="nl">UPDATEDDESCRNL</mdui:Description>', $xml);
+        $this->assertContains('<mdui:Description xml:lang="en">UPDATEDDESCREN</mdui:Description>', $xml);
+        $this->assertContains('<mdui:InformationURL xml:lang="en">http://www.google.nl</mdui:InformationURL>', $xml);
+        $this->assertContains('<mdui:Logo>http://www.google.com</mdui:Logo>', $xml);
 
         // Make sure the generated metadata is valid
         $this->assertInstanceOf(Metadata::class, $this->parser->parseXml($xml));
@@ -252,7 +252,7 @@ class GeneratorTest extends MockeryTestCase
 
         $xml = $this->generator->generate($service);
 
-        $this->assertContains('<ui:Logo width="1006" height="1006">' . $logoUrl . '</ui:Logo>', $xml);
+        $this->assertContains('<mdui:Logo width="1006" height="1006">' . $logoUrl . '</mdui:Logo>', $xml);
 
         // Make sure the generated metadata is valid
         $this->assertInstanceOf(Metadata::class, $this->parser->parseXml($xml));
@@ -280,8 +280,8 @@ class GeneratorTest extends MockeryTestCase
 
         $xml = $this->generator->generate($service);
 
-        $this->assertNotContains('<mdui:Logo', $xml);
         $this->assertNotContains('<ui:Logo', $xml);
+        $this->assertNotContains('<mdui:Logo', $xml);
 
         // Make sure the generated metadata is valid
         $this->assertInstanceOf(Metadata::class, $this->parser->parseXml($xml));
@@ -294,8 +294,8 @@ class GeneratorTest extends MockeryTestCase
 
         $xml = $this->generator->generate($service);
 
-        $this->assertNotContains('<mdui:Logo', $xml);
         $this->assertNotContains('<ui:Logo', $xml);
+        $this->assertNotContains('<mdui:Logo', $xml);
 
         // Make sure the generated metadata is valid
         $this->assertInstanceOf(Metadata::class, $this->parser->parseXml($xml));


### PR DESCRIPTION
EngineBlock, manage and the examples in the UI extension specs all use
'mdui' as namespace alias. The dashboard now uses that alias too,
instead of mixing 'ui:' and 'mdui:' in the same document.