### PR TITLE
Fix translation relates issues

### DIFF
--- a/app/Resources/translations/messages.en.yml
+++ b/app/Resources/translations/messages.en.yml
@@ -1,4 +1,5 @@
 page.header.help: Help
+page.header.help_link: https://wiki.surfnet.nl/
 page.header.logout: Logout
 page.header.privacy: Privacy
 page.header.contact: Contact

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -27,7 +27,7 @@
                         {{ identity() }}
                     </li>
                     <li class="border-left">
-                        <a href="https://wiki.surfnet.nl/" target="_blank">{{ 'page.header.help'|trans }}</a>
+                        <a href="{{ 'page.header.help_link'|trans }}" target="_blank">{{ 'page.header.help'|trans }}</a>
                     </li>
                     <li class="border-left"><a>{{ 'page.header.logout'|trans }}</a></li>
                     <li class="service-switcher">

--- a/app/Resources/views/form/fields.html.twig
+++ b/app/Resources/views/form/fields.html.twig
@@ -79,3 +79,26 @@
         </div>
     {%- endif -%}
 {%- endblock datetime_widget -%}
+
+{# Override the form_label to enable us to output anchors in form labels. #}
+{%- block form_label -%}
+    {% if label is not same as(false) -%}
+        {% if not compound -%}
+            {% set label_attr = label_attr|merge({'for': id}) %}
+        {%- endif -%}
+        {% if required -%}
+            {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
+        {%- endif -%}
+        {% if label is empty -%}
+            {%- if label_format is not empty -%}
+                {% set label = label_format|replace({
+                '%name%': name,
+                '%id%': id,
+                }) %}
+            {%- else -%}
+                {% set label = name|humanize %}
+            {%- endif -%}
+        {%- endif -%}
+        <label{% if label_attr %}{% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}{% endif %}>{{ translation_domain is same as(false) ? label|striptags('<a>')|raw : label|trans({}, translation_domain)|striptags('<a>')|raw }}</label>
+    {%- endif -%}
+{%- endblock form_label -%}

--- a/app/scss/excludes/forms.scss
+++ b/app/scss/excludes/forms.scss
@@ -10,6 +10,11 @@ label {
   text-transform: uppercase;
   color: $medium-grey;
   display: block;
+
+  a {
+    color: #4DB2CF;
+  }
+
 }
 
 em, div.message {

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/EntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/EntityType.php
@@ -152,7 +152,7 @@ class EntityType extends AbstractType
                         ContactType::class,
                         [
                             'by_reference' => false,
-                            'attr' => ['help' => 'entity.edit.information.administrativeContact'],
+                            'attr' => ['help' => 'entity.edit.information.technicalContact'],
                         ]
                     )
                     ->add(

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/PrivacyQuestions/PrivacyQuestionsFormBuilder.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/PrivacyQuestions/PrivacyQuestionsFormBuilder.php
@@ -36,7 +36,7 @@ class PrivacyQuestionsFormBuilder
             'whatData',
             TextareaType::class,
             [
-                'label' => 'privacy.form.label.whatData',
+                'label' => 'privacy.form.label.whatData.html',
                 'attr' => [
                     'help' => 'privacy.information.whatData',
                     'rows' => 8,
@@ -48,7 +48,7 @@ class PrivacyQuestionsFormBuilder
             'accessData',
             TextareaType::class,
             [
-                'label' => 'privacy.form.label.accessData',
+                'label' => 'privacy.form.label.accessData.html',
                 'attr' => [
                     'help' => 'privacy.information.accessData',
                     'rows' => 8,
@@ -60,7 +60,7 @@ class PrivacyQuestionsFormBuilder
             'country',
             TextareaType::class,
             [
-                'label' => 'privacy.form.label.country',
+                'label' => 'privacy.form.label.country.html',
                 'attr' => [
                     'help' => 'privacy.information.country',
                     'rows' => 8,
@@ -72,7 +72,7 @@ class PrivacyQuestionsFormBuilder
             'securityMeasures',
             TextareaType::class,
             [
-                'label' => 'privacy.form.label.securityMeasures',
+                'label' => 'privacy.form.label.securityMeasures.html',
                 'attr' => [
                     'help' => 'privacy.information.securityMeasures',
                     'rows' => 8,
@@ -84,7 +84,7 @@ class PrivacyQuestionsFormBuilder
             'certification',
             CheckboxType::class,
             [
-                'label' => 'privacy.form.label.certification',
+                'label' => 'privacy.form.label.certification.html',
                 'attr' => ['help' => 'privacy.information.certification'],
             ]
         );
@@ -93,7 +93,7 @@ class PrivacyQuestionsFormBuilder
             'certificationLocation',
             TextareaType::class,
             [
-                'label' => 'privacy.form.label.certificationLocation',
+                'label' => 'privacy.form.label.certificationLocation.html',
                 'attr' => [
                     'help' => 'privacy.information.certificationLocation',
                     'rows' => 8,
@@ -105,7 +105,7 @@ class PrivacyQuestionsFormBuilder
             'certificationValidFrom',
             DateType::class,
             [
-                'label' => 'privacy.form.label.certificationValidFrom',
+                'label' => 'privacy.form.label.certificationValidFrom.html',
                 'widget' => 'single_text',
             ]
         );
@@ -114,7 +114,7 @@ class PrivacyQuestionsFormBuilder
             'certificationValidTo',
             DateType::class,
             [
-                'label' => 'privacy.form.label.certificationValidTo',
+                'label' => 'privacy.form.label.certificationValidTo.html',
                 'widget' => 'single_text',
             ]
         );
@@ -123,7 +123,7 @@ class PrivacyQuestionsFormBuilder
             'surfmarketDpaAgreement',
             CheckboxType::class,
             [
-                'label' => 'privacy.form.label.surfmarketDpaAgreement',
+                'label' => 'privacy.form.label.surfmarketDpaAgreement.html',
                 'attr' => ['help' => 'privacy.information.surfmarketDpaAgreement'],
             ]
         );
@@ -132,7 +132,7 @@ class PrivacyQuestionsFormBuilder
             'surfnetDpaAgreement',
             CheckboxType::class,
             [
-                'label' => 'privacy.form.label.surfnetDpaAgreement',
+                'label' => 'privacy.form.label.surfnetDpaAgreement.html',
                 'attr' => ['help' => 'privacy.information.surfnetDpaAgreement'],
             ]
         );
@@ -141,7 +141,7 @@ class PrivacyQuestionsFormBuilder
             'snDpaWhyNot',
             TextareaType::class,
             [
-                'label' => 'privacy.form.label.snDpaWhyNot',
+                'label' => 'privacy.form.label.snDpaWhyNot.html',
                 'attr' => [
                     'help' => 'privacy.information.snDpaWhyNot',
                     'rows' => 8,
@@ -153,7 +153,7 @@ class PrivacyQuestionsFormBuilder
             'privacyPolicy',
             CheckboxType::class,
             [
-                'label' => 'privacy.form.label.privacyPolicy',
+                'label' => 'privacy.form.label.privacyPolicy.html',
                 'attr' => ['help' => 'privacy.information.privacyPolicy'],
             ]
         );
@@ -162,7 +162,7 @@ class PrivacyQuestionsFormBuilder
             'privacyPolicyUrl',
             TextType::class,
             [
-                'label' => 'privacy.form.label.privacyPolicyUrl',
+                'label' => 'privacy.form.label.privacyPolicyUrl.html',
                 'attr' => ['help' => 'privacy.information.privacyPolicyUrl'],
             ]
         );
@@ -171,7 +171,7 @@ class PrivacyQuestionsFormBuilder
             'otherInfo',
             TextareaType::class,
             [
-                'label' => 'privacy.form.label.otherInfo',
+                'label' => 'privacy.form.label.otherInfo.html',
                 'attr' => [
                     'help' => 'privacy.information.otherInfo',
                     'rows' => 8,

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -120,20 +120,20 @@ entity.published_test.text.html: "Thanks for publishing \"%entityName%\" to our 
 entity.published_test.title: "Successfully published the entity to test"
 privacy.edit.title: GDPR related questions
 privacy.edit.introduction.html: "<p><strong>Pellentesque habitant morbi tristique</strong> senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. <em>Aenean ultricies mi vitae est.</em> Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, <code>commodo vitae</code>, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. <a href=\"#\">Donec non enim</a> in turpis pulvinar facilisis. Ut felis.</p>"
-privacy.form.label.accessData: 2. Who can access the data?
-privacy.form.label.certification: "5. Can you supply a Third Party Memorandum? If not: skip to question 9"
-privacy.form.label.certificationValidFrom: 7. Valid from:
-privacy.form.label.certificationLocation: 6. Where can an institution find/request it?
-privacy.form.label.certificationValidTo: 8. Valid to:
-privacy.form.label.country: 3. In what country is the data stored?
-privacy.form.label.otherInfo: 14. Other data privacy and security information
-privacy.form.label.privacyPolicy: "12. Do you publish your privacy policy? If not: skip to question 14"
-privacy.form.label.privacyPolicyUrl: 13. What is the URL?
-privacy.form.label.securityMeasures: 4. What security measures have you taken?
-privacy.form.label.snDpaWhyNot: 11. What articles pose a problem & why?
-privacy.form.label.surfmarketDpaAgreement: "9. Did you agree a DPA with SURFmarket? If yes: skip to question 12"
-privacy.form.label.surfnetDpaAgreement: 10. Are you willing to sign the SURF model DPA? If “Yes” skip to question 12
-privacy.form.label.whatData: 1. What (kind of) data is processed?
+privacy.form.label.accessData.html: 2. Who can access the data?
+privacy.form.label.certification.html: "5. Can you supply a Third Party Memorandum? If not: skip to question 9"
+privacy.form.label.certificationValidFrom.html: 7. Valid from:
+privacy.form.label.certificationLocation.html: 6. Where can an institution find/request it?
+privacy.form.label.certificationValidTo.html: 8. Valid to:
+privacy.form.label.country.html: 3. In what country is the data stored?
+privacy.form.label.otherInfo.html: 14. Other data privacy and security information
+privacy.form.label.privacyPolicy.html: "12. Do you publish your privacy policy? If not: skip to question 14"
+privacy.form.label.privacyPolicyUrl.html: 13. What is the URL?
+privacy.form.label.securityMeasures.html: 4. What security measures have you taken?
+privacy.form.label.snDpaWhyNot.html: 11. What articles pose a problem & why?
+privacy.form.label.surfmarketDpaAgreement.html: "9. Did you agree a DPA with SURFmarket? If yes: skip to question 12"
+privacy.form.label.surfnetDpaAgreement.html: 10. Are you willing to sign the SURF model DPA? If “Yes” skip to question 12
+privacy.form.label.whatData.html: 1. What (kind of) data is processed?
 privacy.information.accessData: Specify which organizations, including your own, and per organization what roles / (groups of) individuals have access to the data (including backups etc). Explain why they need access, and what access exactly each one has (like read only of certain specified data).
 privacy.information.certification: Is there an active valid certification, like ISO27001, ISO27002, ISAE3402 etc?
 privacy.information.certificationLocation: Where can an institution find (URL) or requestion the certifications and third party memorandum?

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -122,9 +122,9 @@ privacy.edit.title: GDPR related questions
 privacy.edit.introduction.html: "<p><strong>Pellentesque habitant morbi tristique</strong> senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. <em>Aenean ultricies mi vitae est.</em> Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, <code>commodo vitae</code>, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. <a href=\"#\">Donec non enim</a> in turpis pulvinar facilisis. Ut felis.</p>"
 privacy.form.label.accessData: 2. Who can access the data?
 privacy.form.label.certification: "5. Can you supply a Third Party Memorandum? If not: skip to question 9"
-privacy.form.label.certificationFrom: 7. Valid from:
+privacy.form.label.certificationValidFrom: 7. Valid from:
 privacy.form.label.certificationLocation: 6. Where can an institution find/request it?
-privacy.form.label.certificationTo: 8. Valid to:
+privacy.form.label.certificationValidTo: 8. Valid to:
 privacy.form.label.country: 3. In what country is the data stored?
 privacy.form.label.otherInfo: 14. Other data privacy and security information
 privacy.form.label.privacyPolicy: "12. Do you publish your privacy policy? If not: skip to question 14"

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -98,6 +98,7 @@ entity.edit.information.descriptionNl: Text should be set in web translations
 entity.edit.information.descriptionEn: Text should be set in web translations
 entity.edit.information.administrativeContact: Text should be set in web translations
 entity.edit.information.supportContact: Text should be set in web translations
+entity.edit.information.technicalContact: Text should be set in web translations
 entity.edit.information.givenNameAttribute: Text should be set in web translations
 entity.edit.information.surNameAttribute: Text should be set in web translations
 entity.edit.information.commonNameAttribute: Text should be set in web translations


### PR DESCRIPTION
**Translation privacy questions 7 & 8**
Label 7 and 8 contained a typo. The 'Valid' keyword was missing from the messages.en.yml file. An update of this value, and a rescan of the translations fixed this issue. 

Fixes #154869772 (466ad78)

**Translatable help link**
Fixes #154920261 (82146d4)

**Privacy labels can contain anchors**
Fixes: #154920044 (8bba053)

**Technical contact translatable**
Fixes #154921698 (ed4dd6b)
