### PR TITLE
Install Monitor-bundle 1.0.1

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -15,6 +15,7 @@ class AppKernel extends Kernel
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new Stfalcon\Bundle\TinymceBundle\StfalconTinymceBundle(),
             new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
+            new OpenConext\MonitorBundle\OpenConextMonitorBundle(),
             new Surfnet\SamlBundle\SurfnetSamlBundle(),
             new Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\DashboardBundle(),
             new Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\DashboardSamlBundle(),

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -6,6 +6,10 @@ dashboard_saml:
     type:     annotation
     prefix:   /
 
+openconext_monitor:
+    resource: "@OpenConextMonitorBundle/Resources/config/routing.yml"
+    prefix: /
+
 lexik_translation_edition:
     resource: "@LexikTranslationBundle/Resources/config/routing.yml"
     prefix:   /translations

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -24,6 +24,10 @@ security:
             pattern:    ^/entity/metadata/*
             anonymous:  ~
 
+        monitor:
+            pattern: ^/(info|health)$
+            security: false
+
         saml_based:
             saml: true
             logout:

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "knplabs/knp-menu-bundle": "^2.1",
         "league/tactician-bundle": "^0.4.1",
         "lexik/translation-bundle": "dev-feature/fix-url-encode-issue",
+        "openconext/monitor-bundle": "^1.0",
         "ramsey/uuid": "^3.7",
         "sensio/framework-extra-bundle": "^3.0",
         "stfalcon/tinymce-bundle": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c9c7eadf3af5837398302837cc961e7b",
+    "content-hash": "448976cb853267e2d00d14692b959e08",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -1831,6 +1831,59 @@
             "time": "2015-08-09T04:28:19+00:00"
         },
         {
+            "name": "openconext/monitor-bundle",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/OpenConext/Monitor-bundle.git",
+                "reference": "12803aaf3084966e41876ebe6da63bce245aca07"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/OpenConext/Monitor-bundle/zipball/12803aaf3084966e41876ebe6da63bce245aca07",
+                "reference": "12803aaf3084966e41876ebe6da63bce245aca07",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4,<8.0-dev",
+                "symfony/dependency-injection": ">=2.7,<4",
+                "symfony/framework-bundle": ">=2.7,<4",
+                "webmozart/assert": "^1.2"
+            },
+            "require-dev": {
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "liip/rmt": "^1.1",
+                "malukenho/docheader": "^0.1.6",
+                "matthiasnoback/symfony-config-test": "^2.1",
+                "mockery/mockery": "~0.9",
+                "phpdocumentor/reflection-docblock": "3.3.*",
+                "phpmd/phpmd": "^2.6",
+                "phpunit/php-token-stream": "1.4.*",
+                "phpunit/phpunit": "^5.7",
+                "sebastian/phpcpd": "^3.0",
+                "squizlabs/php_codesniffer": "^3.1"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "OpenConext\\MonitorBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "A Symfony2 bundle that facilitates health and info endpoints to a Symfony application",
+            "keywords": [
+                "OpenConext",
+                "health",
+                "monitoring",
+                "stepup",
+                "surfnet"
+            ],
+            "time": "2017-12-11T10:22:11+00:00"
+        },
+        {
             "name": "paragonie/random_compat",
             "version": "v2.0.11",
             "source": {
@@ -3312,6 +3365,56 @@
                 "templating"
             ],
             "time": "2017-09-27T18:06:46+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2016-11-23T20:04:58+00:00"
         },
         {
             "name": "zendframework/zend-code",
@@ -5586,56 +5689,6 @@
             "description": "The classes contained within this repository extend the standard DOM to use exceptions at all occasions of errors instead of PHP warnings or notices. They also add various custom methods and shortcuts for convenience and to simplify the usage of DOM.",
             "homepage": "https://github.com/theseer/fDOMDocument",
             "time": "2017-06-30T11:53:12+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "time": "2016-11-23T20:04:58+00:00"
         }
     ],
     "aliases": [],

--- a/var/SymfonyRequirements.php
+++ b/var/SymfonyRequirements.php
@@ -634,12 +634,6 @@ class SymfonyRequirements extends RequirementCollection
         );
 
         $this->addRecommendation(
-            function_exists('iconv'),
-            'iconv() should be available',
-            'Install and enable the <strong>iconv</strong> extension.'
-        );
-
-        $this->addRecommendation(
             function_exists('utf8_decode'),
             'utf8_decode() should be available',
             'Install and enable the <strong>XML</strong> extension.'

--- a/web/config.php
+++ b/web/config.php
@@ -11,7 +11,7 @@
  */
 
 if (!isset($_SERVER['HTTP_HOST'])) {
-    exit('This script cannot be run from the CLI. Run it from a browser.');
+    exit("This script cannot be run from the CLI. Run it from a browser.\n");
 }
 
 if (!in_array(@$_SERVER['REMOTE_ADDR'], array(


### PR DESCRIPTION
The health and info responses can be requested at respectively: hostname/health and hostname/info

The endpoints are not restricted by firewall rules and thus are publically available. This should be restricted by the load balancer.

As a part of the installation of the bundle, Symfony also updated the
web/config file and updated the SymfonyRequirements checker.
