### PR TITLE
Improve logo validation

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Exception/LogoInvalidTypeException.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Exception/LogoInvalidTypeException.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Exception;
+
+use Exception;
+
+class LogoInvalidTypeException extends Exception
+{
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Exception/LogoNotFoundException.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Exception/LogoNotFoundException.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Exception;
+
+use Exception;
+
+class LogoNotFoundException extends Exception
+{
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -171,8 +171,13 @@ services:
 
     surfnet.dashboard.validator.logo:
         class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\ValidLogoValidator
+        arguments:  ['@surfnet.dashboard.validator.logo_validation_helper']
         tags:
             - { name: validator.constraint_validator, alias: logo }
+
+    surfnet.dashboard.validator.logo_validation_helper:
+        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\CurlLogoValidationHelper
+        arguments:  ['@logger']
 
     surfnet.manage.client.publish_entity.test_environment:
         class: Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\PublishEntityClient

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/validators.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/validators.en.yml
@@ -1,5 +1,6 @@
 validator.logo.wrong_type: 'Logo should be a PNG or GIF image.'
 validator.logo.not_an_image: 'Logo is not a valid image. Press question mark for details.'
+validator.logo.download_failed: 'The logo could not be downloaded to the server.'
 validator.ssl_certificate.not_valid: 'The certificate is not valid.'
 validator.ssl_certificate.unknown_key_length: 'Cannot determine key length.'
 validator.ssl_certificate.wrong_key_length: 'Key length is %length% bit, it should be 2048 bit or more.'

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/CurlLogoValidationHelper.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/CurlLogoValidationHelper.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service;
+
+use Psr\Log\LoggerInterface;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Exception\LogoInvalidTypeException;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Exception\LogoNotFoundException;
+
+class CurlLogoValidationHelper implements LogoValidationHelperInterface
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * Using Curl: tests:
+     *  - is the curl response code erroneous (>= 400)
+     *  - if the content type is correct
+     *
+     * @param $url
+     * @throws LogoInvalidTypeException
+     * @throws LogoNotFoundException
+     */
+    public function validateLogo($url)
+    {
+        $this->logger->debug(sprintf('Validating logo: "%s" using curl', $url));
+
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_VERBOSE, 1);
+        curl_setopt($ch, CURLOPT_HEADER, 1);
+
+        curl_exec($ch);
+
+        $contentType = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
+        $responseCode = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+        $error = curl_error($ch);
+        curl_close($ch);
+
+
+        $this->logger->debug(sprintf('Curl returned a "%d" HTTP response code', $responseCode));
+        $this->logger->debug(sprintf('Downloaded a file with content type: "%s"', $contentType));
+
+        // Test if the response is not in the 4xx / 5xx range
+        if ($responseCode >= 400 || !empty($error)) {
+            $this->logger->info('The logo can not be downloaded');
+            if (!empty($error)) {
+                $this->logger->info(sprintf('Received the following curl error: "%s"', $error));
+            }
+            throw new LogoNotFoundException('Downloading of the logo failed');
+        }
+
+        // Test if the resource is of the correct file type
+        if ($contentType !== LogoValidationHelperInterface::IMAGE_TYPE_PNG &&
+            $contentType !== LogoValidationHelperInterface::IMAGE_TYPE_GIF
+        ) {
+            $this->logger->info('The logo file type is invalid');
+            throw new LogoInvalidTypeException('The logo file type is invalid');
+        }
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/LogoValidationHelperInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/LogoValidationHelperInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service;
+
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Exception\LogoInvalidTypeException;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Exception\LogoNotFoundException;
+
+interface LogoValidationHelperInterface
+{
+    /**
+     * Valid type: PNG
+     */
+    const IMAGE_TYPE_PNG = 'image/png';
+
+    /**
+     * Valid type: GIF
+     */
+    const IMAGE_TYPE_GIF = 'image/gif';
+
+    /**
+     * Validates the logo, throws an exception if validation failed.
+     *
+     * @param $url
+     * @throws LogoInvalidTypeException
+     * @throws LogoNotFoundException
+     */
+    public function validateLogo($url);
+}


### PR DESCRIPTION
Logo validation was previously only performed using the getimagesize
function. This function internally resolved the logo and retured either
boolean false (not an image) or an array with the image details.

This was not sufficient as some logos seem to be valid PNG/GIF but are
not available for other reasons. By adding an extra curl based download,
we gain more insighs in the how and why an image might be unavailable.

Extra logging was also added to enable us to debug logo failures more
easily in the future.

@quartje, the error messages can be found [here](https://github.com/SURFnet/sp-dashboard/blob/ecdb1d61a3ec8f0367b33b20de741697ff587a19/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/validators.en.yml#L1-L3).