### PR TITLE
Loosen PHPMD CBO threshold

### DIFF
--- a/phpmd.xml
+++ b/phpmd.xml
@@ -20,7 +20,15 @@
 
     <rule ref="rulesets/controversial.xml" />
 
-    <rule ref="rulesets/design.xml" />
+    <rule ref="rulesets/design.xml">
+        <exclude name="CouplingBetweenObjects" />
+    </rule>
+
+    <rule ref="rulesets/design.xml/CouplingBetweenObjects">
+        <properties>
+            <property name="minimum" value="20" />
+        </properties>
+    </rule>
 
     <rule ref="rulesets/naming.xml">
         <exclude name="ShortVariable" />


### PR DESCRIPTION
The CouplingBetweenObjects rule now has a threshold of 20, which is
the same threshold as PMD itself uses.