### PR TITLE
Allow privileged users to create draft entities for production

### DIFF
--- a/app/DoctrineMigrations/Version20180110141503.php
+++ b/app/DoctrineMigrations/Version20180110141503.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180110141503 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE service ADD production_entities_enabled TINYINT(1) NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE service DROP production_entities_enabled');
+    }
+}

--- a/app/scss/components/actions.scss
+++ b/app/scss/components/actions.scss
@@ -1,3 +1,18 @@
+div.add-entity-actions {
+  text-align: right;
+
+  a {
+    color: $blue;
+
+    &:visited, &:hover {
+      text-decoration: none;
+    }
+    text-decoration: none;
+
+    padding-left: 1rem;
+  }
+}
+
 div.actions {
   text-align: right;
   position: relative;

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveEntityCommand.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Command\Entity;
 
+use InvalidArgumentException;
 use Surfnet\ServiceProviderDashboard\Application\Command\Command;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
@@ -495,6 +496,15 @@ class SaveEntityCommand implements Command
      */
     public function setEnvironment($environment)
     {
+        if (!in_array($environment, [
+            Entity::ENVIRONMENT_TEST,
+            Entity::ENVIRONMENT_PRODUCTION,
+        ])) {
+            throw new InvalidArgumentException(
+                "Unknown environment '{$environment}'"
+            );
+        }
+
         $this->environment = $environment;
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/CreateServiceCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/CreateServiceCommand.php
@@ -45,6 +45,11 @@ class CreateServiceCommand implements Command
     /**
      * @var bool
      */
+    private $productionEntitiesEnabled = false;
+
+    /**
+     * @var bool
+     */
     private $privacyQuestionsEnabled = true;
 
     /**
@@ -69,6 +74,14 @@ class CreateServiceCommand implements Command
     public function setName($name)
     {
         $this->name = $name;
+    }
+
+    /**
+     * @param bool $enabled
+     */
+    public function setProductionEntitiesEnabled($enabled)
+    {
+        $this->productionEntitiesEnabled = $enabled;
     }
 
     /**
@@ -101,6 +114,14 @@ class CreateServiceCommand implements Command
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isProductionEntitiesEnabled()
+    {
+        return $this->productionEntitiesEnabled;
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/EditServiceCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/EditServiceCommand.php
@@ -50,6 +50,11 @@ class EditServiceCommand implements Command
     /**
      * @var bool
      */
+    private $productionEntitiesEnabled = true;
+
+    /**
+     * @var bool
+     */
     private $privacyQuestionsEnabled = true;
 
     /**
@@ -57,14 +62,16 @@ class EditServiceCommand implements Command
      * @param string $guid
      * @param string $name
      * @param string $teamName
-     * @param $privacyQuestionsEnabled
+     * @param bool $productionEntitiesEnabled
+     * @param bool $privacyQuestionsEnabled
      */
-    public function __construct($id, $guid, $name, $teamName, $privacyQuestionsEnabled)
+    public function __construct($id, $guid, $name, $teamName, $productionEntitiesEnabled, $privacyQuestionsEnabled)
     {
         $this->id = $id;
         $this->guid = $guid;
         $this->name = $name;
         $this->teamName = $teamName;
+        $this->productionEntitiesEnabled = $productionEntitiesEnabled;
         $this->privacyQuestionsEnabled = $privacyQuestionsEnabled;
     }
 
@@ -90,6 +97,14 @@ class EditServiceCommand implements Command
     public function setName($name)
     {
         $this->name = $name;
+    }
+
+    /**
+     * @param bool $productionEntitiesEnabled
+     */
+    public function setProductionEntitiesEnabled($enabled)
+    {
+        $this->productionEntitiesEnabled = $enabled;
     }
 
     /**
@@ -130,6 +145,14 @@ class EditServiceCommand implements Command
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isProductionEntitiesEnabled()
+    {
+        return $this->productionEntitiesEnabled;
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/CreateServiceCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/CreateServiceCommandHandler.php
@@ -49,6 +49,7 @@ class CreateServiceCommandHandler implements CommandHandler
         $service->setName($command->getName());
         $service->setGuid($command->getGuid());
         $service->setTeamName($command->getTeamName());
+        $service->setProductionEntitiesEnabled($command->isProductionEntitiesEnabled());
         $service->setPrivacyQuestionsEnabled($command->isPrivacyQuestionsEnabled());
 
         $this->serviceRepository->isUnique($service);

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/EditServiceCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/EditServiceCommandHandler.php
@@ -55,6 +55,7 @@ class EditServiceCommandHandler implements CommandHandler
         $service->setName($command->getName());
         $service->setGuid($command->getGuid());
         $service->setTeamName($command->getTeamName());
+        $service->setProductionEntitiesEnabled($command->isProductionEntitiesEnabled());
         $service->setPrivacyQuestionsEnabled($command->isPrivacyQuestionsEnabled());
 
         $this->serviceRepository->isUnique($service);

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
@@ -65,6 +65,13 @@ class Service
      *
      * @ORM\Column(type="boolean")
      */
+    private $productionEntitiesEnabled = false;
+
+    /**
+     * @var bool
+     *
+     * @ORM\Column(type="boolean")
+     */
     private $privacyQuestionsEnabled = true;
 
     /**
@@ -143,6 +150,14 @@ class Service
     }
 
     /**
+     * @param bool $enabled
+     */
+    public function setProductionEntitiesEnabled($enabled)
+    {
+        $this->productionEntitiesEnabled = $enabled;
+    }
+
+    /**
      * @param bool $privacyQuestionsEnabled
      */
     public function setPrivacyQuestionsEnabled($privacyQuestionsEnabled)
@@ -194,6 +209,14 @@ class Service
     public function setPrivacyQuestions(PrivacyQuestions $privacyQuestions)
     {
         $this->privacyQuestions = $privacyQuestions;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isProductionEntitiesEnabled()
+    {
+        return $this->productionEntitiesEnabled;
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityListController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityListController.php
@@ -76,6 +76,7 @@ class EntityListController extends Controller
 
         $service = null;
         $entityList = [];
+        $productionEntitiesEnabled = false;
 
         $activeServiceId = $this->authorizationService->getActiveServiceId();
         if ($activeServiceId) {
@@ -86,10 +87,12 @@ class EntityListController extends Controller
 
         if ($service) {
             $entityList = $this->entityService->getEntityListForService($service);
+            $productionEntitiesEnabled = $service->isProductionEntitiesEnabled();
         }
 
         return [
             'no_service_selected' => empty($service),
+            'production_entities_enabled' => $productionEntitiesEnabled,
             'entity_list' => $entityList,
         ];
     }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -129,6 +129,7 @@ class ServiceController extends Controller
             $service->getGuid(),
             $service->getName(),
             $service->getTeamName(),
+            $service->isProductionEntitiesEnabled(),
             $service->isPrivacyQuestionsEnabled()
         );
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DataFixtures/ORM/WebTestFixtures.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DataFixtures/ORM/WebTestFixtures.php
@@ -29,19 +29,20 @@ class WebTestFixtures extends Fixture
 {
     public function load(ObjectManager $manager)
     {
-        $manager->persist(
-            $this->createService('SURFnet', 'urn:collab:org:surf.nl')
-                ->addEntity(
-                    $this->createEntity('SP1')
-                )
-                ->addEntity(
-                    $this->createEntity('SP2')
-                )
-        );
+        $service = $this->createService('SURFnet', 'urn:collab:org:surf.nl')
+            ->addEntity(
+                $this->createEntity('SP1')
+            )
+            ->addEntity(
+                $this->createEntity('SP2')
+            );
 
-        $manager->persist(
-            $this->createService('Ibuildings B.V.', 'urn:collab:org:ibuildings.nl')
-        );
+        $service->setProductionEntitiesEnabled(false);
+        $manager->persist($service);
+
+        $service =  $this->createService('Ibuildings B.V.', 'urn:collab:org:ibuildings.nl');
+        $service->setProductionEntitiesEnabled(true);
+        $manager->persist($service);
 
         $manager->flush();
     }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/CreateServiceType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/CreateServiceType.php
@@ -33,6 +33,7 @@ class CreateServiceType extends AbstractType
             ->add('guid')
             ->add('name')
             ->add('teamName')
+            ->add('productionEntitiesEnabled', CheckboxType::class)
             ->add('privacyQuestionsEnabled', CheckboxType::class)
             ->add('save', SubmitType::class, ['attr' => ['class'=>'button']]);
     }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/EditServiceType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/EditServiceType.php
@@ -33,6 +33,7 @@ class EditServiceType extends AbstractType
             ->add('guid')
             ->add('name')
             ->add('teamName')
+            ->add('productionEntitiesEnabled', CheckboxType::class)
             ->add('privacyQuestionsEnabled', CheckboxType::class)
             ->add('save', SubmitType::class, ['attr' => ['class'=>'button']]);
     }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Menu/Builder.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Menu/Builder.php
@@ -40,10 +40,6 @@ class Builder
         if ($this->authorizationService->hasActiveServiceId()) {
             $menu->addChild('My entities', array('route' => 'entity_list'));
 
-            $menu->addChild('Add new entity', array(
-                'route' => 'entity_add',
-            ));
-
             if ($this->authorizationService->hasActivatedPrivacyQuestions()) {
                 $menu->addChild(
                     'Privacy',

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -9,6 +9,8 @@ entity.delete.confirmation: "You are about to delete the entity %name%, are you 
 entity.list.title: My entities
 entity.list.empty: There are no entities configured
 entity.list.no_service_selected: Please select a service
+entity.list.add_to_test: Add for test
+entity.list.add_to_production: Add for production
 entity.list.name: Entity
 entity.list.entity_id: Entity ID
 entity.list.primary_contact: Primary contact

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityList/list.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityList/list.html.twig
@@ -2,11 +2,27 @@
 
 {% block page_heading %}{{ 'entity.list.title'|trans }}{%endblock%}
 {% block body %}
+    {% if not no_service_selected %}
+    <div class="add-entity-actions">
+        <a href="{{ path('entity_add') }}">
+            <i class="fa fa-plus"></i>
+            {{ 'entity.list.add_to_test'|trans}}
+        </a>
+        {% if production_entities_enabled %}
+            <a href="{{ path('entity_add', {environment: "production"}) }}">
+                <i class="fa fa-plus"></i>
+                {{ 'entity.list.add_to_production'|trans}}
+            </a>
+        {% endif %}
+    </div>
+    {% endif %}
+
     {% if no_service_selected %}
         {{ 'entity.list.no_service_selected'|trans }}
     {% elseif entity_list.entities is empty %}
         {{ 'entity.list.empty'|trans }}
     {% else %}
+
     <table>
         <thead>
             <tr>

--- a/tests/integration/Application/CommandHandler/Service/EditServiceCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Service/EditServiceCommandHandlerTest.php
@@ -52,6 +52,7 @@ class EditServiceCommandHandlerTest extends MockeryTestCase
             '30dd879c-ee2f-11db-8314-0800200c9a66',
             'Foobar',
             'team-foobar',
+            false,
             false
         );
         $command->setName('Foobar');
@@ -95,6 +96,7 @@ class EditServiceCommandHandlerTest extends MockeryTestCase
             '30dd879c-ee2f-11db-8314-0800200c9a66',
             'Foobar',
             'team-foobar',
+            false,
             true
         );
 
@@ -115,6 +117,7 @@ class EditServiceCommandHandlerTest extends MockeryTestCase
             '30dd879c-ee2f-11db-8314-0800200c9a66',
             'Foobar',
             'team-foobar',
+            false,
             false
         );
 

--- a/tests/webtests/EntityListTest.php
+++ b/tests/webtests/EntityListTest.php
@@ -100,6 +100,50 @@ class EntityListTest extends WebTestCase
         $this->assertEquals('test', $row->filter('td')->eq(4)->text(), 'Environment not found in entity list');
     }
 
+    public function test_entity_list_shows_add_to_test_link()
+    {
+        $this->loadFixtures();
+
+        // Surfnet is not allowed to create production entities.
+        $service = $this->getServiceRepository()->findByName('SURFnet');
+        $this->logIn('ROLE_USER', [$service]);
+
+        $this->mockHandler->append(new Response(200, [], '[]'));
+
+        $this->getAuthorizationService()->setSelectedServiceId(
+            $service->getId()
+        );
+
+        $crawler = $this->client->request('GET', '/');
+
+        $actions = $crawler->filter('div.add-entity-actions a');
+
+        $this->assertContains('Add for test', $actions->eq(0)->text(), 'Add for test link not found');
+        $this->assertEquals(1, $actions->count(), 'There should be only one add link');
+    }
+
+    public function test_entity_list_shows_add_to_production_link()
+    {
+        $this->loadFixtures();
+
+        // Ibuildings is allowed to create production entities.
+        $service = $this->getServiceRepository()->findByName('Ibuildings B.V.');
+        $this->logIn('ROLE_USER', [$service]);
+
+        $this->mockHandler->append(new Response(200, [], '[]'));
+
+        $this->getAuthorizationService()->setSelectedServiceId(
+            $service->getId()
+        );
+
+        $crawler = $this->client->request('GET', '/');
+
+        $actions = $crawler->filter('div.add-entity-actions a');
+
+        $this->assertContains('Add for test', $actions->eq(0)->text(), 'Add for test link not found');
+        $this->assertContains('Add for production', $actions->eq(1)->text(), 'Add for production link not found');
+    }
+
     public function test_entity_list_redirects_to_service_add_when_no_service_exists()
     {
         $this->clearFixtures();


### PR DESCRIPTION
SURF-administrators can enable service administrators to create
entities on the production environment without going to test
first.

When the checkbox 'allow production entities' is enabled, users are
allowed to create entities directly for the production environment. To
distinguish creating entities for test and production, the navigation
link 'Add entity' is removed and the 'Add' actions are shown above the
entity list.