### PR TITLE
Show the actual service state on the home

### DIFF
--- a/app/js/application.js
+++ b/app/js/application.js
@@ -3,6 +3,7 @@
 import 'jquery';
 import './components/service_switcher.js';
 import './components/service_form.ts';
+import './components/service_status.ts';
 import './components/validation.js';
 import './components/service_edit_attribute.js';
 import './components/translation_ui.js';

--- a/app/js/components/service_form.test.ts
+++ b/app/js/components/service_form.test.ts
@@ -1,12 +1,11 @@
+import { loadServiceForm } from "./service_form";
+import * as $ from "jquery";
+
 jest
     .dontMock('fs')
     .dontMock('jquery');
 
-
-window.$ = require('jquery');
-
-
-const loadServiceForm = require('./service_form.ts');
+(<any>window).$ = $;
 
 describe('validate visibility toggling of service status fields on the service edit form', function() {
 

--- a/app/js/components/service_form.ts
+++ b/app/js/components/service_form.ts
@@ -1,4 +1,4 @@
-'use strict';
+import * as $ from 'jquery';
 
 class ServiceForm {
   private $privacyQuestionsEnabledToggle: JQuery;
@@ -85,7 +85,7 @@ class ServiceForm {
   }
 }
 
-function loadServiceForm() {
+export function loadServiceForm() {
   if ($('#dashboard_bundle_edit_service_type').length > 0 || $('#dashboard_bundle_service_type').length > 0) {
     const serviceForm = new ServiceForm(
       $('.privacy-questions-toggle'),
@@ -98,5 +98,3 @@ function loadServiceForm() {
 }
 
 $(document).ready(loadServiceForm);
-
-module.exports = loadServiceForm;

--- a/app/js/components/service_status.test.ts
+++ b/app/js/components/service_status.test.ts
@@ -1,0 +1,83 @@
+import { loadServiceStatus } from "./service_status";
+
+import * as $ from "jquery";
+
+jest
+    .dontMock('fs')
+    .dontMock('jquery');
+
+(<any>window).$ = $;
+
+(<any>window).$.ajax = function() {
+    return {
+        done: function(e: any) {
+            let result = {
+                service: {
+                    link: '/service/edit/1',
+                    name: 'service name',
+                    entities: [{
+                        name: 'prod entity name',
+                        link: '/entity/edit/2',
+                        environment: 'production',
+
+                    },
+                    {
+                        name: 'test entity name',
+                        link: '/entity/edit/1',
+                        environment: 'test',
+
+                    }],
+                    states: {
+                        "intake-conducted": "success",
+                        "entity-on-test":"success",
+                        "representative-approved":"success",
+                        "privacy-questions":"success",
+                        "production-connection":"info"
+                    },
+                    labels: {
+                        "intake-conducted":"Intake done",
+                        "entity-on-test":"Entity on test",
+                        "representative-approved":"Approved by representative",
+                        "contract-signed":"Contract signed",
+                        "privacy-questions":"Privacy questions answered",
+                        "production-connection":"Production connection aquired"
+                    },
+                    tooltips: {
+                        "intake-conducted":"Is the intake done",
+                        "entity-on-test":"Is there an entity on the test environment",
+                        "representative-approved":"Is the service approved by a representative",
+                        "contract-signed":"Is a contract signed",
+                        "privacy-questions":"Are the privacy questions answered",
+                        "production-connection":"Is a production connection active"
+                    },
+                }
+            };
+            e(result);
+        }
+    }
+};
+
+
+
+describe('validate donut status graph', function() {
+
+    let stateHtml = `
+        <div id="service-states">
+            <div class="service-status-container" data-service-id="2"></div>
+            <div class="service-status-container" data-service-id="1"></div>
+        </div>`;
+
+    it('should generate content based on the api call', function() {
+        document.body.innerHTML = stateHtml;
+        loadServiceStatus();
+
+        let expected = `
+            <div class="service-status-container" data-service-id="2"><div class="service-status-title"><a href="/service/edit/1">service name</a></div><div class="service-status-canvas"><div style="display: block;" class="chartjs-render-monitor"></div></div><div class="service-status-entities"><a href="/entity/edit/1" class="service-status-entity-link">test entity name</a></div><div class="service-status-entities"></div></div>
+            <div class="service-status-container" data-service-id="1"><div class="service-status-title"><a href="/service/edit/1">service name</a></div><div class="service-status-canvas"><div style="display: block;" class="chartjs-render-monitor"></div></div><div class="service-status-entities"><a href="/entity/edit/1" class="service-status-entity-link">test entity name</a></div><div class="service-status-entities"></div></div>
+        `;
+
+        let actual = $('#service-states').html();
+
+        expect(actual).toBe(expected);
+    });
+});

--- a/app/js/components/service_status.test.ts
+++ b/app/js/components/service_status.test.ts
@@ -72,8 +72,8 @@ describe('validate donut status graph', function() {
         loadServiceStatus();
 
         let expected = `
-            <div class="service-status-container" data-service-id="2"><div class="service-status-title"><a href="/service/edit/1">service name</a></div><div class="service-status-canvas"><div style="display: block;" class="chartjs-render-monitor"></div></div><div class="service-status-entities"><a href="/entity/edit/1" class="service-status-entity-link">test entity name</a></div><div class="service-status-entities"></div></div>
-            <div class="service-status-container" data-service-id="1"><div class="service-status-title"><a href="/service/edit/1">service name</a></div><div class="service-status-canvas"><div style="display: block;" class="chartjs-render-monitor"></div></div><div class="service-status-entities"><a href="/entity/edit/1" class="service-status-entity-link">test entity name</a></div><div class="service-status-entities"></div></div>
+            <div class="service-status-container" data-service-id="2"><div class="service-status-title"><a href="/service/edit/1">service name</a></div><div class="service-status-canvas"><div style="display: block;" class="chartjs-render-monitor"></div></div><div class="service-status-entities"><a href="/entity/edit/1" class="service-status-entity-link">test entity name</a></div><div class="service-status-entities"><a href=\"/entity/edit/2\" class=\"service-status-entity-link\">prod entity name</a></div></div>
+            <div class="service-status-container" data-service-id="1"><div class="service-status-title"><a href="/service/edit/1">service name</a></div><div class="service-status-canvas"><div style="display: block;" class="chartjs-render-monitor"></div></div><div class="service-status-entities"><a href="/entity/edit/1" class="service-status-entity-link">test entity name</a></div><div class="service-status-entities"><a href=\"/entity/edit/2\" class=\"service-status-entity-link\">prod entity name</a></div></div>
         `;
 
         let actual = $('#service-states').html();

--- a/app/js/components/service_status.ts
+++ b/app/js/components/service_status.ts
@@ -1,0 +1,217 @@
+import * as Chart from 'chart.js';
+import { ChartTooltipItem } from 'chart.js';
+import * as $ from 'jquery';
+
+interface StatesDictionary {
+  [key: string]: string;
+}
+
+interface EntityJson {
+  name: string;
+  environment: string;
+  link: string;
+}
+
+interface StatesResponseJson {
+  service: {
+    entities: EntityJson[];
+    link: string;
+    name: string;
+    states: StatesDictionary;
+    labels: StatesDictionary;
+    tooltips: StatesDictionary;
+  };
+}
+
+export class ServiceStatus {
+  private stateColors: StatesDictionary;
+  private elementContainer: HTMLElement;
+  private elementTitle: HTMLElement;
+  private elementListTest: HTMLElement;
+  private elementListProd: HTMLElement;
+  private canvas: HTMLCanvasElement;
+  private serviceId: string;
+  private chart: Chart|undefined;
+
+  constructor(elementContainer: HTMLElement, serviceId: string) {
+    this.elementContainer = elementContainer;
+    this.serviceId = serviceId;
+    this.stateColors = {};
+    this.chart = undefined;
+    this.initStateColors();
+    this.canvas = document.createElement('canvas') as HTMLCanvasElement;
+    this.elementTitle = document.createElement('div') as HTMLElement;
+    this.elementListTest = document.createElement('div') as HTMLElement;
+    this.elementListProd = document.createElement('div') as HTMLElement;
+    this.initCanvas();
+  }
+
+  /**
+   * Init the eventhandlers on the elements
+   */
+  public registerEventHandlers() {
+    this.fetchState();
+  }
+
+  /**
+   * Check if loaded
+   */
+  public isLoaded() {
+    return this.chart !== undefined;
+  }
+
+  private fetchState() {
+    $.ajax({
+      url: `/api/service/status/${this.serviceId}`,
+      context: document.body,
+    }).done((e) => {
+      const statesResponse = e as StatesResponseJson;
+      this.drawTitle(statesResponse);
+      this.drawChart(statesResponse);
+      this.drawEntities(statesResponse);
+    });
+  }
+
+  private drawChart(states: StatesResponseJson) {
+    const labels: string[] = [];
+    const tooltips: string[] = [];
+    const data: number[] = [];
+    const backgroundColor: string[] = [];
+
+    const ratio = 100 / Object.keys(states.service.states).length;
+    for (const key in states.service.states) {
+      if (!states.service.states.hasOwnProperty(key)) {
+        continue;
+      }
+
+      const state = states.service.states[key];
+
+      data.push(ratio);
+      labels.push(states.service.labels[key]);
+      backgroundColor.push(this.stateColors[state]);
+      tooltips.push(states.service.tooltips[key]);
+    }
+
+    const options: Chart.ChartConfiguration = {
+      type: 'doughnut',
+      data: {
+        labels,
+        datasets: [{
+          data,
+          backgroundColor,
+        }],
+      },
+      options: {
+        cutoutPercentage: 85,
+        responsive: true,
+        legend: {
+          position: 'right',
+          labels: {
+            fontSize: 14,
+          },
+        },
+        title: {
+          display: false,
+        },
+        animation: {
+          animateScale: true,
+          animateRotate: true,
+        },
+        tooltips: {
+          callbacks: {
+            label: (tooltipItem: ChartTooltipItem) => {
+              if (tooltipItem.index === undefined) {
+                return '';
+              }
+              return tooltips[tooltipItem.index];
+            },
+          },
+        },
+      },
+    };
+
+    this.chart = new Chart(this.canvas, options);
+  }
+
+  private drawEntities(states: StatesResponseJson) {
+    for (const id in states.service.entities) {
+      if (!states.service.entities.hasOwnProperty(id)) {
+        continue;
+      }
+
+      const entity = states.service.entities[id];
+
+      const link = document.createElement('a') as HTMLAnchorElement;
+      link.href = entity.link;
+      link.innerHTML = entity.name;
+      link.classList.add('service-status-entity-link');
+
+      if (entity.environment === 'prod') {
+        if (this.elementListProd.innerText === '') {
+          this.elementListProd.innerText = 'Prod';
+        }
+        this.elementListProd.appendChild(link);
+      } else if (entity.environment === 'test') {
+        if (this.elementListTest.innerText === '') {
+          this.elementListTest.innerText = 'Test';
+        }
+        this.elementListTest.appendChild(link);
+      }
+    }
+  }
+
+  private drawTitle(states: StatesResponseJson) {
+    const link = document.createElement('a') as HTMLAnchorElement;
+    link.href = states.service.link;
+    link.innerHTML = states.service.name;
+
+    this.elementTitle.appendChild(link);
+  }
+
+  private initStateColors() {
+    this.stateColors.danger = '#d73232';
+    this.stateColors.success = '#67a979';
+    this.stateColors.info = '#f6aa61';
+  }
+
+  private initCanvas() {
+    // title
+    this.elementTitle.classList.add('service-status-title');
+    this.elementContainer.appendChild(this.elementTitle);
+
+    // canvas
+    const container = document.createElement('div');
+    container.classList.add('service-status-canvas');
+
+    container.appendChild(this.canvas);
+    this.elementContainer.appendChild(container);
+
+    // entitylist
+    this.elementListTest.classList.add('service-status-entities');
+    this.elementContainer.appendChild(this.elementListTest);
+    this.elementListProd.classList.add('service-status-entities');
+    this.elementContainer.appendChild(this.elementListProd);
+  }
+}
+
+export function loadServiceStatus() {
+  if ($('#service-states').length > 0) {
+
+    const elements = document.getElementsByClassName('service-status-container');
+    Array.prototype.forEach.call(elements,  (el: HTMLCanvasElement) => {
+
+      const serviceId = el.dataset.serviceId;
+      if (serviceId === undefined) {
+        return;
+      }
+
+      const serviceStatus = new ServiceStatus(
+        el,
+        serviceId,
+      );
+      serviceStatus.registerEventHandlers();
+    });
+  }
+}
+
+$(document).ready(loadServiceStatus);

--- a/app/js/components/service_status.ts
+++ b/app/js/components/service_status.ts
@@ -146,7 +146,7 @@ export class ServiceStatus {
       link.innerHTML = entity.name;
       link.classList.add('service-status-entity-link');
 
-      if (entity.environment === 'prod') {
+      if (entity.environment === 'production') {
         if (this.elementListProd.innerText === '') {
           this.elementListProd.innerText = 'Prod';
         }
@@ -169,7 +169,7 @@ export class ServiceStatus {
   }
 
   private initStateColors() {
-    this.stateColors.danger = '#d73232';
+    this.stateColors.danger = '#d1d2d6';
     this.stateColors.success = '#67a979';
     this.stateColors.info = '#f6aa61';
   }

--- a/app/scss/components/service_status.scss
+++ b/app/scss/components/service_status.scss
@@ -1,0 +1,54 @@
+.service-status-container {
+  display:block;
+  clear: both;
+  overflow: auto;
+  border-bottom: 1px solid #4DB2CF;
+  padding: 30px 0 50px;
+
+  a {
+    color:#428bca;
+    text-decoration:none;
+  }
+  a:hover,a:focus {
+    color:#2a6496;
+    text-decoration:underline;
+  }
+
+  &:last-child {
+    border: none;
+    padding-bottom: 0;
+  }
+
+  .service-status-title {
+    font-size: 25px;
+  }
+
+  .service-status-canvas {
+    display: block;
+    float: left;
+    width: 600px;
+    height: 300px;
+  }
+
+  .service-status-entities {
+    display: block;
+    float: right;
+    width: 300px;
+    font-weight: bold;
+    text-transform: uppercase;
+    margin-left: 40px;
+
+    .service-status-entity-link {
+      display: block;
+      width: 100%;
+      padding: 10px;
+      border-top: 1px solid #d9d9d8;
+      font-weight: normal;
+      text-transform: initial;
+
+      &:last-child {
+        border-bottom: 1px solid #d9d9d8;
+      }
+    }
+  }
+}

--- a/build.xml
+++ b/build.xml
@@ -68,7 +68,7 @@
 
         <echo message="${line.separator}jscpd:" />
         <exec executable="node_modules/jscpd/bin/jscpd" failonerror="true">
-            <arg line='--exclude "**/*.test.js"' />
+            <arg line='--exclude "**/*.test.ts"' />
             <arg line="--limit=-1" />
         </exec>
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -35,5 +35,8 @@ module.exports = {
         "ts-jest": {
             tsConfig: "tsconfig.json",
         }
-    }
+    },
+    "setupFiles": [
+        "jest-canvas-mock",
+    ]
 };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "file-loader": "^2.0.0",
     "import-glob-loader": "^1.1.0",
     "jest": "^23.6.0",
+    "jest-canvas-mock": "^1.1.0",
     "jscpd": "^0.6.23",
     "node-sass": "^4.9.3",
     "sass-loader": "^7.1.0",
@@ -26,7 +27,9 @@
     "webpack-dev-server": "3"
   },
   "dependencies": {
+    "@types/chart.js": "^2.7.40",
     "@types/jquery": "^3.3.22",
+    "chart.js": "^2.7.3",
     "jquery": "^3.2.1",
     "parsleyjs": "^2.8.1",
     "select2": "^4.0.3",

--- a/src/Surfnet/ServiceProviderDashboard/Application/Assembler/ServiceStatusAssembler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Assembler/ServiceStatusAssembler.php
@@ -34,7 +34,6 @@ class ServiceStatusAssembler
     const SERVICE_STATE_PRIVACY_QUESTIONS = 'privacy-questions';
     const SERVICE_STATE_PRODUCTION_CONNECTION = 'production-connection';
 
-
     /**
      * The possible states used in the mapping
      */
@@ -89,9 +88,17 @@ class ServiceStatusAssembler
      * @param string $serviceLink
      * @param ServiceStatusService $serviceStatusService
      * @param EntityList $entityList
+     * @param string[] $labels
+     * @param string[] $tooltips
      */
-    public function __construct(Service $service, $serviceLink, ServiceStatusService $serviceStatusService, EntityList $entityList)
-    {
+    public function __construct(
+        Service $service,
+        $serviceLink,
+        ServiceStatusService $serviceStatusService,
+        EntityList $entityList,
+        array $labels,
+        array $tooltips
+    ) {
         $states = $this->getStates($service, $serviceStatusService);
         $mappedStates = $this->mapStates($states);
 
@@ -99,7 +106,9 @@ class ServiceStatusAssembler
             $service->getName(),
             $serviceLink,
             $entityList,
-            $mappedStates
+            $mappedStates,
+            $labels,
+            $tooltips
         );
     }
 
@@ -109,6 +118,21 @@ class ServiceStatusAssembler
     public function getDto()
     {
         return $this->serviceStatusDto;
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function states()
+    {
+        return [
+            self::SERVICE_STATE_INTAKE_CONDUCTED,
+            self::SERVICE_STATE_ENTITY_ON_TEST,
+            self::SERVICE_STATE_REPRESENTATIVE_APPROVED,
+            self::SERVICE_STATE_CONTRACT_SIGNED,
+            self::SERVICE_STATE_PRIVACY_QUESTIONS,
+            self::SERVICE_STATE_PRODUCTION_CONNECTION,
+        ];
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/Dto/ServiceStatusDto.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Dto/ServiceStatusDto.php
@@ -40,24 +40,38 @@ class ServiceStatusDto implements \JsonSerializable
      * @var string[]
      */
     private $states;
+    /**
+     * @var array
+     */
+    private $labels;
+    /**
+     * @var array
+     */
+    private $tooltips;
 
     /**
      * ServiceStatusDto constructor.
-     * @param $name
-     * @param $link
+     * @param string $name
+     * @param string $link
      * @param EntityList $entityList
-     * @param array $states
+     * @param string[] $states
+     * @param string[] $labels
+     * @param string[] $tooltips
      */
     public function __construct(
         $name,
         $link,
         EntityList $entityList,
-        array $states
+        array $states,
+        array $labels,
+        array $tooltips
     ) {
         $this->name = $name;
         $this->link = $link;
         $this->entityList = $entityList;
         $this->states = $states;
+        $this->labels = $labels;
+        $this->tooltips = $tooltips;
     }
 
     /**
@@ -70,6 +84,8 @@ class ServiceStatusDto implements \JsonSerializable
             'link' => $this->link,
             'entities' => $this->entityList,
             'states' => $this->states,
+            'labels' => $this->labels,
+            'tooltips' => $this->tooltips,
         ];
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Entity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Entity.php
@@ -288,7 +288,23 @@ class Entity implements JsonSerializable
      */
     public function getLink()
     {
-        return $this->router->generate('entity_edit', ['id' => $this->getId()]);
+        if ($this->allowEditAction()) {
+            return $this->router->generate('entity_edit', ['id' => $this->getId()]);
+        } elseif ($this->allowCopyAction()) {
+            return $this->router->generate('entity_copy', [
+                'manageId' => $this->getId(),
+                'targetEnvironment' => $this->environment,
+                'sourceEnvironment' => $this->environment,
+            ]);
+        } else if ($this->allowCloneAction()) {
+            return $this->router->generate('entity_copy', [
+                'manageId' => $this->getId(),
+                'targetEnvironment' => 'production',
+                'sourceEnvironment' => 'production',
+            ]);
+        }
+
+        return '#';
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/Api/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/Api/ServiceController.php
@@ -119,7 +119,7 @@ class ServiceController extends Controller
             $tooltips[$state] = $this->translator->trans('service.overview.progress.tooltip.'.$state);
         }
 
-        $serviceLink = $this->router->generate('service_edit', ['id' => $service->getId()]);
+        $serviceLink = $this->router->generate('select_service', ['service' => $service->getId()]);
         $entityList = $this->entityService->getEntityListForService($service);
 
         $serviceStatusAssembler = new ServiceStatusAssembler(

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -83,6 +83,7 @@ class ServiceController extends Controller
     /**
      * @Method({"GET"})
      * @Route("/", name="service_overview")
+     * @Security("has_role('ROLE_USER')")
      * @Template()
      */
     public function overviewAction()

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -194,3 +194,15 @@ mail.confirmation.publish_production.service_name: Service name
 mail.confirmation.publish_production.publish_date: Publish date
 mail.confirmation.publish_production.team_id: Team id
 mail.confirmation.publish_production.subject: 'Production connection has been requested (%entityId%)'
+service.overview.progress.label.intake-conducted: Intake done
+service.overview.progress.label.entity-on-test: Entity on test
+service.overview.progress.label.contract-signed: Contract signed
+service.overview.progress.label.representative-approved: Approved by representative
+service.overview.progress.label.privacy-questions: Privacy questions answered
+service.overview.progress.label.production-connection: Production connection aquired
+service.overview.progress.tooltip.intake-conducted: Is the intake done
+service.overview.progress.tooltip.entity-on-test: Is there an entity on the test environment
+service.overview.progress.tooltip.contract-signed: Is a contract signed
+service.overview.progress.tooltip.representative-approved: Is the service approved by a representative
+service.overview.progress.tooltip.privacy-questions: Are the privacy questions answered
+service.overview.progress.tooltip.production-connection: Is a production connection active

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
@@ -2,9 +2,11 @@
 
 {% block body %}
 
+    <div id="service-states">
     {% for service in services %}
-        <h1><a href="{{ path('select_service', {"service": service.id }) }}">{{ service.name }}</a></h1>
+        <div class="service-status-container" data-service-id="{{ service.id }}"></div>
     {% endfor %}
+    </div>
 
 {% endblock %}
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/AuthorizationService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/AuthorizationService.php
@@ -174,6 +174,21 @@ class AuthorizationService
     }
 
     /**
+     * Get the service selected in the service switcher.
+     *
+     * @param int $serviceId
+     * @return string
+     */
+    public function assertServiceIdAllowed($serviceId)
+    {
+        if ($serviceId && !$this->hasAccessToService($serviceId)) {
+            throw new RuntimeException(
+                sprintf('User is not granted access to service with ID %d', $serviceId)
+            );
+        }
+    }
+
+    /**
      * Did the user select a service in the switcher?
      *
      * @return bool

--- a/tests/unit/Application/Assembler/ServiceStatusAssemblerTest.php
+++ b/tests/unit/Application/Assembler/ServiceStatusAssemblerTest.php
@@ -69,11 +69,15 @@ class ServiceStatusAssemblerTest extends MockeryTestCase
             $this->service,
             $serviceLink,
             $this->serviceStatusService,
-            $entitiesList
+            $entitiesList,
+            $this->getTestLabels(),
+            $this->getTestTooltips()
         );
 
         $result = $assembler->getDto();
         $json = json_encode($result);
+
+        $expectedJson = json_encode(json_decode($expectedJson));
 
         $this->assertSame($expectedJson, $json);
     }
@@ -99,7 +103,41 @@ class ServiceStatusAssemblerTest extends MockeryTestCase
                     'entityStatus' => Service::ENTITY_PUBLISHED_YES,
                     'privacyQuestions' => true,
                 ],
-                'result' => '{"name":"service-2","link":"service_edit?id=2","entities":[{"name":"entity-1","environment":"production","link":"entity_edit?id=1"}],"states":{"intake-conducted":"success","entity-on-test":"success","representative-approved":"success","privacy-questions":"success","production-connection":"success"}}'
+                'result' => '{
+  "name": "service-2",
+  "link": "service_edit?id=2",
+  "entities": [
+    {
+      "name": "entity-1",
+      "environment": "production",
+      "link": "entity_edit?id=1"
+    }
+  ],
+  "states": {
+    "intake-conducted": "success",
+    "entity-on-test": "success",
+    "representative-approved": "success",
+    "privacy-questions": "success",
+    "production-connection": "success"
+  },
+  "labels": {
+    "intake-conducted": "intake-conducted",
+    "entity-on-test": "entity-on-test",
+    "representative-approved": "representative-approved",
+    "contract-signed": "contract-signed",
+    "privacy-questions": "privacy-questions",
+    "production-connection": "production-connection"
+  },
+  "tooltips": {
+    "intake-conducted": "intake-conducted",
+    "entity-on-test": "entity-on-test",
+    "representative-approved": "representative-approved",
+    "contract-signed": "contract-signed",
+    "privacy-questions": "privacy-questions",
+    "production-connection": "production-connection"
+  }
+}
+'
             ],
             'non-institute-output' => [
                 'service' => [
@@ -119,7 +157,40 @@ class ServiceStatusAssemblerTest extends MockeryTestCase
                     'entityStatus' => Service::ENTITY_PUBLISHED_YES,
                     'privacyQuestions' => true,
                 ],
-                'result' => '{"name":"service-1","link":"service_edit?id=1","entities":[{"name":"entity-1","environment":"production","link":"entity_edit?id=1"}],"states":{"intake-conducted":"success","entity-on-test":"success","contract-signed":"success","privacy-questions":"success","production-connection":"success"}}'
+                'result' => '{
+  "name": "service-1",
+  "link": "service_edit?id=1",
+  "entities": [
+    {
+      "name": "entity-1",
+      "environment": "production",
+      "link": "entity_edit?id=1"
+    }
+  ],
+  "states": {
+    "intake-conducted": "success",
+    "entity-on-test": "success",
+    "contract-signed": "success",
+    "privacy-questions": "success",
+    "production-connection": "success"
+  },
+  "labels": {
+    "intake-conducted": "intake-conducted",
+    "entity-on-test": "entity-on-test",
+    "representative-approved": "representative-approved",
+    "contract-signed": "contract-signed",
+    "privacy-questions": "privacy-questions",
+    "production-connection": "production-connection"
+  },
+  "tooltips": {
+    "intake-conducted": "intake-conducted",
+    "entity-on-test": "entity-on-test",
+    "representative-approved": "representative-approved",
+    "contract-signed": "contract-signed",
+    "privacy-questions": "privacy-questions",
+    "production-connection": "production-connection"
+  }
+}'
             ],
             'entity-links' => [
                 'service' => [
@@ -141,7 +212,51 @@ class ServiceStatusAssemblerTest extends MockeryTestCase
                     'entityStatus' => Service::ENTITY_PUBLISHED_YES,
                     'privacyQuestions' => true,
                 ],
-                'result' => '{"name":"service-2","link":"service_edit?id=2","entities":[{"name":"entity-1","environment":"production","link":"entity_edit?id=1"},{"name":"entity-2","environment":"test","link":"entity_edit?id=2"},{"name":"entity-3","environment":"test","link":"entity_edit?id=3"}],"states":{"intake-conducted":"success","entity-on-test":"success","representative-approved":"success","privacy-questions":"success","production-connection":"success"}}'
+                'result' => '{
+  "name": "service-2",
+  "link": "service_edit?id=2",
+  "entities": [
+    {
+      "name": "entity-1",
+      "environment": "production",
+      "link": "entity_edit?id=1"
+    },
+    {
+      "name": "entity-2",
+      "environment": "test",
+      "link": "entity_edit?id=2"
+    },
+    {
+      "name": "entity-3",
+      "environment": "test",
+      "link": "entity_edit?id=3"
+    }
+  ],
+  "states": {
+    "intake-conducted": "success",
+    "entity-on-test": "success",
+    "representative-approved": "success",
+    "privacy-questions": "success",
+    "production-connection": "success"
+  },
+  "labels": {
+    "intake-conducted": "intake-conducted",
+    "entity-on-test": "entity-on-test",
+    "representative-approved": "representative-approved",
+    "contract-signed": "contract-signed",
+    "privacy-questions": "privacy-questions",
+    "production-connection": "production-connection"
+  },
+  "tooltips": {
+    "intake-conducted": "intake-conducted",
+    "entity-on-test": "entity-on-test",
+    "representative-approved": "representative-approved",
+    "contract-signed": "contract-signed",
+    "privacy-questions": "privacy-questions",
+    "production-connection": "production-connection"
+  }
+}
+'
             ],
             'privacy-questions-disabled' => [
                 'service' => [
@@ -159,7 +274,33 @@ class ServiceStatusAssemblerTest extends MockeryTestCase
                     'entityStatus' => Service::ENTITY_PUBLISHED_YES,
                     'privacyQuestions' => false,
                 ],
-                'result' => '{"name":"service-2","link":"service_edit?id=2","entities":[],"states":{"intake-conducted":"success","entity-on-test":"success","representative-approved":"success","production-connection":"success"}}'
+                'result' => '{
+  "name": "service-2",
+  "link": "service_edit?id=2",
+  "entities": [],
+  "states": {
+    "intake-conducted": "success",
+    "entity-on-test": "success",
+    "representative-approved": "success",
+    "production-connection": "success"
+  },
+  "labels": {
+    "intake-conducted": "intake-conducted",
+    "entity-on-test": "entity-on-test",
+    "representative-approved": "representative-approved",
+    "contract-signed": "contract-signed",
+    "privacy-questions": "privacy-questions",
+    "production-connection": "production-connection"
+  },
+  "tooltips": {
+    "intake-conducted": "intake-conducted",
+    "entity-on-test": "entity-on-test",
+    "representative-approved": "representative-approved",
+    "contract-signed": "contract-signed",
+    "privacy-questions": "privacy-questions",
+    "production-connection": "production-connection"
+  }
+}'
             ],
             'institute-output-danger' => [
                 'service' => [
@@ -177,7 +318,35 @@ class ServiceStatusAssemblerTest extends MockeryTestCase
                     'entityStatus' => Service::ENTITY_PUBLISHED_NO,
                     'privacyQuestions' => false,
                 ],
-                'result' => '{"name":"service-2","link":"service_edit?id=2","entities":[],"states":{"intake-conducted":"danger","entity-on-test":"danger","representative-approved":"danger","privacy-questions":"danger","production-connection":"danger"}}'
+                'result' => '{
+  "name": "service-2",
+  "link": "service_edit?id=2",
+  "entities": [],
+  "states": {
+    "intake-conducted": "danger",
+    "entity-on-test": "danger",
+    "representative-approved": "danger",
+    "privacy-questions": "danger",
+    "production-connection": "danger"
+  },
+  "labels": {
+    "intake-conducted": "intake-conducted",
+    "entity-on-test": "entity-on-test",
+    "representative-approved": "representative-approved",
+    "contract-signed": "contract-signed",
+    "privacy-questions": "privacy-questions",
+    "production-connection": "production-connection"
+  },
+  "tooltips": {
+    "intake-conducted": "intake-conducted",
+    "entity-on-test": "entity-on-test",
+    "representative-approved": "representative-approved",
+    "contract-signed": "contract-signed",
+    "privacy-questions": "privacy-questions",
+    "production-connection": "production-connection"
+  }
+}
+'
             ],
             'none-institute-output-danger' => [
                 'service' => [
@@ -195,7 +364,34 @@ class ServiceStatusAssemblerTest extends MockeryTestCase
                     'entityStatus' => Service::ENTITY_PUBLISHED_NO,
                     'privacyQuestions' => false,
                 ],
-                'result' => '{"name":"service-2","link":"service_edit?id=2","entities":[],"states":{"intake-conducted":"danger","entity-on-test":"danger","contract-signed":"danger","privacy-questions":"danger","production-connection":"danger"}}'
+                'result' => '{
+  "name": "service-2",
+  "link": "service_edit?id=2",
+  "entities": [],
+  "states": {
+    "intake-conducted": "danger",
+    "entity-on-test": "danger",
+    "contract-signed": "danger",
+    "privacy-questions": "danger",
+    "production-connection": "danger"
+  },
+  "labels": {
+    "intake-conducted": "intake-conducted",
+    "entity-on-test": "entity-on-test",
+    "representative-approved": "representative-approved",
+    "contract-signed": "contract-signed",
+    "privacy-questions": "privacy-questions",
+    "production-connection": "production-connection"
+  },
+  "tooltips": {
+    "intake-conducted": "intake-conducted",
+    "entity-on-test": "entity-on-test",
+    "representative-approved": "representative-approved",
+    "contract-signed": "contract-signed",
+    "privacy-questions": "privacy-questions",
+    "production-connection": "production-connection"
+  }
+}'
             ],
             'institute-output-info' => [
                 'service' => [
@@ -213,7 +409,34 @@ class ServiceStatusAssemblerTest extends MockeryTestCase
                     'entityStatus' => Service::ENTITY_PUBLISHED_IN_PROGRESS,
                     'privacyQuestions' => false,
                 ],
-                'result' => '{"name":"service-2","link":"service_edit?id=2","entities":[],"states":{"entity-on-test":"warning","representative-approved":"success","privacy-questions":"danger","production-connection":"info"}}'
+                'result' => '{
+  "name": "service-2",
+  "link": "service_edit?id=2",
+  "entities": [],
+  "states": {
+    "entity-on-test": "warning",
+    "representative-approved": "success",
+    "privacy-questions": "danger",
+    "production-connection": "info"
+  },
+  "labels": {
+    "intake-conducted": "intake-conducted",
+    "entity-on-test": "entity-on-test",
+    "representative-approved": "representative-approved",
+    "contract-signed": "contract-signed",
+    "privacy-questions": "privacy-questions",
+    "production-connection": "production-connection"
+  },
+  "tooltips": {
+    "intake-conducted": "intake-conducted",
+    "entity-on-test": "entity-on-test",
+    "representative-approved": "representative-approved",
+    "contract-signed": "contract-signed",
+    "privacy-questions": "privacy-questions",
+    "production-connection": "production-connection"
+  }
+}
+'
             ],
         ];
     }
@@ -288,5 +511,35 @@ class ServiceStatusAssemblerTest extends MockeryTestCase
         }
 
         return new EntityList($entities);
+    }
+
+    /**
+     * @return array
+     */
+    private function getTestLabels()
+    {
+        return [
+            ServiceStatusAssembler::SERVICE_STATE_INTAKE_CONDUCTED => ServiceStatusAssembler::SERVICE_STATE_INTAKE_CONDUCTED,
+            ServiceStatusAssembler::SERVICE_STATE_ENTITY_ON_TEST => ServiceStatusAssembler::SERVICE_STATE_ENTITY_ON_TEST,
+            ServiceStatusAssembler::SERVICE_STATE_REPRESENTATIVE_APPROVED => ServiceStatusAssembler::SERVICE_STATE_REPRESENTATIVE_APPROVED,
+            ServiceStatusAssembler::SERVICE_STATE_CONTRACT_SIGNED => ServiceStatusAssembler::SERVICE_STATE_CONTRACT_SIGNED,
+            ServiceStatusAssembler::SERVICE_STATE_PRIVACY_QUESTIONS => ServiceStatusAssembler::SERVICE_STATE_PRIVACY_QUESTIONS,
+            ServiceStatusAssembler::SERVICE_STATE_PRODUCTION_CONNECTION => ServiceStatusAssembler::SERVICE_STATE_PRODUCTION_CONNECTION,
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function getTestTooltips()
+    {
+        return [
+            ServiceStatusAssembler::SERVICE_STATE_INTAKE_CONDUCTED => ServiceStatusAssembler::SERVICE_STATE_INTAKE_CONDUCTED,
+            ServiceStatusAssembler::SERVICE_STATE_ENTITY_ON_TEST => ServiceStatusAssembler::SERVICE_STATE_ENTITY_ON_TEST,
+            ServiceStatusAssembler::SERVICE_STATE_REPRESENTATIVE_APPROVED => ServiceStatusAssembler::SERVICE_STATE_REPRESENTATIVE_APPROVED,
+            ServiceStatusAssembler::SERVICE_STATE_CONTRACT_SIGNED => ServiceStatusAssembler::SERVICE_STATE_CONTRACT_SIGNED,
+            ServiceStatusAssembler::SERVICE_STATE_PRIVACY_QUESTIONS => ServiceStatusAssembler::SERVICE_STATE_PRIVACY_QUESTIONS,
+            ServiceStatusAssembler::SERVICE_STATE_PRODUCTION_CONNECTION => ServiceStatusAssembler::SERVICE_STATE_PRODUCTION_CONNECTION,
+        ];
     }
 }

--- a/tests/webtests/ServiceOverviewTest.php
+++ b/tests/webtests/ServiceOverviewTest.php
@@ -40,7 +40,6 @@ class ServiceOverviewTest extends WebTestCase
      * for the contact that is currently logged in
      *
      * Todo: add tests for the entity form
-     * Todo: The link on the h1 will probably be moved elsewhere
      */
     public function test_users_can_use_the_service_overview_page()
     {
@@ -51,17 +50,10 @@ class ServiceOverviewTest extends WebTestCase
         $crawler = $this->client->request('GET', '/');
 
         // By retrieving the h1 titles (stating the services) we can conclude if the correct data is displayed.
-        $nodes = $crawler->filter('.card h1');
+        $nodes = $crawler->filter('.service-status-container');
         $serviceNode = $nodes->first();
 
-        $this->assertEquals('SURFnet', $serviceNode->text());
-
-        $link = $serviceNode->filter('a')->first()->link();
-
-        // Clicking on the anchor, swithces the service context to clicked service.
-        $this->client->click($link);
-        // The my entities page should now be open.
-        $this->assertRegExp('#entities$#', $this->client->getResponse()->headers->get('location'));
+        $this->assertEquals('1', $serviceNode->attr('data-service-id'));
     }
 
     /**
@@ -77,7 +69,7 @@ class ServiceOverviewTest extends WebTestCase
         $crawler = $this->client->request('GET', '/');
 
         // By retrieving the h1 titles (stating the services) we can conclude if the correct data is displayed.
-        $nodes = $crawler->filter('.card h1');
+        $nodes = $crawler->filter('.service-status-container');
 
         // Two services should be on page: surf and ibuildings.
         $this->assertEquals(2, $nodes->count());
@@ -86,8 +78,8 @@ class ServiceOverviewTest extends WebTestCase
         $serviceNode = $nodes->first();
         $service2 = $nodes->eq(1);
 
-        $this->assertEquals('Ibuildings B.V.', $serviceNode->text());
-        $this->assertEquals('SURFnet', $service2->text());
+        $this->assertEquals('2', $serviceNode->attr('data-service-id'));
+        $this->assertEquals('1', $service2->attr('data-service-id'));
     }
 
     public function test_service_overview_redirects_to_service_add_when_no_service_exists()

--- a/tmp.json
+++ b/tmp.json
@@ -1,0 +1,28 @@
+{
+  "name": "service-2",
+  "link": "service_edit?id=2",
+  "entities": [],
+  "states": {
+    "intake-conducted": "danger",
+    "entity-on-test": "danger",
+    "representative-approved": "danger",
+    "privacy-questions": "danger",
+    "production-connection": "danger"
+  },
+  "labels": {
+    "intake-conducted": "intake-conducted",
+    "entity-on-test": "entity-on-test",
+    "representative-approved": "representative-approved",
+    "contract-signed": "contract-signed",
+    "privacy-questions": "privacy-questions",
+    "production-connection": "production-connection"
+  },
+  "tooltips": {
+    "intake-conducted": "intake-conducted",
+    "entity-on-test": "entity-on-test",
+    "representative-approved": "representative-approved",
+    "contract-signed": "contract-signed",
+    "privacy-questions": "privacy-questions",
+    "production-connection": "production-connection"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "**/*.test.ts"
   ],
   "compilerOptions": {
-
     "strict": true,                        /* Enable all strict type-checking options. */
     "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     "strictNullChecks": true,              /* Enable strict null checks. */

--- a/tslint.json
+++ b/tslint.json
@@ -34,7 +34,8 @@
     "cyclomatic-complexity": [
       true,
       12
-    ]
+    ],
+    "eofline": true
   },
   "rulesDirectory": []
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -589,6 +589,11 @@
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.0.tgz#d1d55958d1fccc5527d4aba29fc9c4b942f563ff"
 
+"@types/chart.js@^2.7.40":
+  version "2.7.40"
+  resolved "https://registry.yarnpkg.com/@types/chart.js/-/chart.js-2.7.40.tgz#9e0fbfe8c21fecf1d1549659ede001284ddd636d"
+  integrity sha512-yC8Ff5vsHFTClGCWXoAmNCh33cNYfP2/yFANBLjLiso4jTKsLfQ0KQuBEuKxOWTRoOSLyT6v+ZYcvz0uonvvsA==
+
 "@types/jest@^23.3.2":
   version "23.3.9"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.9.tgz#c16b55186ee73ae65e001fbee69d392c51337ad1"
@@ -1649,6 +1654,29 @@ character-reference-invalid@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz#21e421ad3d84055952dab4a43a04e73cd425d3ed"
 
+chart.js@^2.7.3:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-2.7.3.tgz#cdb61618830bf216dc887e2f7b1b3c228b73c57e"
+  integrity sha512-3+7k/DbR92m6BsMUYP6M0dMsMVZpMnwkUyNSAbqolHKsbIzH2Q4LWVEHHYq7v0fmEV8whXE0DrjANulw9j2K5g==
+  dependencies:
+    chartjs-color "^2.1.0"
+    moment "^2.10.2"
+
+chartjs-color-string@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/chartjs-color-string/-/chartjs-color-string-0.5.0.tgz#8d3752d8581d86687c35bfe2cb80ac5213ceb8c1"
+  integrity sha512-amWNvCOXlOUYxZVDSa0YOab5K/lmEhbFNKI55PWc4mlv28BDzA7zaoQTGxSBgJMHIW+hGX8YUrvw/FH4LyhwSQ==
+  dependencies:
+    color-name "^1.0.0"
+
+chartjs-color@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/chartjs-color/-/chartjs-color-2.2.0.tgz#84a2fb755787ed85c39dd6dd8c7b1d88429baeae"
+  integrity sha1-hKL7dVeH7YXDndbdjHsdiEKbrq4=
+  dependencies:
+    chartjs-color-string "^0.5.0"
+    color-convert "^0.5.3"
+
 chokidar@^2.0.0, chokidar@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
@@ -1791,6 +1819,11 @@ collection-visit@^1.0.0:
   dependencies:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
+
+color-convert@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-0.5.3.tgz#bdb6c69ce660fadffe0b0007cc447e1b9f7282bd"
+  integrity sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=
 
 color-convert@^1.3.0, color-convert@^1.9.0:
   version "1.9.3"
@@ -4027,6 +4060,11 @@ istanbul-reports@^1.5.1:
   dependencies:
     handlebars "^4.0.3"
 
+jest-canvas-mock@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-1.1.0.tgz#f6ed0998b6be3ae2b7e095d7173441ae62cc831e"
+  integrity sha512-D2VoKl+L6r9VpqTPygXKvIOQ1aou7gz3PvstlWDZqPT7EVYcSz0Nj+yjJ9G+Y9EqJd2X95f3dzcmmXb2dvQ1DQ==
+
 jest-changed-files@^23.4.2:
   version "23.4.2"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-23.4.2.tgz#1eed688370cd5eebafe4ae93d34bb3b64968fe83"
@@ -4321,9 +4359,10 @@ jquery-mousewheel@~3.1.13:
   version "3.1.13"
   resolved "https://registry.yarnpkg.com/jquery-mousewheel/-/jquery-mousewheel-3.1.13.tgz#06f0335f16e353a695e7206bf50503cb523a6ee5"
 
-jquery@>=1.8.0, jquery@^3.2.1:
+jquery@3.3.1, jquery@>=1.8.0, jquery@^3.2.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
+  integrity sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==
 
 js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.4.9"
@@ -5061,6 +5100,11 @@ mkdirp@0.5.x, mkdirp@0.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp
   resolved "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+moment@^2.10.2:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+  integrity sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
On the servicepage the actual service state should be made visible
so it should become more intuitive for the enduser where in the
process the service connection request is.

 https://www.pivotaltracker.com/story/show/161719597

~~There are still some tasks that need to be done:~~

- [x] test the js status logic
- [x] add an entitylist per environment
- [x] optimize styling