### PR TITLE
Introduce a word-threshold configuration option

### DIFF
--- a/app/js/components/validation.js
+++ b/app/js/components/validation.js
@@ -66,6 +66,13 @@ if (form.length) {
 
     function descriptionHasEnoughWords(input) {
         let val = input.val();
+        let wordThreshold = 10;
+
+        const configuredThreshold = input.data('word-threshold');
+
+        if (configuredThreshold && Number.isInteger(configuredThreshold)) {
+            wordThreshold = input.data('word-threshold');
+        }
 
         // See service_edit_attribute.js, it stores the value of a
         // disabled attribute in 'data-old-value', and restoring that
@@ -76,7 +83,7 @@ if (form.length) {
 
         const words = val.split(' ').filter(v => v !== "");
 
-        return (val === '' || words.length >= 10);
+        return (val === '' || words.length >= wordThreshold);
     }
 
     function showWarning(errorContainer, warning) {

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/AttributeType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/AttributeType.php
@@ -37,7 +37,8 @@ class AttributeType extends AbstractType
                 'attr' => [
                     'class' => 'motivation',
                     'placeholder' => 'entity.edit.attribute_input_placeholder',
-                    'data-motivation-keep-talking' => 'entity.edit.motivation.keep_talking'
+                    'data-motivation-keep-talking' => 'entity.edit.motivation.keep_talking',
+                    'data-word-threshold' => 3,
                 ],
             ]
         );


### PR DESCRIPTION
TextTypes with the 'keep talking' feature can now also be set with an
optional word-threshold attribute. Should be set with an integer value.
When the attribute is omitted the default (set to 10) word threshold
will be used.

The attribute motivation TextTypes are now configured to set a three
word input warning threshold.

See pivotal https://www.pivotaltracker.com/story/show/158141820