### PR TITLE
Remove published prod entities unknown to manage

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Domain/Repository/EntityRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Repository/EntityRepository.php
@@ -49,4 +49,13 @@ interface EntityRepository
      * @return Entity[]
      */
     public function findByServiceId($serviceId);
+
+    /**
+     * @param string $status
+     * @param string $environment
+     * @param int $limit
+     *
+     * @return Entity[]
+     */
+    public function findByState($status, $environment, $limit = 10);
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Console/CleanOldProductionEntitiesCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Console/CleanOldProductionEntitiesCommand.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Console;
+
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityRepository;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\QueryServiceProviderException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CleanOldProductionEntitiesCommand extends Command
+{
+    /**
+     * @var EntityRepository
+     */
+    private $entityRepository;
+    /**
+     * @var QueryClient
+     */
+    private $productionManageClient;
+
+    /**
+     * @param EntityRepository $entityRepository
+     * @param QueryClient $productionManageClient
+     */
+    public function __construct(EntityRepository $entityRepository, QueryClient $productionManageClient)
+    {
+        $this->entityRepository = $entityRepository;
+        $this->productionManageClient = $productionManageClient;
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('sp-dashboard:clear-old-entities')
+            ->setDescription('Clears local manage production entities not known to Manage. No entities will be removed from manage.')
+            ->setHelp('This command will clear local published production entities not known in to the production Manage. ' .
+                'No entities will be removed from manage.');
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|null|void
+     * @throws QueryServiceProviderException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('Start');
+        do {
+            $output->writeln('Process next batch');
+        } while ($this->updateNextBatch($output));
+        $output->write("Done\n");
+    }
+
+    /**
+     * @param OutputInterface $output
+     * @return bool
+     * @throws QueryServiceProviderException
+     */
+    private function updateNextBatch(OutputInterface $output)
+    {
+        // fetch published production entities
+        $clearEntities = $this->entityRepository->findByState(Entity::STATE_PUBLISHED, Entity::ENVIRONMENT_PRODUCTION);
+        if (empty($clearEntities)) {
+            return false;
+        }
+
+        // remove entities in queue
+        /** @var $entity Entity */
+        foreach ($clearEntities as $entity) {
+            $output->write(sprintf("Delete entity: %s (local id)", $entity->getId()));
+            if ($entity->getManageId()) {
+                $output->write(sprintf("\t%s (manage)", $entity->getManageId()));
+            }
+            $output->writeln('');
+            $this->entityRepository->delete($entity);
+        }
+
+        return true;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Repository/EntityRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Repository/EntityRepository.php
@@ -72,6 +72,17 @@ class EntityRepository extends DoctrineEntityRepository implements EntityReposit
         ]);
     }
 
+    /**
+     * @inheritdoc
+     */
+    public function findByState($status, $environment, $limit = 10)
+    {
+        return parent::findBy([
+            'status' => $status,
+            'environment' => $environment,
+        ], null, $limit, 0);
+    }
+
     public function delete(Entity $entity)
     {
         $this->_em->remove($entity);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -238,3 +238,10 @@ services:
         arguments:
         - base_uri: "%manage_prod_host%"
           auth: ["%manage_prod_username%", "%manage_prod_password%", "Basic"]
+
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Console\CleanOldProductionEntitiesCommand:
+        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Console\CleanOldProductionEntitiesCommand
+        arguments:
+          - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\EntityRepository'
+          - '@surfnet.manage.client.query_client.prod_environment'
+        tags: ['console.command']

--- a/tests/webtests/CleanOldProductionEntitiesCommandTest.php
+++ b/tests/webtests/CleanOldProductionEntitiesCommandTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Webtests;
+
+use GuzzleHttp\Psr7\Response;
+use Ramsey\Uuid\Uuid;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class CleanOldProductionEntitiesCommandTest extends WebTestCase
+{
+
+    const NOF_PUBLISHED_ON_PRODUCTION_ENTITIES = 20;
+    const NOF_DRAFT_ON_PRODUCTION_ENTITIES = 2;
+
+    public function setUp($loadFixtures = true)
+    {
+        parent::setUp();
+
+        $this->loadFixtures();
+
+        $this->addTestEntities(self::NOF_PUBLISHED_ON_PRODUCTION_ENTITIES, self::NOF_DRAFT_ON_PRODUCTION_ENTITIES);
+    }
+
+    public function testExecute()
+    {
+        $kernel = $this->client->getKernel();
+
+        $application = new Application($kernel);
+
+        $command = $application->find('sp-dashboard:clear-old-entities');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array(
+            'command'  => $command->getName(),
+        ));
+
+        // test the result
+        $output = $commandTester->getDisplay();
+        $this->assertContains('Done', $output);
+
+        // test the entities
+        $ids = [];
+        $allEntities = $this->getEntityRepository()->findAll();
+        foreach ($allEntities as $entity) {
+            $ids[] = $entity->getEntityId();
+        }
+
+        // assert remaining entities
+        $this->assertSame([
+            'SP1',
+            'SP2',
+            'b8e7cffd-0409-45c7-a37a-000000000000',
+            'b8e7cffd-0409-45c7-a37a-000000000001',
+        ], $ids);
+    }
+
+    /**
+     * @param int $nofInvalid
+     * @param int $nofValid
+     */
+    private function addTestEntities($nofInvalid, $nofValid)
+    {
+        $service = new Service();
+        $service->setName('Console action test service');
+        $service->setTeamName('team-x');
+        $service->setGuid(Uuid::uuid4());
+
+        $this->getServiceRepository()->save($service);
+
+        for ($i = 0; $i < $nofInvalid; $i++) {
+            $id = 'a8e7cffd-0409-45c7-a37a-' . str_pad($i, 12, '0', STR_PAD_LEFT);
+            $entity = new Entity();
+            $entity->setId($id);
+            $entity->setService($service);
+            $entity->setManageId($id);
+            $entity->setEntityId($id);
+            $entity->setStatus(Entity::STATE_PUBLISHED);
+            $entity->setEnvironment(Entity::ENVIRONMENT_PRODUCTION);
+
+            $this->getEntityRepository()->save($entity);
+        }
+
+        for ($i = 0; $i < $nofValid; $i++) {
+            $id = 'b8e7cffd-0409-45c7-a37a-' . str_pad($i, 12, '0', STR_PAD_LEFT);
+            $entity = new Entity();
+            $entity->setId($id);
+            $entity->setService($service);
+            $entity->setManageId($id);
+            $entity->setEntityId($id);
+            $entity->setStatus(Entity::STATE_DRAFT);
+            $entity->setEnvironment(Entity::ENVIRONMENT_PRODUCTION);
+
+            $this->getEntityRepository()->save($entity);
+        }
+    }
+}


### PR DESCRIPTION
Because of the separation of manage in a production and a test
environment the old published to production entities needed to be
cleaned from the local database.

 https://www.pivotaltracker.com/story/show/162051868