### PR TITLE
Use RSA-SHA256 as signature algorithm for service providers

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
@@ -159,6 +159,7 @@ class JsonGenerator implements GeneratorInterface
                 'name:en' => $entity->getNameEn(),
                 'name:nl' => $entity->getNameNl(),
             ],
+            $this->generateSecurityMetadata($entity),
             $this->generateAllContactsMetadata($entity),
             $this->generateOrganizationMetadata($entity),
             $this->motivationMetadataGenerator->build($entity),
@@ -166,14 +167,25 @@ class JsonGenerator implements GeneratorInterface
             $this->spDashboardMetadataGenerator->build($entity)
         );
 
+        if (!empty($entity->getLogoUrl())) {
+            $metadata += $this->generateLogoMetadata($entity);
+        }
+
+        return $metadata;
+    }
+
+    /**
+     * @param Entity $entity
+     * @return array
+     */
+    private function generateSecurityMetadata(Entity $entity)
+    {
+        $metadata['coin:signature_method'] = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
+
         if (!empty($entity->getCertificate())) {
             $metadata['certData'] = $this->stripCertificateEnvelope(
                 $entity->getCertificate()
             );
-        }
-
-        if (!empty($entity->getLogoUrl())) {
-            $metadata += $this->generateLogoMetadata($entity);
         }
 
         return $metadata;

--- a/tests/unit/Application/Metadata/JsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/JsonGeneratorTest.php
@@ -100,6 +100,7 @@ class JsonGeneratorTest extends MockeryTestCase
 
         $fields = $metadata['metaDataFields'];
 
+        $this->assertEquals('http://www.w3.org/2001/04/xmldsig-more#rsa-sha256', $fields['coin:signature_method']);
         $this->assertEquals('privacy', $fields['privacy']);
         $this->assertEquals('motivation', $fields['motivation']);
         $this->assertEquals('sp', $fields['sp']);
@@ -150,6 +151,7 @@ class JsonGeneratorTest extends MockeryTestCase
         $this->assertEquals('revisionnote', $metadata['revisionnote']);
         $this->assertEquals(['arp' => 'arp'], $metadata['arp']);
 
+        $this->assertEquals('http://www.w3.org/2001/04/xmldsig-more#rsa-sha256', $metadata['metaDataFields.coin:signature_method']);
         $this->assertEquals('privacy', $metadata['metaDataFields.privacy']);
         $this->assertEquals('motivation', $metadata['metaDataFields.motivation']);
         $this->assertEquals('sp', $metadata['metaDataFields.sp']);


### PR DESCRIPTION
All service providers should use RSA-SHA256, if new service providers
don't support it, we want to know about it as early as possible.

See: https://www.pivotaltracker.com/story/show/158296323