### PR TITLE
Fix missing shacHomeOrganisationType attribute

### DIFF
--- a/app/Resources/metadata/attributes.json
+++ b/app/Resources/metadata/attributes.json
@@ -56,7 +56,7 @@
   {
     "id": "organizationType",
     "getterName": "getOrganizationTypeAttribute",
-    "friendlyName": "shacHomeOrganizationType",
+    "friendlyName": "schacHomeOrganizationType",
     "urns": [
       "urn:mace:terena.org:attribute-def:schacHomeOrganizationType",
       "urn:oid:1.3.6.1.4.1.25178.1.2.10"


### PR DESCRIPTION
The attribute did not end up in manage after publication because there
was a typo in the friendly name.