### PR TITLE
Allow basic HTTP authentication for SP dashboard vhost

### DIFF
--- a/ansible/roles/spdashboard/templates/spdashboard.conf.j2
+++ b/ansible/roles/spdashboard/templates/spdashboard.conf.j2
@@ -8,6 +8,7 @@ Listen {{ apache_app_listen_address.spdashboard }}:{{ loadbalancing.spdashboard.
     ServerAdmin {{ apache_server_admin }}
     Options -indexes +Includes
     DocumentRoot {{ spdashboard_document_root }}
+    SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
     SetEnv HTTPS on
 
     <Directory {{ spdashboard_document_root }}>


### PR DESCRIPTION
PHP under fcgi doesn't parse the Authorization header into PHP_AUTH_*
$_SERVER variables. Symfony requires this to work. This commit changes
the vhost configuration to copy the contents of Authorization into an
environment variable HTTP_AUTHORIZATION.

EngineBlock API already uses this rule in its configuration.