### PR TITLE
Set default name id format

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveEntityCommand.php
@@ -1045,6 +1045,14 @@ class SaveEntityCommand implements Command
     }
 
     /**
+     * @return bool
+     */
+    public function hasNameIdFormat()
+    {
+        return !empty($this->nameIdFormat);
+    }
+
+    /**
      * @return string
      */
     public function getOrganizationNameNl()

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveEntityCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveEntityCommandHandler.php
@@ -109,7 +109,14 @@ class SaveEntityCommandHandler implements CommandHandler
         $entity->setEduPersonTargetedIDAttribute($command->getEduPersonTargetedIDAttribute());
         $entity->setComments($command->getComments());
 
-        $entity->setNameIdFormat($command->getNameIdFormat());
+        // Set the name id format, fall back on the most sensible default (transient). This is only for users not
+        // utilizing the import feature.
+        if ($command->hasNameIdFormat()) {
+            $entity->setNameIdFormat($command->getNameIdFormat());
+        } else {
+            $entity->setNameIdFormat(Entity::NAME_ID_FORMAT_DEFAULT);
+        }
+
         $entity->setOrganizationNameNl($command->getOrganizationNameNl());
         $entity->setOrganizationNameEn($command->getOrganizationNameEn());
         $entity->setOrganizationDisplayNameNl($command->getOrganizationDisplayNameNl());

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
@@ -37,6 +37,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Entity
 {
     const BINDING_HTTP_POST = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST';
+    const NAME_ID_FORMAT_DEFAULT = 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient';
 
     const ENVIRONMENT_TEST = 'test';
     const ENVIRONMENT_PRODUCTION = 'production';


### PR DESCRIPTION
Users not utilizing the import feature are not setting the name id format. As this is not yet a feature you can set on the form.

This will fix that issue, by setting the default value (transient) for new entities.