### PR TITLE
Set curl timeout on logo downloads

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/CurlLogoValidationHelper.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/CurlLogoValidationHelper.php
@@ -51,6 +51,8 @@ class CurlLogoValidationHelper implements LogoValidationHelperInterface
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_VERBOSE, 1);
         curl_setopt($ch, CURLOPT_HEADER, 1);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 10);
 
         curl_exec($ch);
 


### PR DESCRIPTION
The timeout is now set at ten seconds for both the connect timeout
and the entire running time of the curl request.

:warning: The build fails on the security checker. The recommended updates will be installed in another PR. Either merge this PR with the failing build or rebase onto afore mentioned PR.

See: https://www.pivotaltracker.com/story/show/158383467
See: https://github.com/SURFnet/sp-dashboard/pull/147 (composer update)