### PR TITLE
Publish production entities to manage

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
@@ -156,6 +156,12 @@ class JsonGenerator implements GeneratorInterface
             $this->spDashboardMetadataGenerator->build($entity)
         );
 
+        // When publishing to production, the coin:exclude_from_push must be present and set to '1'. This prevents the
+        // entity from being pushed to engineblock.
+        if ($entity->isProduction()) {
+            $metadata['coin:exclude_from_push'] = 1;
+        }
+
         if (!empty($entity->getLogoUrl())) {
             $metadata += $this->generateLogoMetadata($entity);
         }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityPublishedController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityPublishedController.php
@@ -23,7 +23,6 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityCommand;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
@@ -39,8 +38,10 @@ class EntityPublishedController extends Controller
      * @Security("has_role('ROLE_USER')")
      * @Template()
      */
-    public function publishedProductionAction(Entity $entity)
+    public function publishedProductionAction()
     {
+        /** @var Entity $entity */
+        $entity = $this->get('session')->get('published.entity.clone');
         return [
             'entityName' => $entity->getNameEn(),
         ];

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -71,6 +71,14 @@ services:
 
     surfnet.dashboard.command_handler.publish_production_entity:
         class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\PublishEntityProductionCommandHandler
+        arguments:
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\EntityRepository'
+            - '@surfnet.manage.client.publish_client.prod_environment'
+            - '@tactician.commandbus.default'
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Factory\MailMessageFactory'
+            - '@security.token_storage'
+            - '@session.flash_bag'
+            - '@logger'
         public: true
         tags:
             - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityProductionCommand }

--- a/tests/integration/Application/CommandHandler/Entity/PublishEntityProductionCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/PublishEntityProductionCommandHandlerTest.php
@@ -30,9 +30,12 @@ use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Mailer\Message;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityRepository;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\PublishEntityRepository;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Factory\MailMessageFactory;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Token\SamlToken;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Identity;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\PublishMetadataException;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
@@ -47,6 +50,11 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
      * @var EntityRepository|Mock
      */
     private $repository;
+
+    /**
+     * @var PublishEntityRepository|Mock
+     */
+    private $publishEntityClient;
 
     /**
      * @var CommandBus|Mock
@@ -64,6 +72,11 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
     private $tokenStorage;
 
     /**
+     * @var FlashBagInterface|Mock
+     */
+    private $flashBag;
+
+    /**
      * @var LoggerInterface|Mock
      */
     private $logger;
@@ -72,16 +85,20 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
     {
 
         $this->repository = m::mock(EntityRepository::class);
+        $this->publishEntityClient = m::mock(PublishEntityRepository::class);
         $this->commandBus = m::mock(CommandBus::class);
         $this->mailMessageFactory = m::mock(MailMessageFactory::class);
         $this->tokenStorage = m::mock(TokenStorageInterface::class);
+        $this->flashBag = m::mock(FlashBagInterface::class);
         $this->logger = m::mock(LoggerInterface::class);
 
         $this->commandHandler = new PublishEntityProductionCommandHandler(
             $this->repository,
+            $this->publishEntityClient,
             $this->commandBus,
             $this->mailMessageFactory,
             $this->tokenStorage,
+            $this->flashBag,
             $this->logger
         );
 
@@ -99,7 +116,7 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
 
         $entity = m::mock(Entity::class);
         $entity
-            ->shouldReceive('getNameEn')
+            ->shouldReceive('getNameNl')
             ->andReturn('Test Entity Name');
 
         $entity
@@ -114,6 +131,14 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
         $this->repository
             ->shouldReceive('save')
             ->with($entity);
+
+        $this->publishEntityClient
+            ->shouldReceive('publish')
+            ->once()
+            ->with($entity)
+            ->andReturn([
+                'id' => 123,
+            ]);
 
         $this->commandBus
             ->shouldReceive('handle')
@@ -130,8 +155,50 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
 
         $this->logger
             ->shouldReceive('info')
+            ->times(3);
+
+
+        $command = new PublishEntityProductionCommand('d6f394b2-08b1-4882-8b32-81688c15c489');
+        $this->commandHandler->handle($command);
+    }
+
+    public function test_it_handles_failing_publish()
+    {
+        $entity = m::mock(Entity::class);
+        $entity
+            ->shouldReceive('getNameNl')
+            ->andReturn('Test Entity Name');
+
+        $entity
+            ->shouldReceive('setStatus')
+            ->with(Entity::STATE_PUBLISHED);
+
+        $this->repository
+            ->shouldReceive('findById')
+            ->with('d6f394b2-08b1-4882-8b32-81688c15c489')
+            ->andReturn($entity);
+
+        $this->repository
+            ->shouldReceive('save')
+            ->with($entity);
+
+        $this->logger
+            ->shouldReceive('info')
             ->times(2);
 
+        $this->logger
+            ->shouldReceive('error')
+            ->times(1);
+
+        $this->publishEntityClient
+            ->shouldReceive('publish')
+            ->once()
+            ->with($entity)
+            ->andThrow(PublishMetadataException::class);
+
+        $this->flashBag
+            ->shouldReceive('add')
+            ->with('error', 'entity.edit.error.publish');
 
         $command = new PublishEntityProductionCommand('d6f394b2-08b1-4882-8b32-81688c15c489');
         $this->commandHandler->handle($command);

--- a/tests/webtests/CommandHandler/MockPublishEntityToProductionCommandHandler.php
+++ b/tests/webtests/CommandHandler/MockPublishEntityToProductionCommandHandler.php
@@ -19,16 +19,17 @@
 namespace Surfnet\ServiceProviderDashboard\Webtests\CommandHandler;
 
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityCommand;
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityProductionCommand;
 use Surfnet\ServiceProviderDashboard\Application\CommandHandler\CommandHandler;
 
 /**
  * Publishing to an actual service registry is out of scope for the web tests.
  *
- * The correct functioning of the PublishEntityTestCommandHandler is verified using integration tests.
+ * The correct functioning of the PublishEntityProductionCommandHandler is verified using integration tests.
  */
-class MockPublishEntityCommandHandler implements CommandHandler
+class MockPublishEntityToProductionCommandHandler implements CommandHandler
 {
-    public function handle(PublishEntityCommand $command)
+    public function handle(PublishEntityProductionCommand $command)
     {
     }
 }

--- a/tests/webtests/EntityPublishToProductionTest.php
+++ b/tests/webtests/EntityPublishToProductionTest.php
@@ -124,8 +124,9 @@ class EntityPublishToProductionTest extends WebTestCase
             'Expecting a redirect response after publishing to production'
         );
 
-        $entity = $this->getEntityRepository()->findById('a8e7cffd-0409-45c7-a37a-81bb5e7e5f66');
-        $this->assertEquals('production', $entity->getEnvironment());
+        // After publishing the entity, it should no longer be accessible
+        $this->client->request('GET', '/entity/edit/a8e7cffd-0409-45c7-a37a-81bb5e7e5f66');
+        $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
     }
 
     public function test_it_validates_at_least_one_attribute_present()

--- a/tests/webtests/EntityPublishToProductionTest.php
+++ b/tests/webtests/EntityPublishToProductionTest.php
@@ -107,8 +107,6 @@ class EntityPublishToProductionTest extends WebTestCase
         // Entity id validation
         $this->mockHandler->append(new Response(200, [], '{"id":"f1e394b2-08b1-4882-8b32-43876c15c743"}'));
 
-        $mailer = $this->client->getContainer()->get(Mailer::class);
-
         // Build and save an entity to work with
         $entity = $this->buildEntityWithAttribute($this->getServiceRepository()->findByName('SURFnet'));
         $this->getEntityRepository()->save($entity);
@@ -126,29 +124,13 @@ class EntityPublishToProductionTest extends WebTestCase
             'Expecting a redirect response after publishing to production'
         );
 
-        $sentMail = $mailer->getSent();
-
         $entity = $this->getEntityRepository()->findById('a8e7cffd-0409-45c7-a37a-81bb5e7e5f66');
         $this->assertEquals('production', $entity->getEnvironment());
-        $this->assertEquals('published', $entity->getStatus());
-        $this->assertEquals(
-            'Production connection has been requested (https://domain.org/saml/sp/saml2-post/default-sp/metadata)',
-            $sentMail[0]->getSubject()
-        );
-
-        // @see \Surfnet\ServiceProviderDashboard\Webtests\WebTestCase::logIn
-        $this->assertContains(
-            'Published by: John Doe &lt;johndoe@localhost&gt;',
-            $sentMail[0]->getBody(),
-            'The message should contain the contacts of the publisher (currently logged in user)'
-        );
     }
 
     public function test_it_validates_at_least_one_attribute_present()
     {
         $this->mockHandler->append(new Response(200, [], '{"id":"f1e394b2-08b1-4882-8b32-43876c15c743"}'));
-
-        $mailer = $this->client->getContainer()->get(Mailer::class);
 
         // Build and save an entity to work with
         $entity = $this->buildEntityWithoutAttribute($this->getServiceRepository()->findByName('SURFnet'));

--- a/tests/webtests/Resources/config/services.yml
+++ b/tests/webtests/Resources/config/services.yml
@@ -8,6 +8,12 @@ services:
         tags:
             - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityCommand }
 
+    surfnet.dashboard.command_handler.publish_production_entity:
+        class: Surfnet\ServiceProviderDashboard\Webtests\CommandHandler\MockPublishEntityToProductionCommandHandler
+        public: true
+        tags:
+            - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityProductionCommand }
+
     Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Mailer\Mailer:
         class: Surfnet\ServiceProviderDashboard\Webtests\Mailer\FakeMailer
         public: true


### PR DESCRIPTION
The manage-prod instance is used for this purpose. The additional
coin:exclude_from_push attribute is added to production entities. And
will ensure the entity will end up in the staging area in manage.

To test this functionally first install Manage production.

See https://www.pivotaltracker.com/story/show/161679714

:warning: Built on top of #159 