### PR TITLE
Log all requests and responses to manage

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -172,6 +172,7 @@ services:
     Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Http\HttpClient:
         arguments:
             - '@surfnet.manage.http.guzzle.test_environement'
+            - '@logger'
 
     surfnet.manage.http.guzzle.test_environement:
         class: GuzzleHttp\Client

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -171,10 +171,10 @@ services:
 
     Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Http\HttpClient:
         arguments:
-            - '@surfnet.manage.http.guzzle.test_environement'
+            - '@surfnet.manage.http.guzzle.test_environment'
             - '@logger'
 
-    surfnet.manage.http.guzzle.test_environement:
+    surfnet.manage.http.guzzle.test_environment:
         class: GuzzleHttp\Client
         arguments:
         - base_uri: "%manage_test_host%"

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php
@@ -90,11 +90,6 @@ class PublishEntityClient implements PublishEntityRepositoryInterface
 
             return $response;
         } catch (HttpException $e) {
-            $this->logger->error(
-                sprintf('Error publishing \'%s\' to manage', $entity->getEntityId()),
-                ['exception' => $e]
-            );
-
             throw new PublishMetadataException('Unable to publish the metadata to Manage', 0, $e);
         }
     }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/QueryClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/QueryClient.php
@@ -99,7 +99,7 @@ class QueryClient implements QueryEntityRepository
             );
         } catch (HttpException $e) {
             throw new QueryServiceProviderException(
-                sprintf('Unable to find entity metadata with entityId: "%s"', $manageId),
+                sprintf('Unable to find entity metadata with manage ID: "%s"', $manageId),
                 0,
                 $e
             );

--- a/tests/integration/Infrastructure/DashboardBundle/Validator/Constraints/ValidEntityIdValidatorTest.php
+++ b/tests/integration/Infrastructure/DashboardBundle/Validator/Constraints/ValidEntityIdValidatorTest.php
@@ -22,6 +22,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use Mockery as m;
+use Psr\Log\NullLogger;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveEntityCommand;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityRepository;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\ValidEntityId;
@@ -54,7 +55,7 @@ class ValidEntityIdValidatorTest extends ConstraintValidatorTestCase
         $this->repository = m::mock(EntityRepository::class);
 
         $guzzle = new Client(['handler' => $this->mockHandler]);
-        $client = new QueryClient(new HttpClient($guzzle));
+        $client = new QueryClient(new HttpClient($guzzle, new NullLogger()));
 
         return new ValidEntityIdValidator(
             $client,

--- a/tests/unit/Infrastructure/Manage/Client/PublishEntityClientTest.php
+++ b/tests/unit/Infrastructure/Manage/Client/PublishEntityClientTest.php
@@ -25,6 +25,7 @@ use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Mock;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\GeneratorInterface;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
@@ -62,7 +63,14 @@ class PublishEntityClientTest extends MockeryTestCase
 
         $this->logger = m::mock(LoggerInterface::class);
 
-        $this->client = new PublishEntityClient(new HttpClient($guzzle), $this->generator, $this->logger);
+        $this->client = new PublishEntityClient(
+            new HttpClient(
+                $guzzle,
+                new NullLogger()
+            ),
+            $this->generator,
+            $this->logger
+        );
     }
 
     public function test_it_can_publish_to_manage()

--- a/tests/unit/Infrastructure/Manage/Client/QueryClientTest.php
+++ b/tests/unit/Infrastructure/Manage/Client/QueryClientTest.php
@@ -22,6 +22,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Psr\Log\NullLogger;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Http\HttpClient;
 
@@ -41,7 +42,12 @@ class QueryClientTest extends MockeryTestCase
     {
         $this->mockHandler = new MockHandler();
         $guzzle = new Client(['handler' => $this->mockHandler]);
-        $this->client = new QueryClient(new HttpClient($guzzle));
+        $this->client = new QueryClient(
+            new HttpClient(
+                $guzzle,
+                new NullLogger()
+            )
+        );
     }
 
     public function test_it_can_see_if_entity_id_exists()

--- a/tests/unit/Infrastructure/Manage/Http/HttpClientTest.php
+++ b/tests/unit/Infrastructure/Manage/Http/HttpClientTest.php
@@ -22,6 +22,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit_Framework_TestCase as UnitTest;
+use Psr\Log\NullLogger;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Http\Exception\AccessDeniedException;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Http\Exception\MalformedResponseException;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Http\HttpClient;
@@ -38,7 +39,7 @@ class HttpClientTest extends UnitTest
             ]
         );
         $guzzle = new Client(['handler' => $mockHandler]);
-        $client = new HttpClient($guzzle);
+        $client = new HttpClient($guzzle, new NullLogger());
 
         $response = $client->read('/give-me/resource');
 
@@ -53,7 +54,7 @@ class HttpClientTest extends UnitTest
             new Response(200, [], $malformedJson)
         ]);
         $guzzle = new Client(['handler' => $mockHandler]);
-        $client = new HttpClient($guzzle);
+        $client = new HttpClient($guzzle, new NullLogger());
 
         $this->expectException(MalformedResponseException::class);
 
@@ -66,7 +67,7 @@ class HttpClientTest extends UnitTest
             new Response(404, [])
         ]);
         $guzzle = new Client(['handler' => $mockHandler]);
-        $client = new HttpClient($guzzle);
+        $client = new HttpClient($guzzle, new NullLogger());
 
         $response = $client->read('give-me/404');
 
@@ -82,7 +83,7 @@ class HttpClientTest extends UnitTest
             new Response(403, [])
         ]);
         $guzzle = new Client(['handler' => $mockHandler]);
-        $client = new HttpClient($guzzle);
+        $client = new HttpClient($guzzle, new NullLogger());
 
         $this->expectException(AccessDeniedException::class);
 
@@ -98,7 +99,7 @@ class HttpClientTest extends UnitTest
             ]
         );
         $guzzle      = new Client(['handler' => $mockHandler]);
-        $client      = new HttpClient($guzzle);
+        $client = new HttpClient($guzzle, new NullLogger());
 
         $response = $client->post('/resource', 'Post body');
 
@@ -113,7 +114,7 @@ class HttpClientTest extends UnitTest
             new Response(200, [], $malformedJson)
         ]);
         $guzzle = new Client(['handler' => $mockHandler]);
-        $client = new HttpClient($guzzle);
+        $client = new HttpClient($guzzle, new NullLogger());
 
         $this->expectException(MalformedResponseException::class);
 
@@ -126,7 +127,7 @@ class HttpClientTest extends UnitTest
             new Response(404, [])
         ]);
         $guzzle = new Client(['handler' => $mockHandler]);
-        $client = new HttpClient($guzzle);
+        $client = new HttpClient($guzzle, new NullLogger());
 
         $response = $client->post('post-and-give-me/404', 'Post body');
 
@@ -142,7 +143,7 @@ class HttpClientTest extends UnitTest
             new Response(403, [])
         ]);
         $guzzle = new Client(['handler' => $mockHandler]);
-        $client = new HttpClient($guzzle);
+        $client = new HttpClient($guzzle, new NullLogger());
 
         $this->expectException(AccessDeniedException::class);
 

--- a/tests/webtests/Resources/config/services.yml
+++ b/tests/webtests/Resources/config/services.yml
@@ -36,7 +36,7 @@ services:
         class: GuzzleHttp\Handler\MockHandler
         public: true
 
-    surfnet.manage.http.guzzle.test_environement:
+    surfnet.manage.http.guzzle.test_environment:
         class: GuzzleHttp\Client
         arguments:
         - handler: '@surfnet.manage.http.guzzle.mock_handler'


### PR DESCRIPTION
This PR fixes a misleading error message (referring to a manage ID with "entityId") and makes sure all requests and responses to manage are logged when an error occurs.

See [pivotal](https://www.pivotaltracker.com/story/show/157657124).