### PR TITLE
Small optimalisations after HTML schema validation

### DIFF
--- a/app/Resources/views/form/fields.html.twig
+++ b/app/Resources/views/form/fields.html.twig
@@ -1,6 +1,6 @@
 {%- block help_block -%}
     {% for attrname,attrvalue in attr %}
-        {% if attrname == 'help' %}
+        {% if attrname == 'data-help' %}
             <span title="{{ attrvalue|trans }}" class="help-button">
                 <i class="fa fa-question-circle"></i>
             </span>

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/EntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/EntityType.php
@@ -61,7 +61,7 @@ class EntityType extends AbstractType
                         TextType::class,
                         [
                             'disabled' => true,
-                            'attr' => ['help' => 'entity.edit.information.ticketNumber'],
+                            'attr' => ['data-help' => 'entity.edit.information.ticketNumber'],
                         ]
                     )
             )
@@ -71,7 +71,7 @@ class EntityType extends AbstractType
                         'importUrl',
                         TextType::class,
                         [
-                            'attr' => ['help' => 'entity.edit.information.importUrl'],
+                            'attr' => ['data-help' => 'entity.edit.information.importUrl'],
                         ]
                     )
                     ->add(
@@ -79,7 +79,7 @@ class EntityType extends AbstractType
                         TextareaType::class,
                         [
                             'attr' => [
-                                'help' => 'entity.edit.information.pastedMetadata',
+                                'data-help' => 'entity.edit.information.pastedMetadata',
                                 'rows' => 10,
                             ],
                         ]
@@ -96,21 +96,21 @@ class EntityType extends AbstractType
                         'metadataUrl',
                         TextType::class,
                         [
-                            'attr' => ['help' => 'entity.edit.information.metadataUrl'],
+                            'attr' => ['data-help' => 'entity.edit.information.metadataUrl'],
                         ]
                     )
                     ->add(
                         'acsLocation',
                         TextType::class,
                         [
-                            'attr' => ['help' => 'entity.edit.information.acsLocation'],
+                            'attr' => ['data-help' => 'entity.edit.information.acsLocation'],
                         ]
                     )
                     ->add(
                         'entityId',
                         TextType::class,
                         [
-                            'attr' => ['help' => 'entity.edit.information.entityId'],
+                            'attr' => ['data-help' => 'entity.edit.information.entityId'],
                         ]
                     )
                     ->add(
@@ -118,7 +118,7 @@ class EntityType extends AbstractType
                         TextareaType::class,
                         [
                             'attr' => [
-                                'help' => 'entity.edit.information.certificate',
+                                'data-help' => 'entity.edit.information.certificate',
                                 'rows' => 10,
                             ],
                         ]
@@ -127,14 +127,14 @@ class EntityType extends AbstractType
                         'logoUrl',
                         TextType::class,
                         [
-                            'attr' => ['help' => 'entity.edit.information.logoUrl'],
+                            'attr' => ['data-help' => 'entity.edit.information.logoUrl'],
                         ]
                     )
                     ->add(
                         'nameNl',
                         TextType::class,
                         [
-                            'attr' => ['help' => 'entity.edit.information.nameNl'],
+                            'attr' => ['data-help' => 'entity.edit.information.nameNl'],
                         ]
                     )
                     ->add(
@@ -142,7 +142,7 @@ class EntityType extends AbstractType
                         TextareaType::class,
                         [
                             'attr' => [
-                                'help' => 'entity.edit.information.descriptionNl',
+                                'data-help' => 'entity.edit.information.descriptionNl',
                                 'rows' => 10,
                             ],
                         ]
@@ -151,7 +151,7 @@ class EntityType extends AbstractType
                         'nameEn',
                         TextType::class,
                         [
-                            'attr' => ['help' => 'entity.edit.information.nameEn'],
+                            'attr' => ['data-help' => 'entity.edit.information.nameEn'],
                         ]
                     )
                     ->add(
@@ -159,7 +159,7 @@ class EntityType extends AbstractType
                         TextareaType::class,
                         [
                             'attr' => [
-                                'help' => 'entity.edit.information.descriptionEn',
+                                'data-help' => 'entity.edit.information.descriptionEn',
                                 'rows' => 10,
                             ],
                         ]
@@ -168,14 +168,14 @@ class EntityType extends AbstractType
                         'applicationUrl',
                         TextType::class,
                         [
-                            'attr' => ['help' => 'entity.edit.information.applicationUrl'],
+                            'attr' => ['data-help' => 'entity.edit.information.applicationUrl'],
                         ]
                     )
                     ->add(
                         'eulaUrl',
                         TextType::class,
                         [
-                            'attr' => ['help' => 'entity.edit.information.eulaUrl'],
+                            'attr' => ['data-help' => 'entity.edit.information.eulaUrl'],
                         ]
                     )
             )
@@ -186,7 +186,7 @@ class EntityType extends AbstractType
                         ContactType::class,
                         [
                             'by_reference' => false,
-                            'attr' => ['help' => 'entity.edit.information.administrativeContact'],
+                            'attr' => ['data-help' => 'entity.edit.information.administrativeContact'],
                         ]
                     )
                     ->add(
@@ -194,7 +194,7 @@ class EntityType extends AbstractType
                         ContactType::class,
                         [
                             'by_reference' => false,
-                            'attr' => ['help' => 'entity.edit.information.technicalContact'],
+                            'attr' => ['data-help' => 'entity.edit.information.technicalContact'],
                         ]
                     )
                     ->add(
@@ -202,7 +202,7 @@ class EntityType extends AbstractType
                         ContactType::class,
                         [
                             'by_reference' => false,
-                            'attr' => ['help' => 'entity.edit.information.supportContact'],
+                            'attr' => ['data-help' => 'entity.edit.information.supportContact'],
                         ]
                     )
             )
@@ -217,7 +217,7 @@ class EntityType extends AbstractType
                         [
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['help' => 'entity.edit.information.givenNameAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.givenNameAttribute'],
                         ]
                     )
                     ->add(
@@ -226,7 +226,7 @@ class EntityType extends AbstractType
                         [
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['help' => 'entity.edit.information.surNameAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.surNameAttribute'],
                         ]
                     )
                     ->add(
@@ -235,7 +235,7 @@ class EntityType extends AbstractType
                         [
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['help' => 'entity.edit.information.commonNameAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.commonNameAttribute'],
                         ]
                     )
                     ->add(
@@ -244,7 +244,7 @@ class EntityType extends AbstractType
                         [
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['help' => 'entity.edit.information.displayNameAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.displayNameAttribute'],
                         ]
                     )
                     ->add(
@@ -253,7 +253,7 @@ class EntityType extends AbstractType
                         [
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['help' => 'entity.edit.information.emailAddressAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.emailAddressAttribute'],
                         ]
                     )
                     ->add(
@@ -262,7 +262,7 @@ class EntityType extends AbstractType
                         [
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['help' => 'entity.edit.information.organizationAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.organizationAttribute'],
                         ]
                     )
                     ->add(
@@ -271,7 +271,7 @@ class EntityType extends AbstractType
                         [
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['help' => 'entity.edit.information.organizationTypeAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.organizationTypeAttribute'],
                         ]
                     )
                     ->add(
@@ -280,7 +280,7 @@ class EntityType extends AbstractType
                         [
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['help' => 'entity.edit.information.affiliationAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.affiliationAttribute'],
                         ]
                     )
                     ->add(
@@ -289,7 +289,7 @@ class EntityType extends AbstractType
                         [
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['help' => 'entity.edit.information.entitlementAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.entitlementAttribute'],
                         ]
                     )
                     ->add(
@@ -298,7 +298,7 @@ class EntityType extends AbstractType
                         [
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['help' => 'entity.edit.information.principleNameAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.principleNameAttribute'],
                         ]
                     )
                     ->add(
@@ -307,7 +307,7 @@ class EntityType extends AbstractType
                         [
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['help' => 'entity.edit.information.uidAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.uidAttribute'],
                         ]
                     )
                     ->add(
@@ -316,7 +316,7 @@ class EntityType extends AbstractType
                         [
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['help' => 'entity.edit.information.preferredLanguageAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.preferredLanguageAttribute'],
                         ]
                     )
                     ->add(
@@ -325,7 +325,7 @@ class EntityType extends AbstractType
                         [
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['help' => 'entity.edit.information.personalCodeAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.personalCodeAttribute'],
                         ]
                     )
                     ->add(
@@ -334,7 +334,7 @@ class EntityType extends AbstractType
                         [
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['help' => 'entity.edit.information.scopedAffiliationAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.scopedAffiliationAttribute'],
                         ]
                     )
                     ->add(
@@ -343,7 +343,7 @@ class EntityType extends AbstractType
                         [
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['help' => 'entity.edit.information.eduPersonTargetedIDAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.eduPersonTargetedIDAttribute'],
                         ]
                     )
             )
@@ -354,7 +354,7 @@ class EntityType extends AbstractType
                         TextareaType::class,
                         [
                             'attr' => [
-                                'help' => 'entity.edit.information.comments',
+                                'data-help' => 'entity.edit.information.comments',
                                 'rows' => 10,
                             ],
                         ]

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/PrivacyQuestions/PrivacyQuestionsFormBuilder.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/PrivacyQuestions/PrivacyQuestionsFormBuilder.php
@@ -38,7 +38,7 @@ class PrivacyQuestionsFormBuilder
             [
                 'label' => 'privacy.form.label.whatData.html',
                 'attr' => [
-                    'help' => 'privacy.information.whatData',
+                    'data-help' => 'privacy.information.whatData',
                     'rows' => 8,
                 ],
             ]
@@ -50,7 +50,7 @@ class PrivacyQuestionsFormBuilder
             [
                 'label' => 'privacy.form.label.accessData.html',
                 'attr' => [
-                    'help' => 'privacy.information.accessData',
+                    'data-help' => 'privacy.information.accessData',
                     'rows' => 8,
                 ],
             ]
@@ -62,7 +62,7 @@ class PrivacyQuestionsFormBuilder
             [
                 'label' => 'privacy.form.label.country.html',
                 'attr' => [
-                    'help' => 'privacy.information.country',
+                    'data-help' => 'privacy.information.country',
                     'rows' => 8,
                 ],
             ]
@@ -74,7 +74,7 @@ class PrivacyQuestionsFormBuilder
             [
                 'label' => 'privacy.form.label.securityMeasures.html',
                 'attr' => [
-                    'help' => 'privacy.information.securityMeasures',
+                    'data-help' => 'privacy.information.securityMeasures',
                     'rows' => 8,
                 ],
             ]
@@ -85,7 +85,7 @@ class PrivacyQuestionsFormBuilder
             CheckboxType::class,
             [
                 'label' => 'privacy.form.label.certification.html',
-                'attr' => ['help' => 'privacy.information.certification'],
+                'attr' => ['data-help' => 'privacy.information.certification'],
             ]
         );
 
@@ -95,7 +95,7 @@ class PrivacyQuestionsFormBuilder
             [
                 'label' => 'privacy.form.label.certificationLocation.html',
                 'attr' => [
-                    'help' => 'privacy.information.certificationLocation',
+                    'data-help' => 'privacy.information.certificationLocation',
                     'rows' => 8,
                 ],
             ]
@@ -124,7 +124,7 @@ class PrivacyQuestionsFormBuilder
             CheckboxType::class,
             [
                 'label' => 'privacy.form.label.surfmarketDpaAgreement.html',
-                'attr' => ['help' => 'privacy.information.surfmarketDpaAgreement'],
+                'attr' => ['data-help' => 'privacy.information.surfmarketDpaAgreement'],
             ]
         );
 
@@ -133,7 +133,7 @@ class PrivacyQuestionsFormBuilder
             CheckboxType::class,
             [
                 'label' => 'privacy.form.label.surfnetDpaAgreement.html',
-                'attr' => ['help' => 'privacy.information.surfnetDpaAgreement'],
+                'attr' => ['data-help' => 'privacy.information.surfnetDpaAgreement'],
             ]
         );
 
@@ -143,7 +143,7 @@ class PrivacyQuestionsFormBuilder
             [
                 'label' => 'privacy.form.label.snDpaWhyNot.html',
                 'attr' => [
-                    'help' => 'privacy.information.snDpaWhyNot',
+                    'data-help' => 'privacy.information.snDpaWhyNot',
                     'rows' => 8,
                 ],
             ]
@@ -154,7 +154,7 @@ class PrivacyQuestionsFormBuilder
             CheckboxType::class,
             [
                 'label' => 'privacy.form.label.privacyPolicy.html',
-                'attr' => ['help' => 'privacy.information.privacyPolicy'],
+                'attr' => ['data-help' => 'privacy.information.privacyPolicy'],
             ]
         );
 
@@ -163,7 +163,7 @@ class PrivacyQuestionsFormBuilder
             TextType::class,
             [
                 'label' => 'privacy.form.label.privacyPolicyUrl.html',
-                'attr' => ['help' => 'privacy.information.privacyPolicyUrl'],
+                'attr' => ['data-help' => 'privacy.information.privacyPolicyUrl'],
             ]
         );
 
@@ -173,7 +173,7 @@ class PrivacyQuestionsFormBuilder
             [
                 'label' => 'privacy.form.label.otherInfo.html',
                 'attr' => [
-                    'help' => 'privacy.information.otherInfo',
+                    'data-help' => 'privacy.information.otherInfo',
                     'rows' => 8,
                 ],
             ]

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -62,7 +62,7 @@ When tests are successful you can request a production connection. Simply press 
 entity.edit.general.title: General
 entity.edit.general.html: "<p>Enter/edit your contact information below. We will use this information in case we have additional questions.</p>"
 entity.edit.metadata.fetch.exception: "Unable to load the metadata from the provided import url."
-entity.edit.metadata.html: "Please provide the metadata URL of your entity. The URL will be validated and the fields below will be filled in automatically (when available in the metadata). <strong>If the input is not correct please change the settings in your SAML enabled software.</strong> Note that the fields with a * are required and need to be correctly configured. Check the following page for more information: <a href=\"https://wiki.surfnet.nl/x/vclWAw\">https://wiki.surfnet.nl/x/vclWAw</a>.</p>"
+entity.edit.metadata.html: "Please provide the metadata URL of your entity. The URL will be validated and the fields below will be filled in automatically (when available in the metadata). <strong>If the input is not correct please change the settings in your SAML enabled software.</strong> Note that the fields with a * are required and need to be correctly configured. Check the following page for more information: <a href=\"https://wiki.surfnet.nl/x/vclWAw\">https://wiki.surfnet.nl/x/vclWAw</a>."
 entity.edit.metadata.invalid.exception: "An error occurred while importing the metadata."
 entity.edit.metadata.validation-failed: "Warning! Some entries are missing or incorrect. Please review and fix those entries below."
 entity.edit.metadata.title: Metadata


### PR DESCRIPTION
While debugging another problem I ran the w3 html schema validation tool on the HTML of the entity edit form. Serveral easily fixable issues arose. This PR fixes those issues:
 * the `help` attribute name was renamed to `data-help`.
 * removed a rogue `</p>`.