### PR TITLE
Add contact information to production publication e-mail

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/PublishEntityProductionCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/PublishEntityProductionCommand.php
@@ -19,7 +19,6 @@
 namespace Surfnet\ServiceProviderDashboard\Application\Command\Entity;
 
 use Surfnet\ServiceProviderDashboard\Application\Command\Command;
-use Surfnet\ServiceProviderDashboard\Domain\Mailer\Message;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class PublishEntityProductionCommand implements Command
@@ -32,18 +31,11 @@ class PublishEntityProductionCommand implements Command
     private $id;
 
     /**
-     * @var Message
-     */
-    private $message;
-
-    /**
      * @param string $id
-     * @param Message $message
      */
-    public function __construct($id, Message $message)
+    public function __construct($id)
     {
         $this->id = $id;
-        $this->message = $message;
     }
 
     /**
@@ -52,13 +44,5 @@ class PublishEntityProductionCommand implements Command
     public function getId()
     {
         return $this->id;
-    }
-
-    /**
-     * @return Message
-     */
-    public function getMessage()
-    {
-        return $this->message;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Exception/NotAuthenticatedException.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Exception/NotAuthenticatedException.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Exception;
+
+use Exception;
+
+class NotAuthenticatedException extends Exception
+{
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityControllerTrait.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityControllerTrait.php
@@ -64,11 +64,6 @@ trait EntityControllerTrait
     private $authorizationService;
 
     /**
-     * @var MailMessageFactory
-     */
-    private $mailMessageFactory;
-
-    /**
      * @param CommandBus $commandBus
      * @param EntityService $entityService
      * @param ServiceService $serviceService
@@ -79,14 +74,12 @@ trait EntityControllerTrait
         CommandBus $commandBus,
         EntityService $entityService,
         ServiceService $serviceService,
-        AuthorizationService $authorizationService,
-        MailMessageFactory $mailMessageFactory
+        AuthorizationService $authorizationService
     ) {
         $this->commandBus = $commandBus;
         $this->entityService = $entityService;
         $this->serviceService = $serviceService;
         $this->authorizationService = $authorizationService;
-        $this->mailMessageFactory = $mailMessageFactory;
     }
 
     /**
@@ -147,8 +140,7 @@ trait EntityControllerTrait
                 break;
 
             case Entity::ENVIRONMENT_PRODUCTION:
-                $message = $this->mailMessageFactory->buildPublishToProductionMessage($entity);
-                $publishEntityCommand = new PublishEntityProductionCommand($entity->getId(), $message);
+                $publishEntityCommand = new PublishEntityProductionCommand($entity->getId());
                 $this->commandBus->handle($publishEntityCommand);
                 return $this->redirectToRoute('entity_published_production', ['id' => $entity->getId()]);
                 break;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Factory/MailMessageFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Factory/MailMessageFactory.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Factory;
 
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Mailer\Message;
 use Symfony\Component\Templating\EngineInterface;
@@ -77,7 +78,7 @@ class MailMessageFactory
         $this->templating = $templating;
     }
 
-    public function buildPublishToProductionMessage(Entity $entity)
+    public function buildPublishToProductionMessage(Entity $entity, Contact $contact)
     {
         $message = $this->createNewMessage();
         $message->setSubject(
@@ -89,7 +90,10 @@ class MailMessageFactory
 
         $template = $this->renderView(
             '@Dashboard/Mail/published.html.twig',
-            ['entity' => $entity]
+            [
+                'entity' => $entity,
+                'contact' => $contact,
+            ]
         );
 
         $message->setBody($template, 'text/html');

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Mail/published.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Mail/published.html.twig
@@ -2,12 +2,15 @@
 Hi,<br/>
 
 <p>
-    A {{ entity.environment }} SP Dashboard registration has just been finished. <br />
-
+    A {{ entity.environment }} SP Dashboard registration has just been finished.
+</p>
+<p>
     Link to Metadata:
     <a href="{{ url('entity_metadata', {entityId: entity.id} ) }}">
         {{ url('entity_metadata', {entityId: entity.id} ) }}
     </a>
+    <br>
+    Published by: {{ contact.displayName }} &lt;{{ contact.emailAddress }}&gt;
 </p>
 
 <dl class="dl-horizontal">

--- a/tests/integration/Application/CommandHandler/Entity/PublishEntityProductionCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/PublishEntityProductionCommandHandlerTest.php
@@ -26,9 +26,14 @@ use Psr\Log\LoggerInterface;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityCommand;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityProductionCommand;
 use Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\PublishEntityProductionCommandHandler;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Mailer\Message;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityRepository;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Factory\MailMessageFactory;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Token\SamlToken;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Identity;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
 {
@@ -49,6 +54,16 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
     private $commandBus;
 
     /**
+     * @var MailMessageFactory|Mock
+     */
+    private $mailMessageFactory;
+
+    /**
+     * @var TokenStorageInterface|Mock
+     */
+    private $tokenStorage;
+
+    /**
      * @var LoggerInterface|Mock
      */
     private $logger;
@@ -56,13 +71,17 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
     public function setUp()
     {
 
-        $this->logger = m::mock(LoggerInterface::class);
         $this->repository = m::mock(EntityRepository::class);
         $this->commandBus = m::mock(CommandBus::class);
+        $this->mailMessageFactory = m::mock(MailMessageFactory::class);
+        $this->tokenStorage = m::mock(TokenStorageInterface::class);
+        $this->logger = m::mock(LoggerInterface::class);
 
         $this->commandHandler = new PublishEntityProductionCommandHandler(
             $this->repository,
             $this->commandBus,
+            $this->mailMessageFactory,
+            $this->tokenStorage,
             $this->logger
         );
 
@@ -72,8 +91,13 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
 
     public function test_it_can_publish()
     {
-        $entity = m::mock(Entity::class);
+        $contact = new Contact('nameid', 'name@example.org', 'display name');
+        $user = new Identity($contact);
 
+        $token = new SamlToken([]);
+        $token->setUser($user);
+
+        $entity = m::mock(Entity::class);
         $entity
             ->shouldReceive('getNameEn')
             ->andReturn('Test Entity Name');
@@ -95,13 +119,21 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
             ->shouldReceive('handle')
             ->once();
 
+        $this->tokenStorage->shouldReceive('getToken')
+            ->andReturn($token);
+
+        $message = m::mock(Message::class);
+
+        $this->mailMessageFactory->shouldReceive('buildPublishToProductionMessage')
+            ->with($entity, $contact)
+            ->andReturn($message);
+
         $this->logger
             ->shouldReceive('info')
             ->times(2);
 
-        $message = m::mock(Message::class);
 
-        $command = new PublishEntityProductionCommand('d6f394b2-08b1-4882-8b32-81688c15c489', $message);
+        $command = new PublishEntityProductionCommand('d6f394b2-08b1-4882-8b32-81688c15c489');
         $this->commandHandler->handle($command);
     }
 }

--- a/tests/unit/Infrastructure/DashboardBundle/Factory/MailMessageFactoryTest.php
+++ b/tests/unit/Infrastructure/DashboardBundle/Factory/MailMessageFactoryTest.php
@@ -20,6 +20,7 @@ namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\DashboardBu
 
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Factory\MailMessageFactory;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Mailer\Message;
@@ -71,7 +72,11 @@ class MailMessageFactoryTest extends MockeryTestCase
         $this->templateEngine
             ->shouldReceive('render');
 
-        $message = $this->factory->buildPublishToProductionMessage($entity);
+        $message = $this->factory->buildPublishToProductionMessage(
+            $entity,
+            new Contact('nameid', 'name@example.org', 'display name')
+        );
+
         $this->assertInstanceOf(Message::class, $message);
     }
 }

--- a/tests/webtests/EntityPublishToProductionTest.php
+++ b/tests/webtests/EntityPublishToProductionTest.php
@@ -19,6 +19,7 @@
 namespace Surfnet\ServiceProviderDashboard\Webtests;
 
 use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\MessageInterface;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Supplier;
@@ -72,7 +73,7 @@ class EntityPublishToProductionTest extends WebTestCase
         $entity->setEntityId('https://domain.org/saml/sp/saml2-post/default-sp/metadata');
         $entity->setMetadataUrl('https://domain.org/saml/sp/saml2-post/default-sp/metadata');
         $entity->setAcsLocation('https://domain.org/saml/sp/saml2-post/default-sp/acs');
-        $entity->setCertificate(file_get_contents(__DIR__ . '/fixtures/publish/valid.cer'));
+        $entity->setCertificate(file_get_contents(__DIR__.'/fixtures/publish/valid.cer'));
         $entity->setLogoUrl('http://localhost/img.png');
         $entity->setService($service);
         $entity->setNameEn('MyService');
@@ -84,7 +85,7 @@ class EntityPublishToProductionTest extends WebTestCase
         $entity->setTechnicalContact($this->buildContact());
         $entity->setSupportContact($this->buildContact());
         $entity->setEnvironment(Entity::ENVIRONMENT_PRODUCTION);
-        $entity->setMetadataXml(file_get_contents(__DIR__ . '/fixtures/publish/metadata.xml'));
+        $entity->setMetadataXml(file_get_contents(__DIR__.'/fixtures/publish/metadata.xml'));
 
         return $entity;
     }
@@ -97,6 +98,7 @@ class EntityPublishToProductionTest extends WebTestCase
             ->setLastName($lastName)
             ->setEmail($email)
             ->setPhone($phone);
+
         return $contact;
     }
 
@@ -132,6 +134,13 @@ class EntityPublishToProductionTest extends WebTestCase
         $this->assertEquals(
             'Production connection has been requested (https://domain.org/saml/sp/saml2-post/default-sp/metadata)',
             $sentMail[0]->getSubject()
+        );
+
+        // @see \Surfnet\ServiceProviderDashboard\Webtests\WebTestCase::logIn
+        $this->assertContains(
+            'Published by: John Doe &lt;johndoe@localhost&gt;',
+            $sentMail[0]->getBody(),
+            'The message should contain the contacts of the publisher (currently logged in user)'
         );
     }
 


### PR DESCRIPTION
The contact information (display name + email address) is shown in the
e-mail sent when publishing an entity to production.

    ...
    Link to Metadata: https://spdashboard.dev.support.surfconext.nl/entity/metadata/2f4ee070-6f00-11e8-88f4-97d5d5b83948
    Published by: John Doe <j.doe@example.com>
    ...

See: https://www.pivotaltracker.com/story/show/157114703