### PR TITLE
Show XML parser errors on metadata import

### DIFF
--- a/app/scss/excludes/forms.scss
+++ b/app/scss/excludes/forms.scss
@@ -29,6 +29,21 @@ em, div.message {
       margin-bottom: 15px;
     }
   }
+
+  &.preformatted {
+    background: $light-grey;
+    color: $dark-grey;
+    padding: 0.5em 1em;
+    font-family: monospace;
+    font-size: 95%;
+    line-height: 140%;
+    white-space: pre;
+    white-space: pre-wrap;
+    white-space: -moz-pre-wrap;
+    white-space: -o-pre-wrap;
+    overflow: auto;
+    max-height: 12em;
+  }
 }
 
 div.form-row.error {

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityControllerTrait.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityControllerTrait.php
@@ -105,6 +105,10 @@ trait EntityControllerTrait
             $this->addFlash('error', 'entity.edit.metadata.fetch.exception');
         } catch (ParserException $e) {
             $this->addFlash('error', 'entity.edit.metadata.parse.exception');
+            // Also show the parser messages
+            foreach ($e->getParserErrors() as $error) {
+                $this->addFlash('preformatted', $error->message);
+            }
         } catch (InvalidArgumentException $e) {
             $this->addFlash('error', 'entity.edit.metadata.invalid.exception');
         }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityEdit/edit.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityEdit/edit.html.twig
@@ -11,10 +11,10 @@
 
     <div class="fieldset card">
 
-        {% for message in app.flashes('error') %}
-            <div class="message error">
-                {{ message|trans }}
-            </div>
+        {% for type, messages in app.session.flashbag.all %}
+            {% for message in messages %}
+                <div class="message {{ type }}">{{ message|trans }}</div>
+            {% endfor %}
         {% endfor %}
 
         <h2>{{ 'entity.edit.info.title'|trans }}</h2>

--- a/src/Surfnet/ServiceProviderDashboard/Legacy/Metadata/Parser.php
+++ b/src/Surfnet/ServiceProviderDashboard/Legacy/Metadata/Parser.php
@@ -335,6 +335,11 @@ class Parser implements ParserInterface
     {
         libxml_use_internal_errors(true);
 
+        // Web tests use the dom crawler, if any xml errors are encountered by using the crawler they are stored in the
+        // error buffer. Clearing the buffer before validating the schema prevents the showing of irrelevant messages to
+        //the end user.
+        libxml_clear_errors();
+
         $doc = new \DOMDocument();
         $doc->loadXml($xml);
 

--- a/tests/webtests/EntityCreateTest.php
+++ b/tests/webtests/EntityCreateTest.php
@@ -223,9 +223,23 @@ class EntityCreateTest extends WebTestCase
         $message = $crawler->filter('.message.error')->first();
 
         $this->assertEquals(
-            'An error occurred while importing the metadata.',
+            'The provided metadata is invalid.',
             trim($message->text()),
             'Expected an error message for this invalid importUrl'
+        );
+
+        $notAllowedMessage = $crawler->filter('.message.preformatted')->eq(0);
+        $missingMessage = $crawler->filter('.message.preformatted')->eq(1);
+
+        $this->assertContains(
+            "EntityDescriptor', attribute 'entityED': The attribute 'entityED' is not allowed.",
+            $notAllowedMessage->text(),
+            'Expected an XML parse error.'
+        );
+        $this->assertContains(
+            "EntityDescriptor': The attribute 'entityID' is required but missing.",
+            $missingMessage->text(),
+            'Expected an XML parse error.'
         );
     }
 

--- a/tests/webtests/EntityEditTest.php
+++ b/tests/webtests/EntityEditTest.php
@@ -316,9 +316,23 @@ class EntityEditTest extends WebTestCase
         $message = $crawler->filter('.message.error')->first();
 
         $this->assertEquals(
-            'An error occurred while importing the metadata.',
+            'The provided metadata is invalid.',
             trim($message->text()),
             'Expected an error message for this invalid importUrl'
+        );
+
+        $notAllowedMessage = $crawler->filter('.message.preformatted')->eq(0);
+        $missingMessage = $crawler->filter('.message.preformatted')->eq(1);
+
+        $this->assertContains(
+            "EntityDescriptor', attribute 'entityED': The attribute 'entityED' is not allowed.",
+            $notAllowedMessage->text(),
+            'Expected an XML parse error.'
+        );
+        $this->assertContains(
+            "EntityDescriptor': The attribute 'entityID' is required but missing.",
+            $missingMessage->text(),
+            'Expected an XML parse error.'
         );
     }
 }

--- a/tests/webtests/fixtures/metadata/invalid_metadata.xml
+++ b/tests/webtests/fixtures/metadata/invalid_metadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://domain.org/saml/metadata">
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityED="https://domain.org/saml/metadata">
     <md:SPSSODescriptor
             protocolSupportEnumeration="urn:oasis:names:tc:SAML:1.1:protocol urn:oasis:names:tc:SAML:2.0:protocol">
         <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"


### PR DESCRIPTION
Before this change, xml parser errors where only logged to the app log.
Leaving end users in the dark as to what went wrong during import of their metadata.

This commit changes that, adding a flash message for each parse error.

To prevent display of unwanted xml parser messages (in test), the error
buffer is cleared before validating the XML schema.

To test this feature, simply try to import a malformed SAML SP metadata document and hit the import button. The resulting error messages should help you to fix the violations in the schema.