### PR TITLE
Save or publish the form when pressing enter

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/EntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/EntityType.php
@@ -39,6 +39,14 @@ class EntityType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
+            // The first button in a form defines the default behaviour when
+            // submitting the form by pressing ENTER. We add a 'default
+            // action' button on top of the form so the controller action
+            // handling the form submission can choose what action to
+            // perform. This is to prevent the import action when submitting
+            // the form (the import button is now the second button on the
+            // form).
+            ->add('default', SubmitType::class, ['attr' => ['style' => 'display: none']])
             ->add(
                 $builder->create(
                     'general',
@@ -311,6 +319,7 @@ class EntityType extends AbstractType
                     )
             )
 
+            ->add('status', HiddenType::class)
             ->add('manageId', HiddenType::class)
             ->add('environment', HiddenType::class)
             ->add('nameIdFormat', HiddenType::class)

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityEdit/edit.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityEdit/edit.html.twig
@@ -7,6 +7,8 @@
 
     {{ form_start(form, {'attr': {'novalidate': 'novalidate'}}) }}
 
+    {{ form_widget(form.default) }}
+
     <div class="fieldset card">
 
         {% for message in app.flashes('error') %}


### PR DESCRIPTION
Browsers send the first submit button in the form when the for is
submitted using the enter key. In the case of the entity form, this is
'import'. But this is not user-friendly: when pressing enter we want
the default action to occur:

 - enter should save the form when there is a save button
 - enter should publish the form if there is only a publish button

This behaviour is implemented by adding a hidden 'default' submit
button on the top of the form.

This commit also fixes a bug where published entities could still be
saved as draft after using the import button.