### PR TITLE
Support multiple admin teams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,7 @@
 Notable changes
  - Client side validation was added to the form
  - The CRM ID field is no longer required (please run migration 20180502134816)
+ - Added support for multiple admin teams. Can be configured using the `administrator_teams` parameter. The previously used
+   `administrator_team` parameter has been discontinued and is no longer supported. 
  - Symfony was upgraded to version 3.4
  - Lexik translation bundle was upgraded (please update database schema to make it work)

--- a/ansible/roles/spdashboard/templates/parameters.yml.j2
+++ b/ansible/roles/spdashboard/templates/parameters.yml.j2
@@ -13,7 +13,7 @@ parameters:
     mail_receiver: {{ spdashboard_support_email }}
     mail_no_reply: {{ noreply_email }}
     secret: {{ spdashboard_symfony_secret }}
-    administrator_team: {{ spdashboard_administrator_team }}
+    administrator_teams: {{ spdashboard_administrator_team }}
     metadata_url_timeout: 30
     session_max_absolute_lifetime: 172800
     session_max_relative_lifetime: 28800

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -139,5 +139,5 @@ dashboard_saml:
     session_lifetimes:
         max_absolute_lifetime: "%session_max_absolute_lifetime%"
         max_relative_lifetime: "%session_max_relative_lifetime%"
-    administrator_team: "%administrator_team%"
+    administrator_teams: "%administrator_teams%"
 

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -23,8 +23,9 @@ parameters:
 
     logout_redirect_url: https://www.surf.nl/over-surf/werkmaatschappijen/surfnet
 
-    # All users in this team get the administrator role
-    administrator_team: 'urn:collab:org:surf.nl'
+    # All users in these teams get the administrator role
+    administrator_teams:
+        - 'urn:collab:org:surf.nl'
 
     saml_sp_publickey: '%kernel.root_dir%/../vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_publickey.cer'
     saml_sp_privatekey: '%kernel.root_dir%/../vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_privatekey.pem'

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/DependencyInjection/Configuration.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/DependencyInjection/Configuration.php
@@ -45,10 +45,10 @@ class Configuration implements ConfigurationInterface
     private function appendSessionConfiguration(NodeBuilder $childNodes)
     {
         $childNodes
-            ->scalarNode('administrator_team')
+            ->arrayNode('administrator_teams')
+                ->info('All users in these teams get the administrator role')
                 ->isRequired()
-                ->defaultValue('urn:collab:org:surf.nl')
-                ->info('All users in this team get the administrator role')
+                ->scalarPrototype()->end()
             ->end()
             ->arrayNode('session_lifetimes')
                 ->isRequired()

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/DependencyInjection/DashboardSamlExtension.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/DependencyInjection/DashboardSamlExtension.php
@@ -40,8 +40,8 @@ class DashboardSamlExtension extends Extension
         $loader->load('services.yml');
 
         $container->setParameter(
-            'surfnet.dashboard.security.authentication.administrator_team',
-            $config['administrator_team']
+            'surfnet.dashboard.security.authentication.administrator_teams',
+            $config['administrator_teams']
         );
         $container->setParameter(
             'surfnet.dashboard.security.authentication.session.maximum_absolute_lifetime_in_seconds',

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Resources/config/services.yml
@@ -25,7 +25,7 @@ services:
             - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\ServiceRepository'
             - '@surfnet_saml.saml.attribute_dictionary'
             - '@logger'
-            - '%surfnet.dashboard.security.authentication.administrator_team%'
+            - '%surfnet.dashboard.security.authentication.administrator_teams%'
 
     Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\SamlInteractionProvider:
         arguments:

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Security/Authentication/Provider/SamlProvider.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Security/Authentication/Provider/SamlProvider.php
@@ -19,7 +19,6 @@
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Provider;
 
 use Psr\Log\LoggerInterface;
-use RuntimeException as CoreRuntimeException;
 use Surfnet\SamlBundle\Exception\RuntimeException;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
 use Surfnet\SamlBundle\SAML2\Response\AssertionAdapter;
@@ -33,6 +32,7 @@ use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security
 use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Webmozart\Assert\Assert;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -60,7 +60,7 @@ class SamlProvider implements AuthenticationProviderInterface
     private $logger;
 
     /**
-     * @var array
+     * @var string[]
      */
     private $administratorTeams;
 
@@ -75,6 +75,10 @@ class SamlProvider implements AuthenticationProviderInterface
         $this->services = $services;
         $this->attributeDictionary = $attributeDictionary;
         $this->logger = $logger;
+        Assert::allStringNotEmpty(
+            $administratorTeams,
+            'All entries in the `administrator_teams` config parameter should be string.'
+        );
         $this->administratorTeams = $administratorTeams;
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Security/Authentication/Provider/SamlProvider.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Security/Authentication/Provider/SamlProvider.php
@@ -105,10 +105,8 @@ class SamlProvider implements AuthenticationProviderInterface
             $teamNames = [];
         }
 
-        foreach ($this->administratorTeams as $teamName) {
-            if (in_array($teamName, $teamNames)) {
-                $role = 'ROLE_ADMINISTRATOR';
-            }
+        if (!empty(array_intersect($this->administratorTeams, $teamNames))) {
+            $role = 'ROLE_ADMINISTRATOR';
         }
 
         $contact = $this->contacts->findByNameId($nameId);

--- a/tests/unit/Infrastructure/DashboardSamlBundle/Security/Authentication/Provider/SamlProviderTest.php
+++ b/tests/unit/Infrastructure/DashboardSamlBundle/Security/Authentication/Provider/SamlProviderTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\DashboardBundle\Mailer;
+
+use InvalidArgumentException;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\ContactRepository;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\ServiceRepository;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Provider\SamlProvider;
+
+class SamlProviderTest extends TestCase
+{
+    /**
+     * @dataProvider provideValidAdminTeams
+     */
+    public function test_administrator_teams_validation_accepts_valid_teams($validAdminTeams)
+    {
+        $this->assertInstanceOf(SamlProvider::class, $this->buildProvider($validAdminTeams));
+    }
+
+    /**
+     * @dataProvider provideInvalidAdminTeams
+     */
+    public function test_administrator_teams_validation_rejects_invalid_teams($invalidAdminTeams)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('All entries in the `administrator_teams` config parameter should be string.');
+        $this->buildProvider($invalidAdminTeams);
+    }
+
+
+    public function provideValidAdminTeams()
+    {
+        return [
+            [['urn:collab:foo:team.foobar.com']],
+            [['urn:collab:foo:team.foobar.com', 'urn:collab:foo:team.foobar.com']],
+        ];
+    }
+
+    public function provideInvalidAdminTeams()
+    {
+        return [
+            [['']],
+            [[345345]],
+            [[true, false]],
+            [[['foo', 'bar']]],
+        ];
+    }
+
+    private function buildProvider($administratorTeams)
+    {
+        $contactRepo = m::mock(ContactRepository::class);
+        $serviceRepo = m::mock(ServiceRepository::class);
+        $attributeDictionary = m::mock(AttributeDictionary::class);
+        $logger = m::mock(LoggerInterface::class);
+
+        return new SamlProvider($contactRepo, $serviceRepo, $attributeDictionary, $logger, $administratorTeams);
+    }
+}


### PR DESCRIPTION
The configuration has been renamed and rebuild to allow setting more
than one admin team.

The Saml Authentication provider now also supports multiple teams. This,
by simply iterating over the configured teams. And leaving the original
logic unchanged.
