### PR TITLE
Reset the help label on nameIdFormat widget

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/EntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/EntityType.php
@@ -127,7 +127,7 @@ class EntityType extends AbstractType
                                 'entity.edit.label.persistent' => Entity::NAME_ID_FORMAT_PERSISTENT,
                             ],
                             'choice_attr' => function ($val, $key) {
-                                return ['help' => 'entity.edit.information.for.' . $key];
+                                return ['data-help' => 'entity.edit.information.for.' . $key];
                             },
                             'attr' => ['class' => 'nameidformat-container'],
                         ]


### PR DESCRIPTION
During rebasing several commits, the nameIdFormat help attribute was
not renamed to the new style: data-help. Resulting in the loss of the
information popup icons in the frontend.

This issue was easily fixed by prepending 'data-' to the attribute.