### PR TITLE
Upgrade to Symfony 3.4

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -77,7 +77,7 @@ monolog:
             path: '%kernel.logs_dir%/%kernel.environment%.log'
             level: debug
             channels: ['!event']
-            formatter: surfnet.dashboard.monolog.json_formatter
+            formatter: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Monolog\Formatter\JsonFormatter
         console:
             type: console
             channels: ['!event', '!doctrine']

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -8,28 +8,33 @@ security:
     # http://symfony.com/doc/current/security.html#b-configuring-how-users-are-loaded
     providers:
         dashboard:
-            id: surfnet.dashboard.security.service.identity
+            id: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Service\IdentityService
 
     firewalls:
         # disables authentication for assets and the profiler, adapt it according to your needs
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
+            logout_on_user_change: true
 
         login_firewall:
             pattern:    ^/saml/metadata
             anonymous:  ~
+            logout_on_user_change: true
 
         published_metadata:
             pattern:    ^/entity/metadata/*
             anonymous:  ~
+            logout_on_user_change: true
 
         monitor:
             pattern: ^/(info|health)$
             security: false
+            logout_on_user_change: true
 
         saml_based:
             saml: true
+            logout_on_user_change: true
             logout:
                 path: /logout
                 target: "%logout_redirect_url%"

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -1,9 +1,10 @@
 # Learn more about services, parameters and containers at
 # http://symfony.com/doc/current/service_container.html
 parameters:
-    #parameter_name: value
+    container.dumper.inline_class_loader: true
 
 services:
-    #service_name:
-    #    class: AppBundle\Directory\ClassName
-    #    arguments: ['@another_service_name', 'plain_value', '%parameter_name%']
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "symfony/monolog-bundle": "^3.1.0",
         "symfony/polyfill-apcu": "^1.0",
         "symfony/swiftmailer-bundle": "^2.3.10",
-        "symfony/symfony": "3.3.*",
+        "symfony/symfony": "3.4.*",
         "twig/twig": "^1.34.4"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,6 @@
             "vendor/symfony/symfony/src/Symfony/Component/VarDumper/Resources/functions/dump.php"
         ]
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/ibuildingsnl/LexikTranslationBundle.git"
-        }
-    ],
     "require": {
         "php": "^5.6||^7.0",
         "doctrine/doctrine-bundle": "^1.6",
@@ -37,7 +31,7 @@
         "jeremykendall/php-domain-parser": "~1.3.1",
         "knplabs/knp-menu-bundle": "^2.1",
         "league/tactician-bundle": "^0.4.1",
-        "lexik/translation-bundle": "dev-feature/fix-url-encode-issue",
+        "lexik/translation-bundle": "^4.0",
         "openconext/monitor-bundle": "^1.0",
         "ramsey/uuid": "^3.7",
         "sensio/framework-extra-bundle": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9354d813e455b4c795920a5ed490ae17",
+    "content-hash": "af1bd3e11b7e39de52d0c7581c236277",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -3156,16 +3156,16 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "v3.3.14",
+            "version": "v3.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "8e2b473de636a65a018b370d5e88778a260f0e33"
+                "reference": "4babd75194d45f7a4412560038924f3008c67ef2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/8e2b473de636a65a018b370d5e88778a260f0e33",
-                "reference": "8e2b473de636a65a018b370d5e88778a260f0e33",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/4babd75194d45f7a4412560038924f3008c67ef2",
+                "reference": "4babd75194d45f7a4412560038924f3008c67ef2",
                 "shasum": ""
             },
             "require": {
@@ -3182,9 +3182,8 @@
                 "symfony/polyfill-intl-icu": "~1.0",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php56": "~1.0",
-                "symfony/polyfill-php70": "~1.0",
-                "symfony/polyfill-util": "~1.0",
-                "twig/twig": "~1.34|~2.4"
+                "symfony/polyfill-php70": "~1.6",
+                "twig/twig": "^1.35|^2.4.4"
             },
             "conflict": {
                 "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
@@ -3194,6 +3193,7 @@
             "provide": {
                 "psr/cache-implementation": "1.0",
                 "psr/container-implementation": "1.0",
+                "psr/log-implementation": "1.0",
                 "psr/simple-cache-implementation": "1.0"
             },
             "replace": {
@@ -3221,6 +3221,7 @@
                 "symfony/inflector": "self.version",
                 "symfony/intl": "self.version",
                 "symfony/ldap": "self.version",
+                "symfony/lock": "self.version",
                 "symfony/monolog-bridge": "self.version",
                 "symfony/options-resolver": "self.version",
                 "symfony/process": "self.version",
@@ -3261,14 +3262,13 @@
                 "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
                 "phpdocumentor/reflection-docblock": "^3.0|^4.0",
                 "predis/predis": "~1.0",
-                "sensio/framework-extra-bundle": "^3.0.2",
                 "symfony/phpunit-bridge": "~3.4|~4.0",
                 "symfony/security-acl": "~2.8|~3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -3306,7 +3306,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2017-12-04T22:26:41+00:00"
+            "time": "2018-04-30T19:27:18+00:00"
         },
         {
             "name": "twig/twig",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "af1bd3e11b7e39de52d0c7581c236277",
+    "content-hash": "ea5373567334b44f681bbe27593fdfa4",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -1623,21 +1623,21 @@
         },
         {
             "name": "lexik/translation-bundle",
-            "version": "dev-feature/fix-url-encode-issue",
+            "version": "v4.0.9",
             "source": {
                 "type": "git",
-                "url": "https://github.com/ibuildingsnl/LexikTranslationBundle.git",
-                "reference": "950d106daf6c6cbf364e58efb2f8c56d3004ea18"
+                "url": "https://github.com/lexik/LexikTranslationBundle.git",
+                "reference": "0135ac63a168e736e68abacf9aeccc618c146dcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ibuildingsnl/LexikTranslationBundle/zipball/950d106daf6c6cbf364e58efb2f8c56d3004ea18",
-                "reference": "950d106daf6c6cbf364e58efb2f8c56d3004ea18",
+                "url": "https://api.github.com/repos/lexik/LexikTranslationBundle/zipball/0135ac63a168e736e68abacf9aeccc618c146dcd",
+                "reference": "0135ac63a168e736e68abacf9aeccc618c146dcd",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.6 || ^7.0",
-                "symfony/framework-bundle": "~2.8|~3.0"
+                "symfony/framework-bundle": "~2.8|~3.0|~4.0"
             },
             "require-dev": {
                 "doctrine/data-fixtures": "~1.1",
@@ -1645,12 +1645,12 @@
                 "doctrine/mongodb-odm-bundle": "~3.0",
                 "doctrine/orm": "^2.2.3",
                 "phpunit/phpunit": "^5.7",
-                "propel/propel-bundle": "~1.5|3.0.0-alpha1@dev"
+                "propel/propel": "@dev",
+                "propel/propel-bundle": "^3.0@dev|^4.0@dev"
             },
             "suggest": {
                 "doctrine/mongodb-odm-bundle": "~3.0",
-                "doctrine/orm": ">=2.4",
-                "propel/propel-bundle": "~1.5"
+                "doctrine/orm": ">=2.4"
             },
             "type": "symfony-bundle",
             "extra": {
@@ -1663,17 +1663,18 @@
                     "Lexik\\Bundle\\TranslationBundle\\": ""
                 }
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "authors": [
                 {
-                    "name": "Cedric Girard",
-                    "email": "c.girard@lexik.fr"
-                },
-                {
                     "name": "Dev Lexik",
                     "email": "dev@lexik.fr"
+                },
+                {
+                    "name": "Cedric Girard",
+                    "email": "c.girard@lexik.fr"
                 }
             ],
             "description": "This bundle allows to import translation files content into the database and provide a GUI to edit translations.",
@@ -1684,10 +1685,7 @@
                 "i18n",
                 "translation"
             ],
-            "support": {
-                "source": "https://github.com/ibuildingsnl/LexikTranslationBundle/tree/feature/fix-url-encode-issue"
-            },
-            "time": "2017-10-06T06:50:09+00:00"
+            "time": "2018-03-27T11:29:23+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -5700,9 +5698,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "lexik/translation-bundle": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,7 +11,7 @@
 
     <php>
         <ini name="error_reporting" value="-1" />
-        <server name="KERNEL_DIR" value="app/" />
+        <server name="KERNEL_CLASS" value="AppKernel" />
     </php>
 
     <testsuites>

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -38,17 +38,17 @@ services:
 
     surfnet.dashboard.command_handler.load_metadata:
         class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\LoadMetadataCommandHandler
-        arguments:
-            - '@surfnet.dashboard.metadata.fetcher'
-            - '@surfnet.dashboard.metadata.parser'
         public: true
+        arguments:
+            - '@Surfnet\ServiceProviderDashboard\Legacy\Metadata\Fetcher'
+            - '@Surfnet\ServiceProviderDashboard\Legacy\Metadata\Parser'
         tags:
             - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Entity\LoadMetadataCommand }
 
     surfnet.dashboard.command_handler.mailer:
         class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Mail\SendMailCommandHandler
         public: true
-        arguments: ['@surfnet.dashboard.mailer']
+        arguments: ['@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Mailer\Mailer']
         tags:
             - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Mail\PublishToProductionMailCommand }
 
@@ -76,12 +76,10 @@ services:
         tags:
             - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Command\Service\SelectServiceCommand }
 
-    surfnet.dashboard.mailer:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Mailer\Mailer
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Mailer\Mailer:
         arguments: ['@mailer']
 
-    surfnet.dashboard.mailer_factory:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Factory\MailMessageFactory
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Factory\MailMessageFactory:
         arguments:
             - '%mail_from%'
             - '%mail_receiver%'
@@ -90,119 +88,92 @@ services:
             - '@templating'
 
 
-    surfnet.dashboard.menu.builder:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Menu\Builder
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Menu\Builder:
         tags:
             - { name: knp_menu.menu_builder, method: mainMenu, alias: main }
 
-    surfnet.dashboard.metadata.certificate_parser:
+    Surfnet\ServiceProviderDashboard\Legacy\Metadata\CertificateParser:
         class: Surfnet\ServiceProviderDashboard\Legacy\Metadata\CertificateParser
 
     surfnet.dashboard.metadata.client:
         class: GuzzleHttp\Client
 
-    surfnet.dashboard.metadata.fetcher:
-        class: Surfnet\ServiceProviderDashboard\Legacy\Metadata\Fetcher
+    Surfnet\ServiceProviderDashboard\Legacy\Metadata\Fetcher:
         arguments: ['@surfnet.dashboard.metadata.client', '@logger', '%metadata_url_timeout%']
 
-    surfnet.dashboard.metadata.generator:
+    Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator:
         class: Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator
 
-    surfnet.dashboard.metadata.parser:
-        class: Surfnet\ServiceProviderDashboard\Legacy\Metadata\Parser
+    Surfnet\ServiceProviderDashboard\Legacy\Metadata\Parser:
         arguments:
-            - '@surfnet.dashboard.metadata.certificate_parser'
-            - '@surfnet.dashboard.repository.attributes_metadata'
+            - '@Surfnet\ServiceProviderDashboard\Legacy\Metadata\CertificateParser'
+            - '@Surfnet\ServiceProviderDashboard\Legacy\Repository\AttributesMetadataRepository'
             - '%kernel.root_dir%/Resources'
             - '@logger'
 
-    surfnet.dashboard.monolog.json_formatter:
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Monolog\Formatter\JsonFormatter:
         class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Monolog\Formatter\JsonFormatter
 
-    surfnet.dashboard.repository.contact:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\ContactRepository
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\ContactRepository:
         factory: ['@doctrine', 'getRepository']
         arguments: [Surfnet\ServiceProviderDashboard\Domain\Entity\Contact]
 
-    surfnet.dashboard.repository.attributes_metadata:
-        class: Surfnet\ServiceProviderDashboard\Legacy\Repository\AttributesMetadataRepository
+    Surfnet\ServiceProviderDashboard\Legacy\Repository\AttributesMetadataRepository:
         arguments:  ['%kernel.root_dir%/Resources']
 
-    surfnet.dashboard.repository.entity:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\EntityRepository
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\EntityRepository:
         factory: ['@doctrine', 'getRepository']
         arguments: [Surfnet\ServiceProviderDashboard\Domain\Entity\Entity]
 
-    surfnet.dashboard.repository.privacy_questions:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\PrivacyQuestionsRepository
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\PrivacyQuestionsRepository:
         factory: ['@doctrine', 'getRepository']
         arguments: [Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions]
 
-    surfnet.dashboard.repository.service:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\ServiceRepository
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\ServiceRepository:
         factory: ['@doctrine', 'getRepository']
         arguments: [Surfnet\ServiceProviderDashboard\Domain\Entity\Service]
 
-    surfnet.dashboard.service.authorization:
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AuthorizationService:
         class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AuthorizationService
 
-    surfnet.dashboard.service.entity_service:
-        class: Surfnet\ServiceProviderDashboard\Application\Service\EntityService
-
-    surfnet.dashboard.service.service_service:
-        class: Surfnet\ServiceProviderDashboard\Application\Service\ServiceService
-
-    surfnet.dashboard.service.ticket:
-        class: Surfnet\ServiceProviderDashboard\Application\Service\TicketService
-
-    surfnet.dashboard.twig.service_switcher_extension:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Twig\ServiceSwitcherExtension
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Twig\ServiceSwitcherExtension:
         tags: [twig.extension]
 
-    surfnet.dashboard.twig.identity_extension:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Twig\IdentityExtension
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Twig\IdentityExtension:
         tags: [twig.extension]
 
-    surfnet.dashboard.validator.entity_id:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\ValidEntityIdValidator
-        arguments:  ['@surfnet.manage.client.query_entity.test_environment']
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\ValidEntityIdValidator:
+        arguments:  ['@Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient']
         tags:
             - { name: validator.constraint_validator, alias: entity_id }
 
-    surfnet.dashboard.validator.logo:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\ValidLogoValidator
-        arguments:  ['@surfnet.dashboard.validator.logo_validation_helper']
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\ValidLogoValidator:
+        arguments:  ['@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\CurlLogoValidationHelper']
         tags:
             - { name: validator.constraint_validator, alias: logo }
 
-    surfnet.dashboard.validator.logo_validation_helper:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\CurlLogoValidationHelper
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\CurlLogoValidationHelper:
         arguments:  ['@logger']
 
-    surfnet.dashboard.validator.contact:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\ValidContactValidator
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\ValidContactValidator:
         tags:
             - { name: validator.constraint_validator, alias: contact }
 
-    surfnet.dashboard.validator.attribute:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\ValidAttributeValidator
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\ValidAttributeValidator:
         tags:
             - { name: validator.constraint_validator, alias: attribute }
 
-    surfnet.manage.client.publish_entity.test_environment:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\PublishEntityClient
+    Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\PublishEntityClient:
         arguments:
-            - '@surfnet.manage.http.client.test_environment'
-            - '@surfnet.dashboard.metadata.generator'
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Http\HttpClient'
+            - '@Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator'
             - '@logger'
 
-    surfnet.manage.client.query_entity.test_environment:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient
+    Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient:
         arguments:
-            - '@surfnet.manage.http.client.test_environment'
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Http\HttpClient'
 
-    surfnet.manage.http.client.test_environment:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Http\HttpClient
+    Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Http\HttpClient:
         arguments:
             - '@surfnet.manage.http.guzzle.test_environement'
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Resources/config/services.yml
@@ -13,112 +13,93 @@ services:
           - '@surfnet_saml.hosted.service_provider'
 
     # Firewall
-    surfnet.dashboard.security.authentication.listener:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Firewall\SamlListener
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Firewall\SamlListener:
         arguments:
-            - "@surfnet.dashboard.security.authentication.handler.authenticated_user_handler"
-            - "@surfnet.dashboard.security.authentication.saml_interaction"
-            - "@logger"
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Handler\AuthenticatedUserHandler'
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\SamlInteractionProvider'
+            - '@logger'
 
-    surfnet.dashboard.security.authentication.provider.saml:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Provider\SamlProvider
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Provider\SamlProvider:
         arguments:
-            - "@surfnet.dashboard.repository.contact"
-            - "@surfnet.dashboard.repository.service"
-            - "@surfnet_saml.saml.attribute_dictionary"
-            - "@logger"
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\ContactRepository'
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\ServiceRepository'
+            - '@surfnet_saml.saml.attribute_dictionary'
+            - '@logger'
             - '%surfnet.dashboard.security.authentication.administrator_team%'
 
-    surfnet.dashboard.security.authentication.saml_interaction:
-        public: false
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\SamlInteractionProvider
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\SamlInteractionProvider:
         arguments:
-            - "@surfnet_saml.hosted.service_provider"
-            - "@surfnet_saml.remote.idp"
-            - "@surfnet_saml.http.redirect_binding"
-            - "@surfnet_saml.http.post_binding"
-            - "@surfnet.dashboard.security.authentication.session.session_storage"
+            - '@surfnet_saml.hosted.service_provider'
+            - '@surfnet_saml.remote.idp'
+            - '@surfnet_saml.http.redirect_binding'
+            - '@surfnet_saml.http.post_binding'
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Session\SessionStorage'
 
     # Authentication Handlers
-    surfnet.dashboard.security.authentication.handler.authenticated_user_handler:
-        public: false
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Handler\AuthenticatedUserHandler
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Handler\AuthenticatedUserHandler:
         arguments:
-            - "@security.token_storage"
-            - "@surfnet.dashboard.security.authentication.session.session_lifetime_guard"
-            - "@surfnet.dashboard.security.authentication.session.session_storage"
-            - "@logger"
+            - '@security.token_storage'
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Session\SessionLifetimeGuard'
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Session\SessionStorage'
+            - '@logger'
         calls:
-            - ["setNext", ["@surfnet.dashboard.security.authentication.handler.explicit_session_timeout"]]
+            - ['setNext', ['@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Handler\ExplicitSessionTimeoutHandler']]
 
-    surfnet.dashboard.security.authentication.handler.explicit_session_timeout:
-        public: false
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Handler\ExplicitSessionTimeoutHandler
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Handler\ExplicitSessionTimeoutHandler:
         arguments:
-            - "@security.token_storage"
-            - "@surfnet.dashboard.security.authentication.session.session_storage"
-            - "@surfnet.dashboard.security.authentication.session.session_lifetime_guard"
-            - "@security.logout.handler.session"
-            - "@security.logout.handler.cookie_clearing.saml_based"
-            - "@router"
-            - "@logger"
+            - '@security.token_storage'
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Session\SessionStorage'
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Session\SessionLifetimeGuard'
+            - '@security.logout.handler.session'
+            - '@security.logout.handler.cookie_clearing.saml_based'
+            - '@router'
+            - '@logger'
         calls:
-            - ["setNext", ["@surfnet.dashboard.security.authentication.handler.initiate_saml_request"]]
+            - ['setNext', ['@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Handler\InitiateSamlAuthenticationHandler']]
 
-    surfnet.dashboard.security.authentication.handler.initiate_saml_request:
-        public: false
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Handler\InitiateSamlAuthenticationHandler
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Handler\InitiateSamlAuthenticationHandler:
         arguments:
-            - "@security.token_storage"
-            - "@surfnet.dashboard.security.authentication.session.session_storage"
-            - "@surfnet.dashboard.security.authentication.session.session_storage"
-            - "@surfnet.dashboard.security.authentication.saml_interaction"
-            - "@router"
-            - "@surfnet_saml.logger"
-            - "@logger"
+            - '@security.token_storage'
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Session\SessionStorage'
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Session\SessionStorage'
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\SamlInteractionProvider'
+            - '@router'
+            - '@surfnet_saml.logger'
+            - '@logger'
         calls:
-            - ["setNext", ["@surfnet.dashboard.security.authentication.handler.process_saml_response"]]
+            - ['setNext', ['@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Handler\ProcessSamlAuthenticationHandler']]
 
-    surfnet.dashboard.security.authentication.handler.process_saml_response:
-        public: false
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Handler\ProcessSamlAuthenticationHandler
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Handler\ProcessSamlAuthenticationHandler:
         arguments:
-            - "@security.token_storage"
-            - "@surfnet.dashboard.security.authentication.saml_interaction"
-            - "@surfnet.dashboard.security.authentication.session.session_storage"
-            - "@surfnet.dashboard.security.authentication.session.session_storage"
-            - "@security.authentication.manager"
-            - "@surfnet_saml.logger"
-            - "@templating"
+            - '@security.token_storage'
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\SamlInteractionProvider'
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Session\SessionStorage'
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Session\SessionStorage'
+            - '@security.authentication.manager'
+            - '@surfnet_saml.logger'
+            - '@templating'
 
     # Session
-    surfnet.dashboard.security.authentication.session.session_storage:
-        public: false
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Session\SessionStorage
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Session\SessionStorage:
         arguments:
-            - "@session"
+            - '@session'
 
-    surfnet.dashboard.security.authentication.session.session_lifetime_guard:
-        public: false
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Session\SessionLifetimeGuard
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Session\SessionLifetimeGuard:
         arguments:
-            - "@surfnet.dashboard.security.authentication.session.absolute_maximum_lifetime"
-            - "@surfnet.dashboard.security.authentication.session.relative_maximum_lifetime"
+            - '@surfnet.dashboard.security.authentication.session.absolute_maximum_lifetime'
+            - '@surfnet.dashboard.security.authentication.session.relative_maximum_lifetime'
 
     surfnet.dashboard.security.authentication.session.absolute_maximum_lifetime:
-        public: false
         class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Value\TimeFrame
         factory: [Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Value\TimeFrame, ofSeconds]
         arguments:
-            - "%surfnet.dashboard.security.authentication.session.maximum_absolute_lifetime_in_seconds%"
+            - '%surfnet.dashboard.security.authentication.session.maximum_absolute_lifetime_in_seconds%'
 
     surfnet.dashboard.security.authentication.session.relative_maximum_lifetime:
-        public: false
         class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Value\TimeFrame
         factory: [Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Value\TimeFrame, ofSeconds]
         arguments:
-            - "%surfnet.dashboard.security.authentication.session.maximum_relative_lifetime_in_seconds%"
+            - '%surfnet.dashboard.security.authentication.session.maximum_relative_lifetime_in_seconds%'
 
-    surfnet.dashboard.security.service.identity:
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Service\IdentityService:
         class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Service\IdentityService
-

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Security/Factory/SamlFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Security/Factory/SamlFactory.php
@@ -18,6 +18,8 @@
 
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Factory;
 
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Provider\SamlProvider;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Firewall\SamlListener;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -30,13 +32,13 @@ class SamlFactory implements SecurityFactoryInterface
         $providerId = 'security.authentication.provider.saml.' . $id;
         $container->setDefinition(
             $providerId,
-            new ChildDefinition('surfnet.dashboard.security.authentication.provider.saml')
+            new ChildDefinition(SamlProvider::class)
         );
 
         $listenerId = 'security.authentication.listener.saml.' . $id;
         $container->setDefinition(
             $listenerId,
-            new ChildDefinition('surfnet.dashboard.security.authentication.listener')
+            new ChildDefinition(SamlListener::class)
         );
 
         $cookieHandlerId = 'security.logout.handler.cookie_clearing.' . $id;

--- a/tests/webtests/EditPrivacyQuestionsTest.php
+++ b/tests/webtests/EditPrivacyQuestionsTest.php
@@ -19,6 +19,7 @@
 namespace Surfnet\ServiceProviderDashboard\Webtests;
 
 use Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\PrivacyQuestionsRepository;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class EditPrivacyQuestionsTest extends WebTestCase
@@ -34,7 +35,7 @@ class EditPrivacyQuestionsTest extends WebTestCase
         $questions->setService($service);
         $questions->setCountry('Nederland');
 
-        $repo = $this->client->getContainer()->get('surfnet.dashboard.repository.privacy_questions');
+        $repo = $this->client->getContainer()->get(PrivacyQuestionsRepository::class);
         $repo->save($questions);
 
         $this->logIn('ROLE_USER', [$service]);
@@ -59,7 +60,7 @@ class EditPrivacyQuestionsTest extends WebTestCase
         $questions->setService($service);
         $questions->setCountry('Nederland');
 
-        $repo = $this->client->getContainer()->get('surfnet.dashboard.repository.privacy_questions');
+        $repo = $this->client->getContainer()->get(PrivacyQuestionsRepository::class);
         $repo->save($questions);
 
         $this->logIn('ROLE_USER', [$service]);

--- a/tests/webtests/EntityPublishToProductionTest.php
+++ b/tests/webtests/EntityPublishToProductionTest.php
@@ -24,6 +24,7 @@ use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Supplier;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\SupplierRepository;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Mailer\Mailer;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class EntityPublishToProductionTest extends WebTestCase
@@ -90,7 +91,7 @@ class EntityPublishToProductionTest extends WebTestCase
         // Entity id validation
         $this->mockHandler->append(new Response(200, [], '{"id":"f1e394b2-08b1-4882-8b32-43876c15c743"}'));
 
-        $mailer = $this->client->getContainer()->get('surfnet.dashboard.mailer');
+        $mailer = $this->client->getContainer()->get(Mailer::class);
 
         // Build and save an entity to work with
         $entity = $this->buildEntity($this->getServiceRepository()->findByName('SURFnet'));

--- a/tests/webtests/Resources/config/services.yml
+++ b/tests/webtests/Resources/config/services.yml
@@ -9,6 +9,7 @@ services:
 
     surfnet.dashboard.mailer:
         class: Surfnet\ServiceProviderDashboard\Webtests\Mailer\FakeMailer
+        public: true
 
     surfnet.dashboard.metadata.fetcher:
         class: Surfnet\ServiceProviderDashboard\Webtests\Metadata\FakeFetcher
@@ -32,8 +33,39 @@ services:
 
     surfnet.manage.http.guzzle.mock_handler:
         class: GuzzleHttp\Handler\MockHandler
+        public: true
 
     surfnet.manage.http.guzzle.test_environement:
         class: GuzzleHttp\Client
         arguments:
         - handler: '@surfnet.manage.http.guzzle.mock_handler'
+
+    # These services are overloaded for functional tests and have been made public to prevent:
+    #
+    # > The "logger" service is private, getting it from the container is
+    # > deprecated since Symfony 3.2 and will fail in 4.0.
+    logger:
+        alias: 'monolog.logger'
+        public: true
+
+    surfnet.dashboard.repository.entity:
+        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\EntityRepository
+        factory: ['@doctrine', 'getRepository']
+        arguments: [Surfnet\ServiceProviderDashboard\Domain\Entity\Entity]
+        public: true
+
+    surfnet.dashboard.repository.privacy_questions:
+        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\PrivacyQuestionsRepository
+        factory: ['@doctrine', 'getRepository']
+        arguments: [Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions]
+        public: true
+
+    surfnet.dashboard.repository.service:
+        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\ServiceRepository
+        factory: ['@doctrine', 'getRepository']
+        arguments: [Surfnet\ServiceProviderDashboard\Domain\Entity\Service]
+        public: true
+
+    surfnet.dashboard.service.authorization:
+        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AuthorizationService
+        public: true

--- a/tests/webtests/Resources/config/services.yml
+++ b/tests/webtests/Resources/config/services.yml
@@ -1,17 +1,18 @@
 # This DI configuration file containes overrides on the DashboardBundle configuration,
 # typically to replace doctrine repositories with in-memory repositories.
 services:
-    surfnet.dashboard.command_handler.publish_entity:
+
+    Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\PublishEntityTestCommandHandler:
         class: Surfnet\ServiceProviderDashboard\Webtests\CommandHandler\MockPublishEntityCommandHandler
         public: true
         tags:
             - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityCommand }
 
-    surfnet.dashboard.mailer:
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Mailer\Mailer:
         class: Surfnet\ServiceProviderDashboard\Webtests\Mailer\FakeMailer
         public: true
 
-    surfnet.dashboard.metadata.fetcher:
+    Surfnet\ServiceProviderDashboard\Legacy\Metadata\Fetcher:
         class: Surfnet\ServiceProviderDashboard\Webtests\Metadata\FakeFetcher
 
     surfnet.dashboard.session.storage.mock_file:
@@ -21,12 +22,12 @@ services:
             - 'MOCKSESSID'
             - '@session.storage.metadata_bag'
 
-    surfnet.dashboard.validator.logo:
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\ValidLogoValidator:
         class: Surfnet\ServiceProviderDashboard\Webtests\Validator\Constraints\MockValidLogoValidator
         tags:
             - { name: validator.constraint_validator, alias: logo }
 
-    surfnet.dashboard.validator.entity_id:
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\ValidEntityIdValidator:
         class: Surfnet\ServiceProviderDashboard\Webtests\Validator\Constraints\MockEntityIdValidator
         tags:
             - { name: validator.constraint_validator, alias: entity_id }
@@ -44,28 +45,7 @@ services:
     #
     # > The "logger" service is private, getting it from the container is
     # > deprecated since Symfony 3.2 and will fail in 4.0.
-    logger:
-        alias: 'monolog.logger'
+    surfnet_saml.saml2.bridge_container:
+        class: Surfnet\SamlBundle\SAML2\BridgeContainer
         public: true
-
-    surfnet.dashboard.repository.entity:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\EntityRepository
-        factory: ['@doctrine', 'getRepository']
-        arguments: [Surfnet\ServiceProviderDashboard\Domain\Entity\Entity]
-        public: true
-
-    surfnet.dashboard.repository.privacy_questions:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\PrivacyQuestionsRepository
-        factory: ['@doctrine', 'getRepository']
-        arguments: [Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions]
-        public: true
-
-    surfnet.dashboard.repository.service:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\ServiceRepository
-        factory: ['@doctrine', 'getRepository']
-        arguments: [Surfnet\ServiceProviderDashboard\Domain\Entity\Service]
-        public: true
-
-    surfnet.dashboard.service.authorization:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AuthorizationService
-        public: true
+        arguments: ['@logger']

--- a/tests/webtests/WebTestCase.php
+++ b/tests/webtests/WebTestCase.php
@@ -25,16 +25,15 @@ use Doctrine\ORM\EntityManager;
 use GuzzleHttp\Handler\MockHandler;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
-use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityRepository;
-use Surfnet\ServiceProviderDashboard\Domain\Repository\ServiceRepository;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\EntityRepository;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\ServiceRepository;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\DataFixtures\ORM\WebTestFixtures;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AuthorizationService;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Token\SamlToken;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Identity;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as SymfonyWebTestCase;
 use Symfony\Component\BrowserKit\Cookie;
-use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Debug\Debug;
 
 class WebTestCase extends SymfonyWebTestCase
 {
@@ -50,10 +49,13 @@ class WebTestCase extends SymfonyWebTestCase
 
     public function setUp()
     {
+        // Disable notices, strict and deprecated warnings. Many Symfony 3.4 deprecation warnings are still to be fixed.
+        Debug::enable(E_RECOVERABLE_ERROR & ~E_DEPRECATED, false);
+
         $this->client = static::createClient(
             [],
             [
-            'HTTPS' => 'on',
+                'HTTPS' => 'on',
             ]
         );
 
@@ -127,7 +129,7 @@ class WebTestCase extends SymfonyWebTestCase
      */
     protected function getServiceRepository()
     {
-        return $this->client->getContainer()->get('surfnet.dashboard.repository.service');
+        return $this->client->getContainer()->get(ServiceRepository::class);
     }
 
     /**
@@ -135,7 +137,7 @@ class WebTestCase extends SymfonyWebTestCase
      */
     protected function getEntityRepository()
     {
-        return $this->client->getContainer()->get('surfnet.dashboard.repository.entity');
+        return $this->client->getContainer()->get(EntityRepository::class);
     }
 
     /**
@@ -143,6 +145,6 @@ class WebTestCase extends SymfonyWebTestCase
      */
     protected function getAuthorizationService()
     {
-        return $this->client->getContainer()->get('surfnet.dashboard.service.authorization');
+        return $this->client->getContainer()->get(AuthorizationService::class);
     }
 }


### PR DESCRIPTION
Upgrade to Symfony 3.4
 - Some effort was put into getting rid of as many deprecation notices as possible. Not all have been resolved.
 - Lexik Translation bundle was updated to support symfony 3.4

When upgrading to version 4, we might need to take a closer look at the way web tests use the DI container. As this results in the most deprecation warnings (reading of private services)

For the translation bundle to work as intended please force update the database schema:
`bin/console doctrine:schema:update --force` as an additional field was added to the `lexik_trans_unit` table.