### PR TITLE
Remove published entity from database

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityPublishedController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityPublishedController.php
@@ -23,7 +23,6 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityCommand;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
@@ -39,8 +38,10 @@ class EntityPublishedController extends Controller
      * @Security("has_role('ROLE_USER')")
      * @Template()
      */
-    public function publishedProductionAction(Entity $entity)
+    public function publishedProductionAction()
     {
+        /** @var Entity $entity */
+        $entity = $this->get('session')->get('published.entity.clone');
         return [
             'entityName' => $entity->getNameEn(),
         ];

--- a/tests/webtests/EntityPublishToProductionTest.php
+++ b/tests/webtests/EntityPublishToProductionTest.php
@@ -124,8 +124,9 @@ class EntityPublishToProductionTest extends WebTestCase
             'Expecting a redirect response after publishing to production'
         );
 
-        $entity = $this->getEntityRepository()->findById('a8e7cffd-0409-45c7-a37a-81bb5e7e5f66');
-        $this->assertEquals('production', $entity->getEnvironment());
+        // After publishing the entity, it should no longer be accessible
+        $this->client->request('GET', '/entity/edit/a8e7cffd-0409-45c7-a37a-81bb5e7e5f66');
+        $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
     }
 
     public function test_it_validates_at_least_one_attribute_present()


### PR DESCRIPTION
The production entities should always be removed from local database
storage after they have been successfully published to manage (prod).

In doing so I've tried to make the publishEntity of the
EntityControllerTrait a bit more understandable.

See: [Task 4 of #161679714](https://www.pivotaltracker.com/story/show/161679714)