### PR TITLE
Display entity published state on service forms

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/CreateServiceCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/CreateServiceCommand.php
@@ -79,6 +79,12 @@ class CreateServiceCommand implements Command
      * @Assert\NotBlank
      */
     private $connectionStatus = Service::CONNECTION_STATUS_NOT_REQUESTED;
+
+    /**
+     * @var string
+     */
+    private $entityPublished = Service::ENTITY_PUBLISHED_NO;
+
     /**
      * @param string $guid
      */
@@ -246,5 +252,13 @@ class CreateServiceCommand implements Command
     public function hasPrivacyQuestionsAnswered()
     {
         return false;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEntityPublished()
+    {
+        return $this->entityPublished;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/EditServiceCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/EditServiceCommand.php
@@ -90,12 +90,17 @@ class EditServiceCommand implements Command
     private $connectionStatus;
 
     /**
+     * @var string
+     */
+    private $entityPublished;
+
+    /**
      * @SuppressWarnings(PHPMD.ExcessiveParameterList) - Could be decomposed, but for now makes no sense.
      *
      * @param int $id
      * @param string $guid
-     * @param string $teamName
      * @param string $name
+     * @param string $teamName
      * @param bool $productionEntitiesEnabled
      * @param bool $privacyQuestionsEnabled
      * @param string $serviceType
@@ -104,6 +109,7 @@ class EditServiceCommand implements Command
      * @param string $surfconextRepresentativeApproved
      * @param string $privacyQuestionsAnswered
      * @param string $connectionStatus
+     * @param string $entityPublished
      */
     public function __construct(
         $id,
@@ -117,7 +123,8 @@ class EditServiceCommand implements Command
         $contractSigned,
         $surfconextRepresentativeApproved,
         $privacyQuestionsAnswered,
-        $connectionStatus
+        $connectionStatus,
+        $entityPublished
     ) {
         $this->id = $id;
         $this->guid = $guid;
@@ -131,6 +138,7 @@ class EditServiceCommand implements Command
         $this->surfconextRepresentativeApproved = $surfconextRepresentativeApproved;
         $this->privacyQuestionsAnswered = $privacyQuestionsAnswered;
         $this->connectionStatus = $connectionStatus;
+        $this->entityPublished = $entityPublished;
     }
 
 
@@ -324,5 +332,13 @@ class EditServiceCommand implements Command
     public function isPrivacyQuestionsEnabled()
     {
         return $this->privacyQuestionsEnabled;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEntityPublished()
+    {
+        return $this->entityPublished;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
@@ -53,6 +53,10 @@ class Service
     const CONNECTION_STATUS_SURFCONEXT_INFORMED = 'surfconext-informed';
     const CONNECTION_STATUS_ACTIVE = 'active';
 
+    const ENTITY_PUBLISHED_NO = 'no';
+    const ENTITY_PUBLISHED_IN_PROGRESS = 'in-progress';
+    const ENTITY_PUBLISHED_YES = 'yes';
+
     /**
      * @var int
      *

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -145,7 +145,8 @@ class ServiceController extends Controller
             $service->getContractSigned(),
             $service->getSurfconextRepresentativeApproved(),
             $this->serviceStatusService->hasPrivacyQuestions($service),
-            $service->getConnectionStatus()
+            $service->getConnectionStatus(),
+            $this->serviceStatusService->getEntityStatus($service)
         );
 
         $form = $this->createForm(EditServiceType::class, $command);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/CreateServiceType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/CreateServiceType.php
@@ -21,6 +21,7 @@ namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form;
 use Surfnet\ServiceProviderDashboard\Application\Command\Service\CreateServiceCommand;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service\ConnectionStatusType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service\ContractSignedType;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service\EntityPublishedType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service\IntakeStatusType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service\PrivacyQuestionAnsweredType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service\RepresentativeApprovedType;
@@ -44,6 +45,7 @@ class CreateServiceType extends AbstractType
 
             ->add('serviceType', ServiceTypeType::class)
             ->add('intakeStatus', IntakeStatusType::class)
+            ->add('entityPublished', EntityPublishedType::class)
             ->add('contractSigned', ContractSignedType::class)
             ->add('surfconextRepresentativeApproved', RepresentativeApprovedType::class)
             ->add('privacyQuestionsAnswered', PrivacyQuestionAnsweredType::class)

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/EditServiceType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/EditServiceType.php
@@ -21,6 +21,7 @@ namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form;
 use Surfnet\ServiceProviderDashboard\Application\Command\Service\EditServiceCommand;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service\ConnectionStatusType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service\ContractSignedType;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service\EntityPublishedType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service\IntakeStatusType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service\PrivacyQuestionAnsweredType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service\RepresentativeApprovedType;
@@ -45,6 +46,7 @@ class EditServiceType extends AbstractType
 
             ->add('serviceType', ServiceTypeType::class)
             ->add('intakeStatus', IntakeStatusType::class)
+            ->add('entityPublished', EntityPublishedType::class)
             ->add('contractSigned', ContractSignedType::class)
             ->add('surfconextRepresentativeApproved', RepresentativeApprovedType::class)
             ->add('privacyQuestionsAnswered', PrivacyQuestionAnsweredType::class)

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Service/EntityPublishedType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Service/EntityPublishedType.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service;
+
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class EntityPublishedType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(
+            [
+                'label' => 'service.form.label.entity_published',
+                'expanded' => true,
+                'multiple' => false,
+                'disabled' => true,
+                'choices' => [
+                    'service.form.label.entity_published_no' => 'no',
+                    'service.form.label.entity_published_in_progress' => 'in-progress',
+                    'service.form.label.entity_published_yes' => 'yes',
+                ],
+                'attr' => ['class' => 'service-status-container'],
+            ]
+        );
+    }
+
+    public function getParent()
+    {
+        return ChoiceType::class;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -169,6 +169,10 @@ service.form.label.connection_status_active: Active
 service.form.label.contract_signed: Contract signed
 service.form.label.contract_signed_no: No
 service.form.label.contract_signed_yes: Yes
+service.form.label.entity_published: Entity published?
+service.form.label.entity_published_no: No
+service.form.label.entity_published_in_progress: In progress
+service.form.label.entity_published_yes: Yes
 service.form.label.intake_status: Intake finished
 service.form.label.intake_status_no: No
 service.form.label.intake_status_yes: Yes

--- a/tests/integration/Application/CommandHandler/Service/EditServiceCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Service/EditServiceCommandHandlerTest.php
@@ -59,7 +59,8 @@ class EditServiceCommandHandlerTest extends MockeryTestCase
             'no',
             'no',
             true,
-            'active'
+            'active',
+            'in-progress'
         );
         $command->setName('Foobar');
         $command->setTeamName('team-foobar');
@@ -121,7 +122,8 @@ class EditServiceCommandHandlerTest extends MockeryTestCase
             'no',
             'no',
             true,
-            'active'
+            'active',
+            'no'
         );
 
         $this->repository->shouldReceive('findById')->andReturn(null)->once();
@@ -148,7 +150,8 @@ class EditServiceCommandHandlerTest extends MockeryTestCase
             'no',
             'no',
             true,
-            'active'
+            'active',
+            'yes'
         );
 
         $mockEntity = m::mock(Service::class)->makePartial();

--- a/tests/unit/Application/Service/ServiceStatusServiceTest.php
+++ b/tests/unit/Application/Service/ServiceStatusServiceTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Application\Service;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Surfnet\ServiceProviderDashboard\Application\Service\EntityService;
+use Surfnet\ServiceProviderDashboard\Application\Service\ServiceStatusService;
+use Surfnet\ServiceProviderDashboard\Application\ViewObject\Entity as ViewObjectEntity;
+use Surfnet\ServiceProviderDashboard\Application\ViewObject\EntityList;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\PrivacyQuestionsRepository;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\ServiceRepository;
+
+class ServiceStatusServiceTest extends MockeryTestCase
+{
+    /** @var ServiceRepository|m\MockInterface */
+    private $repository;
+
+    /**
+     * @var EntityService|m\MockInterface
+     */
+    private $entityService;
+
+    /**
+     * @var ServiceStatusService
+     */
+    private $service;
+
+    public function setUp()
+    {
+        $this->repository = m::mock(PrivacyQuestionsRepository::class);
+        $this->entityService = m::mock(EntityService::class);
+        $this->service = new ServiceStatusService($this->repository, $this->entityService);
+    }
+
+    /**
+     * @dataProvider createEntityStatus
+     * @param EntityList $entities
+     * @param string $expectedStatus
+     * @param string $dataProviderContext provides information on what test data was used
+     */
+    public function test_it_displays_correct_entity_status(EntityList $entities, $expectedStatus, $dataProviderContext)
+    {
+        $service = m::mock(Service::class);
+
+        $this->entityService
+            ->shouldReceive('getEntityListForService')
+            ->with($service)
+            ->andReturn($entities);
+
+        $actualStatus = $this->service->getEntityStatus($service);
+        $this->assertEquals($expectedStatus, $actualStatus, $dataProviderContext);
+    }
+
+    public function createEntityStatus()
+    {
+        return [
+            [
+                $this->buildEntityList([]),
+                Service::ENTITY_PUBLISHED_NO,
+                'No entities are available for this service, so none are published.',
+            ],
+            [
+                $this->buildEntityList([0 => Entity::STATE_DRAFT]),
+                Service::ENTITY_PUBLISHED_IN_PROGRESS,
+                'One drafted entity should result in "in progress"',
+            ],
+            [
+                $this->buildEntityList([0 => Entity::STATE_DRAFT, 1 => Entity::STATE_DRAFT, 2 => Entity::STATE_DRAFT]),
+                Service::ENTITY_PUBLISHED_IN_PROGRESS,
+                'Multiple drafted entity should result in "in progress"',
+            ],
+            [
+                $this->buildEntityList([0 => Entity::STATE_PUBLISHED]),
+                Service::ENTITY_PUBLISHED_YES,
+                'One published entity should result in "yes"',
+            ],
+            [
+                $this->buildEntityList([0 => Entity::STATE_PUBLISHED, 1 => Entity::STATE_PUBLISHED]),
+                Service::ENTITY_PUBLISHED_YES,
+                'Multiple published entity should result in "yes"',
+            ],
+            [
+                $this->buildEntityList(
+                    [0 => Entity::STATE_DRAFT, 1 => Entity::STATE_PUBLISHED, 2 => Entity::STATE_DRAFT]
+                ),
+                Service::ENTITY_PUBLISHED_YES,
+                'Multiple mixed value published entity should result in "yes"',
+            ],
+        ];
+    }
+
+    private function buildEntityList(array $entities)
+    {
+        $entityList = [];
+        foreach ($entities as $key => $status) {
+            $mockEntity = m::mock(ViewObjectEntity::class);
+            $mockEntity
+                ->shouldReceive('getState')
+                ->andReturn($status);
+
+            $entityList[] = $mockEntity;
+        }
+        return new EntityList($entityList);
+    }
+}

--- a/tests/webtests/EditServiceTest.php
+++ b/tests/webtests/EditServiceTest.php
@@ -49,6 +49,9 @@ class EditServiceTest extends WebTestCase
             ]
         ];
 
+        // EntityService::getEntityListForService -> findByTeamName
+        $this->mockHandler->append(new Response(200, [], '[]'));
+
         $crawler = $this->client->request('GET', '/service/edit');
 
         $form = $crawler
@@ -73,6 +76,10 @@ class EditServiceTest extends WebTestCase
         $serviceRepository = $this->getServiceRepository();
 
         $this->logIn('ROLE_ADMINISTRATOR');
+
+        // EntityService::getEntityListForService -> findByTeamName
+        $this->mockHandler->append(new Response(200, [], '[]'));
+
         $crawler = $this->client->request('GET', '/service/edit');
 
         // Step 1: Admin sets privacy questions enabled to false
@@ -107,6 +114,11 @@ class EditServiceTest extends WebTestCase
 
         // Step 3: Admin enables the Privacy questions
         $this->logIn('ROLE_ADMINISTRATOR');
+
+        // EntityService::getEntityListForService -> findByTeamName (is called twice)
+        $this->mockHandler->append(new Response(200, [], '[]'));
+        $this->mockHandler->append(new Response(200, [], '[]'));
+
         $crawler = $this->client->request('GET', '/service/edit');
 
         $formData = [
@@ -139,6 +151,9 @@ class EditServiceTest extends WebTestCase
         $this->logIn('ROLE_ADMINISTRATOR');
         $this->loadFixtures();
         $this->switchToService('Ibuildings B.V.');
+
+        // EntityService::getEntityListForService -> findByTeamName
+        $this->mockHandler->append(new Response(200, [], '{}'));
 
         $crawler = $this->client->request('GET', '/service/edit');
 


### PR DESCRIPTION
The service reads the entities for the service and checks if any are published or drafted. If none of the above the status 'no' is returned, in the other cases 'yes' or 'in progress' are returned.

See: https://www.pivotaltracker.com/story/show/161341178