### PR TITLE
Introduction of the services overview page

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/ServiceService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/ServiceService.php
@@ -73,7 +73,7 @@ class ServiceService
             }
         }
 
-        asort($services);
+        ksort($services);
 
         return $services;
     }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/ServiceService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/ServiceService.php
@@ -59,14 +59,15 @@ class ServiceService
      *
      * Format [ '<service name>' => '<service entity>' ]
      *
-     * @param $serviceIds
+     * @param array $serviceNames The input should be service names keyed by service id.
+     *                            As provided by: AuthorizationService::getAllowedServiceNamesById
      * @return array
      */
-    public function getServicesByCurrentServiceIds($serviceIds)
+    public function getServicesByCurrentServiceIds(array $serviceNames)
     {
         $services = [];
 
-        foreach ($serviceIds as $serviceId => $serviceName) {
+        foreach ($serviceNames as $serviceId => $serviceName) {
             $service = $this->getServiceById($serviceId);
             if ($service) {
                 $services[$service->getName()] = $service;

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/ServiceService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/ServiceService.php
@@ -55,6 +55,30 @@ class ServiceService
     }
 
     /**
+     * Retrieve service entities based on an array keyed by service id
+     *
+     * Format [ '<service name>' => '<service entity>' ]
+     *
+     * @param $serviceIds
+     * @return array
+     */
+    public function getServicesByCurrentServiceIds($serviceIds)
+    {
+        $services = [];
+
+        foreach ($serviceIds as $serviceId => $serviceName) {
+            $service = $this->getServiceById($serviceId);
+            if ($service) {
+                $services[$service->getName()] = $service;
+            }
+        }
+
+        asort($services);
+
+        return $services;
+    }
+
+    /**
      * @param int $id
      *
      * @return Service|null

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityListController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityListController.php
@@ -60,7 +60,7 @@ class EntityListController extends Controller
 
     /**
      * @Method("GET")
-     * @Route("/", name="entity_list")
+     * @Route("/entities", name="entity_list")
      * @Security("has_role('ROLE_USER')")
      * @Template()
      *

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -188,14 +188,15 @@ class ServiceController extends Controller
     }
 
     /**
-     * @Method("POST")
+     * @Method({"GET", "POST"})
      * @Route("/service/select", name="select_service")
-     * @Security("has_role('ROLE_ADMINISTRATOR')")
+     * @Security("has_role('ROLE_USER')")
      */
     public function selectAction(Request $request)
     {
+        $serviceId = $request->get('service', $request->query->get('service'));
         $command = new SelectServiceCommand(
-            $request->request->get('service')
+            $serviceId
         );
 
         $this->commandBus->handle($command);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -87,10 +87,10 @@ class ServiceController extends Controller
      */
     public function overviewAction()
     {
-        $serviceOptions = $this->authorizationService->getAllowedServiceNamesById();
-        $services = $this->serviceService->getServicesByCurrentServiceIds($serviceOptions);
+        $allowedServices = $this->authorizationService->getAllowedServiceNamesById();
+        $services = $this->serviceService->getServicesByCurrentServiceIds($allowedServices);
 
-        if (empty($serviceOptions)) {
+        if (empty($services)) {
             return $this->redirectToRoute('service_add');
         }
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -81,6 +81,22 @@ class ServiceController extends Controller
     }
 
     /**
+     * @Method({"GET"})
+     * @Route("/", name="service_overview")
+     * @Template()
+     */
+    public function overviewAction()
+    {
+        $serviceOptions = $this->authorizationService->getAllowedServiceNamesById();
+
+        if (empty($serviceOptions)) {
+            return $this->redirectToRoute('service_add');
+        }
+
+        return $this->render('DashboardBundle:Service:overview.html.twig');
+    }
+    
+    /**
      * @Method({"GET", "POST"})
      * @Route("/service/create", name="service_add")
      * @Security("has_role('ROLE_ADMINISTRATOR')")

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -88,12 +88,15 @@ class ServiceController extends Controller
     public function overviewAction()
     {
         $serviceOptions = $this->authorizationService->getAllowedServiceNamesById();
+        $services = $this->serviceService->getServicesByCurrentServiceIds($serviceOptions);
 
         if (empty($serviceOptions)) {
             return $this->redirectToRoute('service_add');
         }
 
-        return $this->render('DashboardBundle:Service:overview.html.twig');
+        return $this->render('DashboardBundle:Service:overview.html.twig', [
+            'services' => $services
+        ]);
     }
     
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Menu/Builder.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Menu/Builder.php
@@ -37,6 +37,8 @@ class Builder
             return $menu;
         }
 
+        $menu->addChild('Services', ['route' => 'service_overview']);
+
         if ($this->authorizationService->hasActiveServiceId()) {
             $menu->addChild('My entities', array('route' => 'entity_list'));
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -182,6 +182,7 @@ service.form.label.representative_approved_yes: Yes
 service.form.label.service_type: Type of service
 service.form.label.service_type_institute: Institute
 service.form.label.service_type_non_institute: Not an institute
+service.overview.title: My services
 mail.confirmation.publish_production.comment: Comments
 mail.confirmation.publish_production.entity_id: EntityID
 mail.confirmation.publish_production.entity_name_en: Entity name (en)

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
@@ -1,0 +1,11 @@
+{% extends '::base.html.twig' %}
+
+{% block body %}
+
+    {% for service in services %}
+        <h1><a href="{{ path('select_service', {"service": service.id }) }}">{{ service.name }}</a></h1>
+    {% endfor %}
+
+{% endblock %}
+
+{% block page_heading %}{{ 'service.overview.title'|trans }}{%endblock%}

--- a/tests/webtests/ServiceOverviewTest.php
+++ b/tests/webtests/ServiceOverviewTest.php
@@ -50,12 +50,17 @@ class ServiceOverviewTest extends WebTestCase
 
         $crawler = $this->client->request('GET', '/');
 
+        // By retrieving the h1 titles (stating the services) we can conclude if the correct data is displayed.
         $nodes = $crawler->filter('.card h1');
         $serviceNode = $nodes->first();
+
         $this->assertEquals('SURFnet', $serviceNode->text());
+
         $link = $serviceNode->filter('a')->first()->link();
 
+        // Clicking on the anchor, swithces the service context to clicked service.
         $this->client->click($link);
+        // The my entities page should now be open.
         $this->assertRegExp('#entities$#', $this->client->getResponse()->headers->get('location'));
     }
 
@@ -71,15 +76,17 @@ class ServiceOverviewTest extends WebTestCase
 
         $crawler = $this->client->request('GET', '/');
 
+        // By retrieving the h1 titles (stating the services) we can conclude if the correct data is displayed.
         $nodes = $crawler->filter('.card h1');
 
+        // Two services should be on page: surf and ibuildings.
         $this->assertEquals(2, $nodes->count());
 
         // The two nodes are sorted alphabetically.
         $serviceNode = $nodes->first();
-        $this->assertEquals('Ibuildings B.V.', $serviceNode->text());
-
         $service2 = $nodes->eq(1);
+
+        $this->assertEquals('Ibuildings B.V.', $serviceNode->text());
         $this->assertEquals('SURFnet', $service2->text());
     }
 

--- a/tests/webtests/ServiceOverviewTest.php
+++ b/tests/webtests/ServiceOverviewTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Webtests;
+
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+class ServiceOverviewTest extends WebTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->loadFixtures();
+
+        $this->getAuthorizationService()->setSelectedServiceId(
+            $this->getServiceRepository()->findByName('SURFnet')->getId()
+        );
+    }
+
+    /**
+     * From the services overview page we summarize the available services
+     * for the contact that is currently logged in
+     *
+     * Todo: add tests for the entity form
+     * Todo: The link on the h1 will probably be moved elsewhere
+     */
+    public function test_users_can_use_the_service_overview_page()
+    {
+        $serviceRepository = $this->getServiceRepository();
+        $surfNet = $serviceRepository->findByName('SURFnet');
+        $this->logIn('ROLE_USER', [$surfNet]);
+
+        $crawler = $this->client->request('GET', '/');
+
+        $nodes = $crawler->filter('.card h1');
+        $serviceNode = $nodes->first();
+        $this->assertEquals('SURFnet', $serviceNode->text());
+        $link = $serviceNode->filter('a')->first()->link();
+
+        $this->client->click($link);
+        $this->assertRegExp('#entities$#', $this->client->getResponse()->headers->get('location'));
+    }
+
+    /**
+     * Multiple services can be listed on the page
+     */
+    public function test_multiple_services_can_be_listed()
+    {
+        $serviceRepository = $this->getServiceRepository();
+        $surfNet = $serviceRepository->findByName('SURFnet');
+        $ibuildings = $serviceRepository->findByName('Ibuildings B.V.');
+        $this->logIn('ROLE_USER', [$surfNet, $ibuildings]);
+
+        $crawler = $this->client->request('GET', '/');
+
+        $nodes = $crawler->filter('.card h1');
+
+        $this->assertEquals(2, $nodes->count());
+
+        // The two nodes are sorted alphabetically.
+        $serviceNode = $nodes->first();
+        $this->assertEquals('Ibuildings B.V.', $serviceNode->text());
+
+        $service2 = $nodes->eq(1);
+        $this->assertEquals('SURFnet', $service2->text());
+    }
+
+}


### PR DESCRIPTION
Some decisions have been made which might need adjustment later on:
1. The service names have been made links to enable us to switch to that service (to get to their entities & privacy questions)
2. The service overview has been made the default route at (/) And the previous default (entities overview) is now available at /entities.
3. Service entities are fed into the twig template. A more template friendly object might be required at some point.

:warning: This PR is built on top of #158 