### PR TITLE
Loosen UUID validation to allow GUID's

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/CreateServiceCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/CreateServiceCommand.php
@@ -26,7 +26,7 @@ class CreateServiceCommand implements Command
     /**
      * @var string
      * @Assert\NotBlank
-     * @Assert\Uuid
+     * @Assert\Uuid(strict=false)
      */
     private $guid;
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/EditServiceCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/EditServiceCommand.php
@@ -31,7 +31,7 @@ class EditServiceCommand implements Command
     /**
      * @var string
      * @Assert\NotBlank
-     * @Assert\Uuid
+     * @Assert\Uuid(strict=false)
      */
     private $guid;
 

--- a/tests/webtests/ServiceCreateTest.php
+++ b/tests/webtests/ServiceCreateTest.php
@@ -60,6 +60,33 @@ class ServiceCreateTest extends WebTestCase
         $this->assertEquals('This is not a valid UUID.', $nodes->first()->text());
     }
 
+    public function test_it_validates_guid_correctly()
+    {
+        $this->logIn('ROLE_ADMINISTRATOR');
+
+        // This UUID is not compliant to the RFC-4122 spec, but is a valid GUID
+        $formData = [
+            'dashboard_bundle_service_type' => [
+                'guid' => '1234abcd-146e-e711-80e8-005056956c1e',
+                'name' => 'The A Team',
+                'teamName' => 'team-a',
+            ]
+        ];
+
+        $crawler = $this->client->request('GET', '/service/create');
+
+        $form = $crawler
+            ->selectButton('Save')
+            ->form();
+
+        $this->client->submit($form, $formData);
+
+        $this->assertTrue(
+            $this->client->getResponse() instanceof RedirectResponse,
+            'Expecting a redirect response after adding a service'
+        );
+    }
+
     public function test_it_rejects_duplicate_teamnames()
     {
         $this->logIn('ROLE_ADMINISTRATOR');


### PR DESCRIPTION
The Symfony UUID validator is configured very strict by default. GUIDs
from the MS CRM suite generate GUID (UUID's) not compliant to the
RFC 4122 standard.

By loosening the strictness of the validator, the MS GUID's are now
also considered valid.