### PR TITLE
 Verify privacy questions are displayed correctly 

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DataFixtures/ORM/WebTestFixtures.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DataFixtures/ORM/WebTestFixtures.php
@@ -22,6 +22,7 @@ use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
 
@@ -42,7 +43,12 @@ class WebTestFixtures extends Fixture
 
         $service =  $this->createService('Ibuildings B.V.', 'urn:collab:org:ibuildings.nl');
         $service->setProductionEntitiesEnabled(true);
+        $service->setPrivacyQuestionsEnabled(true);
         $manager->persist($service);
+
+        // Service Ibuildings B.V. also has privacy questions
+        $privacyQuestions = $this->createPrivacyQuestions($service);
+        $manager->persist($privacyQuestions);
 
         $manager->flush();
     }
@@ -97,5 +103,14 @@ class WebTestFixtures extends Fixture
         $contact->setEmail($email);
 
         return $contact;
+    }
+
+    private function createPrivacyQuestions(Service $service)
+    {
+        $privacyQuestions = new PrivacyQuestions();
+        $privacyQuestions->setService($service);
+        $privacyQuestions->setWhatData('All your data are belong to us');
+
+        return $privacyQuestions;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -164,7 +164,7 @@ service.edit.title: Edit service
 service.form.label.connection_status: Connection status
 service.form.label.connection_status_not_requested: Not requested
 service.form.label.connection_status_requested: Requested
-service.form.label.connection_status_informed: Infromed
+service.form.label.connection_status_informed: Informed
 service.form.label.connection_status_active: Active
 service.form.label.contract_signed: Contract signed
 service.form.label.contract_signed_no: No

--- a/tests/webtests/EditServiceTest.php
+++ b/tests/webtests/EditServiceTest.php
@@ -132,4 +132,20 @@ class EditServiceTest extends WebTestCase
         $this->client->request('GET', '/service/privacy');
         $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
     }
+
+    public function test_privacy_questions_filled_status_is_reflected_correctly()
+    {
+        // Log in with Ibuildings
+        $this->logIn('ROLE_ADMINISTRATOR');
+        $this->loadFixtures();
+        $this->switchToService('Ibuildings B.V.');
+
+        $crawler = $this->client->request('GET', '/service/edit');
+
+        $radio = $crawler->filter('#dashboard_bundle_edit_service_type_privacyQuestionsAnswered_1');
+        // The checked element should be the 'Yes' radio option as the ibuildings service has a privacy questions entity
+        $this->assertEquals(1, $radio->attr('value'));
+        // The radio is disabled
+        $this->assertEquals('disabled', $radio->attr('disabled'));
+    }
 }

--- a/tests/webtests/WebTestCase.php
+++ b/tests/webtests/WebTestCase.php
@@ -34,6 +34,7 @@ use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as SymfonyWebTestCase;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\Debug\Debug;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class WebTestCase extends SymfonyWebTestCase
 {
@@ -122,6 +123,32 @@ class WebTestCase extends SymfonyWebTestCase
         $cookie = new Cookie($session->getName(), $session->getId());
 
         $this->client->getCookieJar()->set($cookie);
+    }
+
+    /**
+     * @param $serviceName
+     * @return \Symfony\Component\DomCrawler\Crawler
+     * @throws \Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException
+     */
+    protected function switchToService($serviceName)
+    {
+        $crawler = $this->client->request('GET', '/service/create');
+        $form = $crawler->filter('.service-switcher')
+            ->selectButton('Select')
+            ->form();
+
+        $form['service']->select(
+            $this->getServiceRepository()->findByName($serviceName)->getId()
+        );
+
+        $this->client->submit($form);
+
+        $this->assertTrue(
+            $this->client->getResponse() instanceof RedirectResponse,
+            'Expecting a redirect response after selecting a service'
+        );
+
+        return $this->client->followRedirect();
     }
 
     /**


### PR DESCRIPTION
First review #148 .. #152 
This adds a web test to the test suite that verifies the correct determination of the privacy questions filled service status option.