### PR TITLE
Disable privacy questions service status

### DIFF
--- a/app/DoctrineMigrations/Version20181107134447.php
+++ b/app/DoctrineMigrations/Version20181107134447.php
@@ -6,9 +6,18 @@ use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
 /**
- * Add required service status columns for better status tracking
+ * Add required service status columns for better status tracking.
+ * And fill the existing records with sensible default values.
+ *
+ * The following default are set for:
+ *
+ *  | Column           | Value          | Matching Service entity constant
+ *  |==================|================|====================================
+ *  | service_type     | non-institute  | Service::SERVICE_TYPE_NON_INSTITUTE
+ *  | intake_status    | yes            | Service::INTAKE_STATUS_YES
+ *  | contract_signed  | yes            | Service::CONTRACT_SIGNED_YES
  */
-class Version20181106121253 extends AbstractMigration
+class Version20181107134447 extends AbstractMigration
 {
     /**
      * @param Schema $schema
@@ -27,8 +36,19 @@ class Version20181106121253 extends AbstractMigration
             ADD intake_status VARCHAR(50) NOT NULL, 
             ADD contract_signed VARCHAR(50) DEFAULT NULL, 
             ADD surfconext_representative_approved VARCHAR(50) DEFAULT NULL, 
-            ADD privacy_questions_answered VARCHAR(50) DEFAULT NULL, 
             ADD connection_status VARCHAR(50) NOT NULL'
+        );
+
+        $this->addSql(
+            sprintf(
+                'UPDATE service SET 
+                service_type = "%s",
+                intake_status = "%s",
+                contract_signed = "%s"',
+                'non-institute',
+                'yes',
+                'yes'
+            )
         );
     }
 
@@ -49,7 +69,6 @@ class Version20181106121253 extends AbstractMigration
             DROP intake_status, 
             DROP contract_signed, 
             DROP surfconext_representative_approved, 
-            DROP privacy_questions_answered, 
             DROP connection_status'
         );
     }

--- a/app/js/application.js
+++ b/app/js/application.js
@@ -2,6 +2,7 @@
 
 import 'jquery';
 import './components/service_switcher.js';
+import './components/service_status_interactions.js';
 import './components/validation.js';
 import './components/service_edit_attribute.js';
 import './components/translation_ui.js';

--- a/app/js/components/service_status_interactions.js
+++ b/app/js/components/service_status_interactions.js
@@ -1,0 +1,17 @@
+'use strict';
+
+
+function togglePrivacyQuestionsAnsweredStatusField(){
+    let privacyQuestionsStatusContainer = $('.privacy-questions-container');
+    let privacyQuestionsEnabledCheckbox = $(".privacy-questions-toggle");
+    if (privacyQuestionsEnabledCheckbox.is(':checked')) {
+        privacyQuestionsStatusContainer.find('input[type="radio"]').prop('disabled', false);
+    } else {
+        privacyQuestionsStatusContainer.find('input[type="radio"]').prop('disabled', true);
+    }
+}
+
+$(document).ready(function(){
+    $(".privacy-questions-toggle").on('change', togglePrivacyQuestionsAnsweredStatusField);
+    togglePrivacyQuestionsAnsweredStatusField();
+});

--- a/app/js/components/service_status_interactions.js
+++ b/app/js/components/service_status_interactions.js
@@ -5,9 +5,9 @@ function togglePrivacyQuestionsAnsweredStatusField(){
     let privacyQuestionsStatusContainer = $('.privacy-questions-container');
     let privacyQuestionsEnabledCheckbox = $(".privacy-questions-toggle");
     if (privacyQuestionsEnabledCheckbox.is(':checked')) {
-        privacyQuestionsStatusContainer.find('input[type="radio"]').prop('disabled', false);
+        privacyQuestionsStatusContainer.parent().show(200);
     } else {
-        privacyQuestionsStatusContainer.find('input[type="radio"]').prop('disabled', true);
+        privacyQuestionsStatusContainer.parent().hide();
     }
 }
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/CreateServiceCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/CreateServiceCommand.php
@@ -76,11 +76,6 @@ class CreateServiceCommand implements Command
 
     /**
      * @var string
-     */
-    private $privacyQuestionsAnswered = Service::PRIVACY_QUESTIONS_ANSWERED_NO;
-
-    /**
-     * @var string
      * @Assert\NotBlank
      */
     private $connectionStatus = Service::CONNECTION_STATUS_NOT_REQUESTED;
@@ -154,14 +149,6 @@ class CreateServiceCommand implements Command
     public function setSurfconextRepresentativeApproved($surfconextRepresentativeApproved)
     {
         $this->surfconextRepresentativeApproved = $surfconextRepresentativeApproved;
-    }
-
-    /**
-     * @param string $privacyQuestionsAnswered
-     */
-    public function setPrivacyQuestionsAnswered($privacyQuestionsAnswered)
-    {
-        $this->privacyQuestionsAnswered = $privacyQuestionsAnswered;
     }
 
     /**
@@ -247,16 +234,17 @@ class CreateServiceCommand implements Command
     /**
      * @return string
      */
-    public function getPrivacyQuestionsAnswered()
-    {
-        return $this->privacyQuestionsAnswered;
-    }
-
-    /**
-     * @return string
-     */
     public function getConnectionStatus()
     {
         return $this->connectionStatus;
+    }
+
+    /**
+     * New services have no privacy questions answers yet.
+     * @return bool
+     */
+    public function hasPrivacyQuestionsAnswered()
+    {
+        return false;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/EditServiceCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/EditServiceCommand.php
@@ -215,7 +215,7 @@ class EditServiceCommand implements Command
     }
 
     /**
-     * @param string $privacyQuestionsAnswered
+     * @param bool $privacyQuestionsAnswered
      */
     public function setPrivacyQuestionsAnswered($privacyQuestionsAnswered)
     {
@@ -295,9 +295,9 @@ class EditServiceCommand implements Command
     }
 
     /**
-     * @return string
+     * @return bool
      */
-    public function getPrivacyQuestionsAnswered()
+    public function isPrivacyQuestionsAnswered()
     {
         return $this->privacyQuestionsAnswered;
     }

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/CreateServiceCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/CreateServiceCommandHandler.php
@@ -55,7 +55,6 @@ class CreateServiceCommandHandler implements CommandHandler
         $service->setConnectionStatus($command->getConnectionStatus());
         $service->setContractSigned($command->getContractSigned());
         $service->setIntakeStatus($command->getIntakeStatus());
-        $service->setPrivacyQuestionsAnswered($command->getPrivacyQuestionsAnswered());
         $service->setSurfconextRepresentativeApproved($command->getSurfconextRepresentativeApproved());
 
         $this->serviceRepository->isUnique($service);

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/EditServiceCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/EditServiceCommandHandler.php
@@ -62,7 +62,6 @@ class EditServiceCommandHandler implements CommandHandler
         $service->setConnectionStatus($command->getConnectionStatus());
         $service->setContractSigned($command->getContractSigned());
         $service->setIntakeStatus($command->getIntakeStatus());
-        $service->setPrivacyQuestionsAnswered($command->getPrivacyQuestionsAnswered());
         $service->setSurfconextRepresentativeApproved($command->getSurfconextRepresentativeApproved());
 
         $this->serviceRepository->isUnique($service);

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/ServiceStatusService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/ServiceStatusService.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Surfnet\ServiceProviderDashboard\Application\Service;
+
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\PrivacyQuestionsRepository;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\ServiceRepository;
+
+class ServiceStatusService
+{
+    /**
+     * @var PrivacyQuestionsRepository
+     */
+    private $privacyStatusRepository;
+
+    public function __construct(PrivacyQuestionsRepository $privacyQuestionsRepository)
+    {
+        $this->privacyStatusRepository = $privacyQuestionsRepository;
+    }
+
+    /**
+     * Test if the service has filled out privacy questions
+     *
+     * @param Service $service
+     * @return bool
+     */
+    public function hasPrivacyQuestions(Service $service)
+    {
+        if ($this->privacyStatusRepository->findByService($service)) {
+            // At some point, the privacy questions where answered (they might be all empty now but there is a record)
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
@@ -47,10 +47,6 @@ class Service
     const SURFCONEXT_APPROVED_YES = 'yes';
     const SURFCONEXT_APPROVED_NO = 'no';
 
-    // If privacyQuestionsEnabled: have privacy questions been filled? (null if disabled)
-    const PRIVACY_QUESTIONS_ANSWERED_YES = 'yes';
-    const PRIVACY_QUESTIONS_ANSWERED_NO = 'no';
-
     // Production connection status: (not-requested|requested|active|surfconext-informed)
     const CONNECTION_STATUS_NOT_REQUESTED = 'not-requested';
     const CONNECTION_STATUS_REQUESTED = 'requested';
@@ -124,12 +120,6 @@ class Service
      * @ORM\Column(length=50, nullable=true)
      */
     private $surfconextRepresentativeApproved;
-
-    /**
-     * @var string
-     * @ORM\Column(length=50, nullable=true)
-     */
-    private $privacyQuestionsAnswered;
 
     /**
      * @var string
@@ -363,22 +353,6 @@ class Service
     public function setSurfconextRepresentativeApproved($surfconextRepresentativeApproved)
     {
         $this->surfconextRepresentativeApproved = $surfconextRepresentativeApproved;
-    }
-
-    /**
-     * @return string
-     */
-    public function getPrivacyQuestionsAnswered()
-    {
-        return $this->privacyQuestionsAnswered;
-    }
-
-    /**
-     * @param string $privacyQuestionsAnswered
-     */
-    public function setPrivacyQuestionsAnswered($privacyQuestionsAnswered)
-    {
-        $this->privacyQuestionsAnswered = $privacyQuestionsAnswered;
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -29,6 +29,7 @@ use Surfnet\ServiceProviderDashboard\Application\Command\Service\EditServiceComm
 use Surfnet\ServiceProviderDashboard\Application\Exception\EntityNotFoundException;
 use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
 use Surfnet\ServiceProviderDashboard\Application\Service\ServiceService;
+use Surfnet\ServiceProviderDashboard\Application\Service\ServiceStatusService;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Command\Service\SelectServiceCommand;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\CreateServiceType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\EditServiceType;
@@ -57,18 +58,26 @@ class ServiceController extends Controller
     private $serviceService;
 
     /**
+     * @var ServiceStatusService
+     */
+    private $serviceStatusService;
+
+    /**
      * @param CommandBus $commandBus
      * @param AuthorizationService $authorizationService
      * @param ServiceService $serviceService
+     * @param ServiceStatusService $serviceStatusService
      */
     public function __construct(
         CommandBus $commandBus,
         AuthorizationService $authorizationService,
-        ServiceService $serviceService
+        ServiceService $serviceService,
+        ServiceStatusService $serviceStatusService
     ) {
         $this->commandBus = $commandBus;
         $this->authorizationService = $authorizationService;
         $this->serviceService = $serviceService;
+        $this->serviceStatusService = $serviceStatusService;
     }
 
     /**
@@ -135,7 +144,7 @@ class ServiceController extends Controller
             $service->getIntakeStatus(),
             $service->getContractSigned(),
             $service->getSurfconextRepresentativeApproved(),
-            $service->getPrivacyQuestionsAnswered(),
+            $this->serviceStatusService->hasPrivacyQuestions($service),
             $service->getConnectionStatus()
         );
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DataFixtures/ORM/WebTestFixtures.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DataFixtures/ORM/WebTestFixtures.php
@@ -22,6 +22,7 @@ use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
 
@@ -42,7 +43,12 @@ class WebTestFixtures extends Fixture
 
         $service =  $this->createService('Ibuildings B.V.', 'urn:collab:org:ibuildings.nl');
         $service->setProductionEntitiesEnabled(true);
+        $service->setPrivacyQuestionsEnabled(true);
         $manager->persist($service);
+
+        // Service Ibuildings B.V. also has privacy questions
+        $privacyQuestions = $this->createPrivacyQuestions($service);
+        $manager->persist($privacyQuestions);
 
         $manager->flush();
     }
@@ -97,5 +103,14 @@ class WebTestFixtures extends Fixture
         $contact->setEmail($email);
 
         return $contact;
+    }
+
+    private function createPrivacyQuestions(Service $service)
+    {
+        $privacyQuestions = new PrivacyQuestions();
+        $privacyQuestions->setService($service);
+        $privacyQuestions->setWhatData('All your data are belong to us');
+
+        return $privacyQuestions;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/CreateServiceType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/CreateServiceType.php
@@ -40,10 +40,8 @@ class CreateServiceType extends AbstractType
             ->add('name')
             ->add('teamName')
             ->add('productionEntitiesEnabled', CheckboxType::class)
-            ->add('privacyQuestionsEnabled', CheckboxType::class)
+            ->add('privacyQuestionsEnabled', CheckboxType::class, ['attr' => ['class' => 'privacy-questions-toggle']])
 
-            ->add('productionEntitiesEnabled', CheckboxType::class)
-            ->add('privacyQuestionsEnabled', CheckboxType::class)
             ->add('serviceType', ServiceTypeType::class)
             ->add('intakeStatus', IntakeStatusType::class)
             ->add('contractSigned', ContractSignedType::class)

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/EditServiceType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/EditServiceType.php
@@ -41,7 +41,8 @@ class EditServiceType extends AbstractType
             ->add('teamName')
 
             ->add('productionEntitiesEnabled', CheckboxType::class)
-            ->add('privacyQuestionsEnabled', CheckboxType::class)
+            ->add('privacyQuestionsEnabled', CheckboxType::class, ['attr' => ['class' => 'privacy-questions-toggle']])
+
             ->add('serviceType', ServiceTypeType::class)
             ->add('intakeStatus', IntakeStatusType::class)
             ->add('contractSigned', ContractSignedType::class)

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Service/PrivacyQuestionAnsweredType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Service/PrivacyQuestionAnsweredType.php
@@ -35,7 +35,7 @@ class PrivacyQuestionAnsweredType extends AbstractType
                 'service.form.label.privacy_question_answered_no' => Service::PRIVACY_QUESTIONS_ANSWERED_NO,
                 'service.form.label.privacy_question_answered_yes' => Service::PRIVACY_QUESTIONS_ANSWERED_YES,
             ],
-            'attr' => ['class' => 'service-status-container'],
+            'attr' => ['class' => 'service-status-container privacy-questions-container'],
         ]);
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Service/PrivacyQuestionAnsweredType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Service/PrivacyQuestionAnsweredType.php
@@ -31,9 +31,10 @@ class PrivacyQuestionAnsweredType extends AbstractType
             'label' => 'service.form.label.privacy_question_answered',
             'expanded' => true,
             'multiple' => false,
+            'disabled' => true,
             'choices' => [
-                'service.form.label.privacy_question_answered_no' => Service::PRIVACY_QUESTIONS_ANSWERED_NO,
-                'service.form.label.privacy_question_answered_yes' => Service::PRIVACY_QUESTIONS_ANSWERED_YES,
+                'service.form.label.privacy_question_answered_no' => false,
+                'service.form.label.privacy_question_answered_yes' => true,
             ],
             'attr' => ['class' => 'service-status-container privacy-questions-container'],
         ]);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -164,7 +164,7 @@ service.edit.title: Edit service
 service.form.label.connection_status: Connection status
 service.form.label.connection_status_not_requested: Not requested
 service.form.label.connection_status_requested: Requested
-service.form.label.connection_status_informed: Infromed
+service.form.label.connection_status_informed: Informed
 service.form.label.connection_status_active: Active
 service.form.label.contract_signed: Contract signed
 service.form.label.contract_signed_no: No

--- a/tests/integration/Application/CommandHandler/Service/CreateServiceCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Service/CreateServiceCommandHandlerTest.php
@@ -53,7 +53,6 @@ class CreateServiceCommandHandlerTest extends MockeryTestCase
         $service->setPrivacyQuestionsEnabled(true);
         $service->setProductionEntitiesEnabled(true);
 
-        $service->setPrivacyQuestionsAnswered('yes');
         $service->setServiceType('institution');
         $service->setIntakeStatus('yes');
         $service->setSurfconextRepresentativeApproved('yes');
@@ -67,7 +66,6 @@ class CreateServiceCommandHandlerTest extends MockeryTestCase
         $command->setPrivacyQuestionsEnabled($service->isPrivacyQuestionsEnabled());
         $command->setProductionEntitiesEnabled($service->isProductionEntitiesEnabled());
 
-        $command->setPrivacyQuestionsAnswered($service->getPrivacyQuestionsAnswered());
         $command->setServiceType($service->getServiceType());
         $command->setIntakeStatus($service->getIntakeStatus());
         $command->setSurfconextRepresentativeApproved($service->getSurfconextRepresentativeApproved());
@@ -94,7 +92,6 @@ class CreateServiceCommandHandlerTest extends MockeryTestCase
         $command->setProductionEntitiesEnabled(true);
         $command->setPrivacyQuestionsEnabled(false);
 
-        $command->setPrivacyQuestionsAnswered('yes');
         $command->setServiceType('institution');
         $command->setIntakeStatus('yes');
         $command->setSurfconextRepresentativeApproved('yes');

--- a/tests/integration/Application/CommandHandler/Service/EditServiceCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Service/EditServiceCommandHandlerTest.php
@@ -58,7 +58,7 @@ class EditServiceCommandHandlerTest extends MockeryTestCase
             'not-applicable',
             'no',
             'no',
-            'yes',
+            true,
             'active'
         );
         $command->setName('Foobar');
@@ -120,7 +120,7 @@ class EditServiceCommandHandlerTest extends MockeryTestCase
             'not-applicable',
             'no',
             'no',
-            'yes',
+            true,
             'active'
         );
 
@@ -147,7 +147,7 @@ class EditServiceCommandHandlerTest extends MockeryTestCase
             'not-applicable',
             'no',
             'no',
-            'yes',
+            true,
             'active'
         );
 

--- a/tests/webtests/EditServiceTest.php
+++ b/tests/webtests/EditServiceTest.php
@@ -132,4 +132,20 @@ class EditServiceTest extends WebTestCase
         $this->client->request('GET', '/service/privacy');
         $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
     }
+
+    public function test_privacy_questions_filled_status_is_reflected_correctly()
+    {
+        // Log in with Ibuildings
+        $this->logIn('ROLE_ADMINISTRATOR');
+        $this->loadFixtures();
+        $this->switchToService('Ibuildings B.V.');
+
+        $crawler = $this->client->request('GET', '/service/edit');
+
+        $radio = $crawler->filter('#dashboard_bundle_edit_service_type_privacyQuestionsAnswered_1');
+        // The checked element should be the 'Yes' radio option as the ibuildings service has a privacy questions entity
+        $this->assertEquals(1, $radio->attr('value'));
+        // The radio is disabled
+        $this->assertEquals('disabled', $radio->attr('disabled'));
+    }
 }

--- a/tests/webtests/WebTestCase.php
+++ b/tests/webtests/WebTestCase.php
@@ -34,6 +34,7 @@ use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as SymfonyWebTestCase;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\Debug\Debug;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class WebTestCase extends SymfonyWebTestCase
 {
@@ -122,6 +123,32 @@ class WebTestCase extends SymfonyWebTestCase
         $cookie = new Cookie($session->getName(), $session->getId());
 
         $this->client->getCookieJar()->set($cookie);
+    }
+
+    /**
+     * @param $serviceName
+     * @return \Symfony\Component\DomCrawler\Crawler
+     * @throws \Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException
+     */
+    protected function switchToService($serviceName)
+    {
+        $crawler = $this->client->request('GET', '/service/create');
+        $form = $crawler->filter('.service-switcher')
+            ->selectButton('Select')
+            ->form();
+
+        $form['service']->select(
+            $this->getServiceRepository()->findByName($serviceName)->getId()
+        );
+
+        $this->client->submit($form);
+
+        $this->assertTrue(
+            $this->client->getResponse() instanceof RedirectResponse,
+            'Expecting a redirect response after selecting a service'
+        );
+
+        return $this->client->followRedirect();
     }
 
     /**


### PR DESCRIPTION
:warning: Review and merge #149 first!

The privacy questions service status radio group is disabled when
privacy questions are not enabled for the service.