### PR TITLE
Re-enable running encore in production mode

### DIFF
--- a/ansible/roles/spdashboard/files/makeRelease.sh
+++ b/ansible/roles/spdashboard/files/makeRelease.sh
@@ -52,7 +52,7 @@ echo "Running Composer Install";
 curl -sS https://getcomposer.org/installer | php
 php ./composer.phar install -n --prefer-dist -o --ignore-platform-reqs&&
 yarn install &&
-yarn run encore dev &&
+yarn run encore production &&
 
 
 echo "Tagging the release in RELEASE file" &&

--- a/app/js/components/validation.js
+++ b/app/js/components/validation.js
@@ -1,4 +1,4 @@
-import 'parsleyjs/src/parsley';
+import 'parsleyjs';
 
 // Configure Parsley
 const parsleyConfig = {


### PR DESCRIPTION
Thanks to an explanation found on the webpack encore issues page:

> Lyrkan: on Aug 15, 2017
>
> So, looking back at it a bit more, the version of Webpack shipped with
> Encore currently installs uglifyjs-webpack-plugin v0.4.6 which uses
> uglify-js v2.8.29. This version of uglify-js doesn't support ES6 and,
> since vendors don't go through Babel it fails if you require something
> from them written using ES6. It works using the files in dist since
> they have already been processed by Babel using the ES2015 preset.

SO the solution to our problem was not to include Parsley from the 'src'
folder, but to read it from the ES2015 compliant 'dist' folder.

The makeRelease.sh was also updated to run encore in production mode,
reverting the previously made change.