### PR TITLE
Show service name in entity list

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityListController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityListController.php
@@ -75,6 +75,7 @@ class EntityListController extends Controller
         }
 
         $service = null;
+        $serviceName = '';
         $entityList = [];
         $productionEntitiesEnabled = false;
 
@@ -88,12 +89,14 @@ class EntityListController extends Controller
         if ($service) {
             $entityList = $this->entityService->getEntityListForService($service);
             $productionEntitiesEnabled = $service->isProductionEntitiesEnabled();
+            $serviceName = $service->getName();
         }
 
         return [
             'no_service_selected' => empty($service),
             'production_entities_enabled' => $productionEntitiesEnabled,
             'entity_list' => $entityList,
+            'serviceName' => $serviceName,
         ];
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityListController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityListController.php
@@ -75,8 +75,8 @@ class EntityListController extends Controller
         }
 
         $service = null;
-        $serviceName = '';
         $entityList = [];
+        $serviceName = false;
         $productionEntitiesEnabled = false;
 
         $activeServiceId = $this->authorizationService->getActiveServiceId();

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -7,6 +7,7 @@ error.404.text: "Oops, we were unable to find the page."
 entity.delete.title: "Delete entity"
 entity.delete.confirmation: "You are about to delete the entity %name%, are you sure?"
 entity.list.title: Entities of service '%serviceName%'
+entity.list.title_no_service_selected: No service selected
 entity.list.empty: There are no entities configured
 entity.list.no_service_selected: Please select a service
 entity.list.add_to_test: Add for test

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -6,7 +6,7 @@ error.404.title:  "Page not found"
 error.404.text: "Oops, we were unable to find the page."
 entity.delete.title: "Delete entity"
 entity.delete.confirmation: "You are about to delete the entity %name%, are you sure?"
-entity.list.title: My entities
+entity.list.title: Entities of service '%serviceName%'
 entity.list.empty: There are no entities configured
 entity.list.no_service_selected: Please select a service
 entity.list.add_to_test: Add for test

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityList/list.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityList/list.html.twig
@@ -1,6 +1,6 @@
 {% extends '::base.html.twig' %}
 
-{% block page_heading %}{{ 'entity.list.title'|trans }}{%endblock%}
+{% block page_heading %}{{ 'entity.list.title'|trans({'%serviceName%': serviceName }) }}{%endblock%}
 {% block body %}
     {% if not no_service_selected %}
     <div class="add-entity-actions">

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityList/list.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityList/list.html.twig
@@ -1,6 +1,13 @@
 {% extends '::base.html.twig' %}
 
-{% block page_heading %}{{ 'entity.list.title'|trans({'%serviceName%': serviceName }) }}{%endblock%}
+{% block page_heading %}
+    {% if not serviceName %}
+        {{ 'entity.list.title_no_service_selected'|trans }}
+    {% else %}
+        {{ 'entity.list.title'|trans({'%serviceName%': serviceName }) }}
+    {% endif %}
+{%endblock%}
+
 {% block body %}
     {% if not no_service_selected %}
     <div class="add-entity-actions">

--- a/tests/webtests/EntityCreateTest.php
+++ b/tests/webtests/EntityCreateTest.php
@@ -102,7 +102,7 @@ class EntityCreateTest extends WebTestCase
         $pageTitle = $crawler->filter('h1')->first()->text();
         $message = $crawler->filter('.page-container .card')->first()->text();
 
-        $this->assertEquals("Entities of service 'Ibuildings B.V.'", $pageTitle);
+        $this->assertContains("Entities of service 'Ibuildings B.V.'", $pageTitle);
         $this->assertContains('There are no entities configured', $message);
     }
 

--- a/tests/webtests/EntityCreateTest.php
+++ b/tests/webtests/EntityCreateTest.php
@@ -102,7 +102,7 @@ class EntityCreateTest extends WebTestCase
         $pageTitle = $crawler->filter('h1')->first()->text();
         $message = $crawler->filter('.page-container .card')->first()->text();
 
-        $this->assertEquals('My entities', $pageTitle);
+        $this->assertEquals("Entities of service 'Ibuildings B.V.'", $pageTitle);
         $this->assertContains('There are no entities configured', $message);
     }
 

--- a/tests/webtests/EntityListTest.php
+++ b/tests/webtests/EntityListTest.php
@@ -38,7 +38,7 @@ class EntityListTest extends WebTestCase
 
         $pageTitle = $crawler->filter('.page-container h1');
 
-        $this->assertEquals("Entities of service 'SURFnet'", $pageTitle->text());
+        $this->assertContains("Entities of service 'SURFnet'", $pageTitle->text());
         $this->assertCount(3, $crawler->filter('table tr'), 'Expecting three rows (including header)');
 
         $row = $crawler->filter('table tr')->eq(1);
@@ -89,7 +89,7 @@ class EntityListTest extends WebTestCase
 
         $pageTitle = $crawler->filter('.page-container h1');
 
-        $this->assertEquals("Entities of service 'SURFnet'", $pageTitle->text());
+        $this->assertContains("Entities of service 'SURFnet'", $pageTitle->text());
         $this->assertCount(4, $crawler->filter('table tr'), 'Expecting three rows (including header)');
 
         $row = $crawler->filter('table tr')->eq(3);
@@ -149,7 +149,7 @@ class EntityListTest extends WebTestCase
         $this->clearFixtures();
         $this->logIn('ROLE_ADMINISTRATOR');
 
-        $crawler = $this->client->request('GET', '/');
+        $this->client->request('GET', '/');
         $response = $this->client->getResponse();
 
         $this->assertTrue(
@@ -165,9 +165,10 @@ class EntityListTest extends WebTestCase
         $this->loadFixtures();
         $this->logIn('ROLE_ADMINISTRATOR');
 
-        $crawler = $this->client->request('GET', '/');
+        $this->client->request('GET', '/');
         $response = $this->client->getResponse();
 
+        $this->assertContains('No service selected', $response->getContent());
         $this->assertContains('Please select a service', $response->getContent());
     }
 }

--- a/tests/webtests/EntityListTest.php
+++ b/tests/webtests/EntityListTest.php
@@ -38,7 +38,7 @@ class EntityListTest extends WebTestCase
 
         $pageTitle = $crawler->filter('.page-container h1');
 
-        $this->assertEquals('My entities', $pageTitle->text());
+        $this->assertEquals("Entities of service 'SURFnet'", $pageTitle->text());
         $this->assertCount(3, $crawler->filter('table tr'), 'Expecting three rows (including header)');
 
         $row = $crawler->filter('table tr')->eq(1);
@@ -89,7 +89,7 @@ class EntityListTest extends WebTestCase
 
         $pageTitle = $crawler->filter('.page-container h1');
 
-        $this->assertEquals('My entities', $pageTitle->text());
+        $this->assertEquals("Entities of service 'SURFnet'", $pageTitle->text());
         $this->assertCount(4, $crawler->filter('table tr'), 'Expecting three rows (including header)');
 
         $row = $crawler->filter('table tr')->eq(3);


### PR DESCRIPTION
**Show service name in entity list**

The `%serviceName%` placeholder can be used in the `entity.list.title translation` to get this feature to work. See `src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml` and/or the web translation.

Fixes #154358882