### PR TITLE
Allow copy to production action

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
@@ -75,7 +75,10 @@ class EntityCreateController extends Controller
 
         $service = $this->getService();
 
-        if (!$service->isProductionEntitiesEnabled() && $environment !== Entity::ENVIRONMENT_TEST) {
+        if (!$service->isProductionEntitiesEnabled() &&
+            $environment !== Entity::ENVIRONMENT_TEST &&
+            !$this->isCopyRoute($request)
+        ) {
             throw $this->createAccessDeniedException(
                 'You do not have access to create entities without publishing to the test environment first'
             );


### PR DESCRIPTION
Allow copy to production action while revoking illegal production create actions.

See [Pivotal](https://www.pivotaltracker.com/story/show/154357906) story for steps to reproduce in revisions before the bugfix.