### PR TITLE
Specify manifest.json

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -32,7 +32,8 @@ framework:
         save_path:   "%kernel.root_dir%/../var/sessions/%kernel.environment%"
     fragments: ~
     http_method_override: true
-    assets: ~
+    assets:
+        json_manifest_path: '%kernel.project_dir%/web/build/manifest.json'
     php_errors:
         log: true
 


### PR DESCRIPTION
Encore in production mode now creates versioned js/css files to prevent
unwarranted caching at the client side. This however requires symfony
asset manager to be aware of which version to use. Conveniently encore
now dumps a manifest.json, which the asset manager can use to determine
which version of the assets should be used.

For more information read:
https://symfony.com/doc/3.4/frontend/encore/versioning.html#loading-assets-from-entrypoints-json-manifest-json