### PR TITLE
Prevent validation on unwanted events

### DIFF
--- a/app/js/components/validation.js
+++ b/app/js/components/validation.js
@@ -34,6 +34,13 @@ if (form.length) {
             errorContainer.text('');
         }
     });
+
+    // When clicking import, save or cancel, do not validate the form using frontend validation, so disable parsley and
+    // submit the form.
+    $('#dashboard_bundle_entity_type_metadata_importButton, #dashboard_bundle_entity_type_save, #dashboard_bundle_entity_type_cancel').click(function(){
+        $(form).parsley().destroy();
+        $(form).submit();
+    });
 }
 
 // Add a stricter url validator, this one ensures the protocol is set on the input value


### PR DESCRIPTION
We only want form validation on email fields, and possibly when
submitting the form for publication. So refrain from using Parsley when
user presses the import, save or cancel buttons. These buttons would
trigger form validation in unwanted situations.