### PR TITLE
Trigger tooltips on click instead of hover

### DIFF
--- a/app/js/components/tooltips.js
+++ b/app/js/components/tooltips.js
@@ -10,7 +10,8 @@ $(document).ready(
            arrow: true,
            duration: 200,
            placement: 'left',
-           theme: 'light'
+           theme: 'light',
+           trigger: 'click'
        }
     )
 );


### PR DESCRIPTION
**Tooltips are now triggered on click**

See story in pivotal for discussion on how and why this change was applied.

Fixes: #154920879