### PR TITLE
Make all entity fields optional

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/ContactType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/ContactType.php
@@ -21,6 +21,7 @@ namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\E
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -28,19 +29,40 @@ class ContactType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('firstName');
-        $builder->add('lastName');
+        $builder->add(
+            'firstName',
+            TextType::class,
+            [
+                'required' => false,
+            ]
+        );
+
+        $builder->add(
+            'lastName',
+            TextType::class,
+            [
+                'required' => false,
+            ]
+        );
+
         $builder->add(
             'email',
             EmailType::class,
             [
-                'required' => true,
+                'required' => false,
                 'attr' => [
                     'data-parsley-trigger' => 'blur',
                 ],
             ]
         );
-        $builder->add('phone');
+
+        $builder->add(
+            'phone',
+            TextType::class,
+            [
+                'required' => false,
+            ]
+        );
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/EntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/EntityType.php
@@ -110,6 +110,7 @@ class EntityType extends AbstractType
                         'metadataUrl',
                         UrlType::class,
                         [
+                            'required' => false,
                             'attr' => [
                                 'data-help' => 'entity.edit.information.metadataUrl',
                                 'data-parsley-urlstrict' => null,
@@ -121,6 +122,7 @@ class EntityType extends AbstractType
                         'acsLocation',
                         UrlType::class,
                         [
+                            'required' => false,
                             'attr' => [
                                 'data-help' => 'entity.edit.information.acsLocation',
                                 'data-parsley-urlstrict' => null,
@@ -132,6 +134,7 @@ class EntityType extends AbstractType
                         'entityId',
                         UrlType::class,
                         [
+                            'required' => false,
                             'attr' => [
                                 'data-help' => 'entity.edit.information.entityId',
                                 'data-parsley-urlstrict' => null,
@@ -170,6 +173,7 @@ class EntityType extends AbstractType
                         'logoUrl',
                         UrlType::class,
                         [
+                            'required' => false,
                             'attr' => [
                                 'data-help' => 'entity.edit.information.logoUrl',
                                 'data-parsley-urlstrict' => null,
@@ -181,6 +185,7 @@ class EntityType extends AbstractType
                         'nameNl',
                         TextType::class,
                         [
+                            'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.nameNl'],
                         ]
                     )
@@ -188,6 +193,7 @@ class EntityType extends AbstractType
                         'descriptionNl',
                         TextareaType::class,
                         [
+                            'required' => false,
                             'attr' => [
                                 'data-help' => 'entity.edit.information.descriptionNl',
                                 'rows' => 10,
@@ -198,6 +204,7 @@ class EntityType extends AbstractType
                         'nameEn',
                         TextType::class,
                         [
+                            'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.nameEn'],
                         ]
                     )
@@ -205,6 +212,7 @@ class EntityType extends AbstractType
                         'descriptionEn',
                         TextareaType::class,
                         [
+                            'required' => false,
                             'attr' => [
                                 'data-help' => 'entity.edit.information.descriptionEn',
                                 'rows' => 10,
@@ -215,6 +223,7 @@ class EntityType extends AbstractType
                         'applicationUrl',
                         UrlType::class,
                         [
+                            'required' => false,
                             'attr' => [
                                 'data-help' => 'entity.edit.information.applicationUrl',
                                 'data-parsley-urlstrict' => null,
@@ -226,6 +235,7 @@ class EntityType extends AbstractType
                         'eulaUrl',
                         UrlType::class,
                         [
+                            'required' => false,
                             'attr' => [
                                 'data-help' => 'entity.edit.information.eulaUrl',
                                 'data-parsley-urlstrict' => null,


### PR DESCRIPTION
When a value is entered, it must be valid but the form can always be
saved with empty fields. Requiredness is checked on publication.