### PR TITLE
Don't overwrite fields when updating existing entities

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/GeneratorInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/GeneratorInterface.php
@@ -23,10 +23,23 @@ use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 interface GeneratorInterface
 {
     /**
-     * Convert an entity to json-serializable array.
+     * Convert an new, unpublished entity to json-serializable array.
      *
      * @param Entity $entity
      * @return array
      */
-    public function generate(Entity $entity);
+    public function generateForNewEntity(Entity $entity);
+
+    /**
+     * Convert entity to an array for the manage merge-write API call.
+     *
+     * The resulting array is almost identical to the one created by
+     * generateNew(), but only contains fields stored in SP-dashboard, and
+     * never overwrites fields not managed by the dashboard (such as allowed
+     * entities).
+     *
+     * @param Entity $entity
+     * @return array
+     */
+    public function generateForExistingEntity(Entity $entity);
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityMetadataController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityMetadataController.php
@@ -78,7 +78,7 @@ class EntityMetadataController extends Controller
         }
 
         return new JsonResponse(
-            $this->generator->generate($entity)
+            $this->generator->generateForNewEntity($entity)
         );
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php
@@ -66,7 +66,7 @@ class PublishEntityClient implements PublishEntityRepositoryInterface
 
                 $response = $this->client->post(
                     json_encode([
-                        'data' => $this->generator->generate($entity),
+                        'data' => $this->generator->generateForNewEntity($entity),
                         'type' => 'saml20_sp',
                     ]),
                     '/manage/api/internal/metadata'
@@ -76,7 +76,7 @@ class PublishEntityClient implements PublishEntityRepositoryInterface
 
                 $response = $this->client->put(
                     json_encode([
-                        'pathUpdates' => $this->generator->generate($entity),
+                        'pathUpdates' => $this->generator->generateForExistingEntity($entity),
                         'type' => 'saml20_sp',
                         'id' => $entity->getManageId(),
                     ]),

--- a/tests/unit/Infrastructure/Manage/Client/PublishEntityClientTest.php
+++ b/tests/unit/Infrastructure/Manage/Client/PublishEntityClientTest.php
@@ -84,7 +84,7 @@ class PublishEntityClientTest extends MockeryTestCase
             ->shouldReceive('info');
 
         $this->generator
-            ->shouldReceive('generate')
+            ->shouldReceive('generateForNewEntity')
             ->andReturn($json);
 
         $response = $this->client->publish($entity);
@@ -110,7 +110,7 @@ class PublishEntityClientTest extends MockeryTestCase
             ->shouldReceive('info');
 
         $this->generator
-            ->shouldReceive('generate')
+            ->shouldReceive('generateForExistingEntity')
             ->andReturn($json);
 
         $response = $this->client->publish($entity);
@@ -145,7 +145,7 @@ class PublishEntityClientTest extends MockeryTestCase
             ->shouldReceive('error');
 
         $this->generator
-            ->shouldReceive('generate')
+            ->shouldReceive('generateForNewEntity')
             ->andReturn($json);
 
         $this->client->publish($entity);


### PR DESCRIPTION
The problem was two-fold:

1. When publising an entity already existing in manage, entity fields
such as 'active' and 'allowall' were always reset to their original
value. This commit changes the behaviour to only send the values on
the initial push to manage, and not on subsequent pushed.

2. The merge-write implementation was sending a list of metadata
fields, suggesting all metadata fields not in that list should be
deleted. This has been solved by using the flat format so all fields
not known to the dashboard are untouched.

See [pivotal](https://www.pivotaltracker.com/story/show/157119861).