### PR TITLE
Introduction of Jira integration

### DIFF
--- a/ansible/roles/spdashboard/defaults/main.yml
+++ b/ansible/roles/spdashboard/defaults/main.yml
@@ -14,3 +14,6 @@ spdashboard_saml_metadata_privatekey: "%kernel.root_dir%/../vendor/surfnet/stepu
 spdashboard_support_email: coin-logs-dev@list.surfnet.nl
 spdashboard_manage_prod_host: "https://manage-prod.{{ base_domain }}"
 spdashboard_nodejs_rpm_url: "https://rpm.nodesource.com/pub_11.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm"
+spdashboard_jira_host: https://jira-test.surfnet.nl
+spdashboard_jira_username: username
+spdashboard_jira_password: password

--- a/ansible/roles/spdashboard/templates/parameters.yml.j2
+++ b/ansible/roles/spdashboard/templates/parameters.yml.j2
@@ -34,4 +34,7 @@ parameters:
     manage_prod_host: {{ spdashboard_manage_prod_host }}
     manage_prod_username: sp-dashboard
     manage_prod_password: {{ manage_prod_sp_dashboard_secret }}
+    jira_host: {{ spdashboard_jira_host }}
+    jira_username: {{ spdashboard_jira_username }}
+    jira_password: {{ spdashboard_jira_password }}
 

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -55,3 +55,8 @@ parameters:
     mail_from: support@surfconext.nl
     mail_receiver: support@surfconext.nl
     mail_no_reply: no-reply@surfconext.nl
+
+    # Jira settings
+    jira_host: https://jira.example.com
+    jira_username: sp-dashboard
+    jira_password: secret

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "jeremykendall/php-domain-parser": "~1.3.1",
         "knplabs/knp-menu-bundle": "^2.1",
         "league/tactician-bundle": "^0.4.1",
+        "lesstif/php-jira-rest-client": "^1.33",
         "lexik/translation-bundle": "^4.0",
         "openconext/monitor-bundle": "^1.0",
         "ramsey/uuid": "^3.7",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea5373567334b44f681bbe27593fdfa4",
+    "content-hash": "9fd6a0f415e46611c643f801adcfeba0",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -1625,6 +1625,66 @@
             "time": "2016-04-21T08:00:01+00:00"
         },
         {
+            "name": "lesstif/php-jira-rest-client",
+            "version": "1.33.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lesstif/php-jira-rest-client.git",
+                "reference": "bbdd25e4ecfd1fe9123078a943ab1edf014d1745"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lesstif/php-jira-rest-client/zipball/bbdd25e4ecfd1fe9123078a943ab1edf014d1745",
+                "reference": "bbdd25e4ecfd1fe9123078a943ab1edf014d1745",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "monolog/monolog": "~1.12",
+                "netresearch/jsonmapper": "~0.11|^1.0",
+                "php": ">=5.5.9",
+                "vlucas/phpdotenv": "~1.0|~2.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": ">=5.7 <6",
+                "symfony/var-dumper": "~2.8|~3.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "JiraRestApi\\JiraRestApiServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JiraRestApi\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "KwangSeob Jeong",
+                    "email": "lesstif@gmail.com",
+                    "homepage": "http://lesstif.com/"
+                }
+            ],
+            "description": "JIRA REST API Client for PHP Users.",
+            "keywords": [
+                "jira",
+                "jira-php",
+                "jira-rest",
+                "rest"
+            ],
+            "time": "2018-11-02T11:18:12+00:00"
+        },
+        {
             "name": "lexik/translation-bundle",
             "version": "v4.0.12",
             "source": {
@@ -1767,6 +1827,48 @@
                 "psr-3"
             ],
             "time": "2018-11-05T09:00:11+00:00"
+        },
+        {
+            "name": "netresearch/jsonmapper",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweiske/jsonmapper.git",
+                "reference": "3868fe1128ce1169228acdb623359dca74db5ef3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/3868fe1128ce1169228acdb623359dca74db5ef3",
+                "reference": "3868fe1128ce1169228acdb623359dca74db5ef3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8.35 || ~5.7 || ~6.4",
+                "squizlabs/php_codesniffer": "~1.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JsonMapper": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "OSL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Weiske",
+                    "email": "cweiske@cweiske.de",
+                    "homepage": "http://github.com/cweiske/jsonmapper/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Map nested JSON structures onto PHP classes",
+            "time": "2017-11-28T21:30:01+00:00"
         },
         {
             "name": "ocramius/proxy-manager",
@@ -3437,6 +3539,56 @@
                 "templating"
             ],
             "time": "2018-07-13T07:12:17+00:00"
+        },
+        {
+            "name": "vlucas/phpdotenv",
+            "version": "v2.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vlucas/phpdotenv.git",
+                "reference": "8abb4f9aa89ddea9d52112c65bbe8d0125e2fa8e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/8abb4f9aa89ddea9d52112c65bbe8d0125e2fa8e",
+                "reference": "8abb4f9aa89ddea9d52112c65bbe8d0125e2fa8e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dotenv\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Vance Lucas",
+                    "email": "vance@vancelucas.com",
+                    "homepage": "http://www.vancelucas.com"
+                }
+            ],
+            "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "time": "2018-07-29T20:33:41+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Repository/TicketRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Repository/TicketRepository.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Domain\Repository;
+
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Ticket;
+
+interface TicketRepository
+{
+    /**
+     * TODO set the required parameters to build an issue.
+     *
+     * @param Ticket $ticket
+     * @return Ticket
+     */
+    public function createIssue(Ticket $ticket);
+}

--- a/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Ticket.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Ticket.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Domain\ValueObject;
+
+class Ticket
+{
+    private $summary;
+
+    private $description;
+
+    public function __construct($summary, $description)
+    {
+        $this->summary = $summary;
+        $this->description = $description;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getSummary()
+    {
+        return $this->summary;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -278,3 +278,9 @@ services:
           - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\EntityRepository'
           - '@surfnet.manage.client.query_client.prod_environment'
         tags: ['console.command']
+
+    Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Client\JiraServiceFactory:
+        arguments:
+            - '%jira_host%'
+            - '%jira_username%'
+            - '%jira_password%'

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Factory/IssueFieldFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Factory/IssueFieldFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Factory;
+
+use JiraRestApi\Issue\IssueField;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Ticket;
+
+class IssueFieldFactory
+{
+    public function fromTicket(Ticket $ticket)
+    {
+        $issueField = new IssueField();
+        $issueField->setProjectKey("CTX")
+            ->setSummary($ticket->getSummary())
+            ->setPriorityName("Critical")
+            ->setIssueType("Bug")
+            ->setDescription($ticket->getDescription());
+
+        return $issueField;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Factory/JiraServiceFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Factory/JiraServiceFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Factory;
+
+use JiraRestApi\Configuration\ArrayConfiguration;
+use JiraRestApi\Issue\IssueService;
+
+class JiraServiceFactory
+{
+    /**
+     * @var ArrayConfiguration
+     */
+    private $config;
+
+    /**
+     * @param string $host
+     * @param string $username
+     * @param string $password
+     */
+    public function __construct($host, $username, $password)
+    {
+        // Create a IssueService with a Jira connection built in.
+        $this->config = new ArrayConfiguration([
+            'jiraHost' => $host,
+            'jiraUser' => $username,
+            'jiraPassword' => $password
+        ]);
+    }
+
+    public function buildIssueService()
+    {
+        return new IssueService($this->config);
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Service/IssueService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Service/IssueService.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Service;
+
+use Psr\Log\LoggerInterface;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\TicketRepository;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Ticket;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Client\IssueFieldFactoryTest;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Client\JiraServiceFactoryTest;
+
+class IssueService implements TicketRepository
+{
+    /**
+     * @var JiraServiceFactoryTest
+     */
+    private $factory;
+
+    /**
+     * @var IssueFieldFactoryTest
+     */
+    private $fieldFactory;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param JiraServiceFactoryTest $jiraFactory
+     * @param IssueFieldFactoryTest $issueFieldFactory
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        JiraServiceFactoryTest $jiraFactory,
+        IssueFieldFactoryTest $issueFieldFactory,
+        LoggerInterface $logger
+    ) {
+        $this->factory = $jiraFactory;
+        $this->fieldFactory = $issueFieldFactory;
+        $this->logger = $logger;
+    }
+
+    public function createIssue(Ticket $ticket)
+    {
+        $this->logger->info("Creating a Jira issue.");
+
+        $issueField = $this->fieldFactory->fromTicket($ticket);
+
+        return $this->factory
+            ->buildIssueService()
+            ->create($issueField);
+    }
+}

--- a/tests/unit/Infrastructure/Jira/Factory/IssueFieldFactoryTest.php
+++ b/tests/unit/Infrastructure/Jira/Factory/IssueFieldFactoryTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\Jira\Factory;
+
+use PHPUnit_Framework_TestCase;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Ticket;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Factory\IssueFieldFactory;
+
+class IssueFieldFactoryTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var IssueFieldFactory
+     */
+    private $factory;
+
+    public function setUp()
+    {
+        $this->factory = new IssueFieldFactory();
+    }
+
+    public function test_build_issue_field_from_ticket()
+    {
+        $ticket = new Ticket('Summary', 'Description');
+        $issueField = $this->factory->fromTicket($ticket);
+
+        $this->assertEquals('Summary', $issueField->summary);
+        $this->assertEquals('Description', $issueField->description);
+    }
+}

--- a/tests/unit/Infrastructure/Jira/Factory/JiraServiceFactoryTest.php
+++ b/tests/unit/Infrastructure/Jira/Factory/JiraServiceFactoryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\Jira\Factory;
+
+use JiraRestApi\Issue\IssueService;
+use PHPUnit_Framework_TestCase;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Factory\JiraServiceFactory;
+
+class JiraServiceFactoryTest extends PHPUnit_Framework_TestCase
+{
+    public function test_build_issue_service()
+    {
+        $hostname = 'https://jira.example.com/';
+        $username = 'user';
+        $password = 'secret';
+        $factory = new JiraServiceFactory($hostname, $username, $password);
+
+        $issueService = $factory->buildIssueService();
+
+        $this->assertInstanceOf(IssueService::class, $issueService);
+    }
+}

--- a/tests/unit/Infrastructure/Jira/Service/IssueServiceTest.php
+++ b/tests/unit/Infrastructure/Jira/Service/IssueServiceTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\Jira\Service;
+
+use JiraRestApi\Issue\Issue;
+use JiraRestApi\Issue\IssueField;
+use JiraRestApi\Issue\IssueService as JiraIssueService;
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery\Mock;
+use Psr\Log\LoggerInterface;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Ticket;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Client\IssueFieldFactoryTest;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Client\JiraServiceFactoryTest;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Service\IssueService;
+
+class IssueServiceTest extends MockeryTestCase
+{
+    /**
+     * @var IssueService
+     */
+    private $service;
+
+    /**
+     * @var JiraServiceFactoryTest|Mock
+     */
+    private $factory;
+    /**
+     * @var IssueFieldFactoryTest|Mock
+     */
+    private $ticketFactory;
+
+    /**
+     * @var LoggerInterface|Mock
+     */
+    private $logger;
+
+    /**
+     * @var JiraIssueService|Mock
+     */
+    private $jiraIssueService;
+
+    public function setUp()
+    {
+        $this->factory = m::mock(JiraServiceFactoryTest::class);
+        $this->ticketFactory = m::mock(IssueFieldFactoryTest::class);
+        $this->jiraIssueService = m::mock(JiraIssueService::class);
+        $this->logger = m::mock(LoggerInterface::class);
+        $this->service = new IssueService($this->factory, $this->ticketFactory, $this->logger);
+    }
+
+    public function test_create_issue()
+    {
+        // Todo: This test is boilerplate for later implementation!
+
+        $this->logger
+            ->shouldReceive('info')
+            ->once();
+
+        $this->factory
+            ->shouldReceive('buildIssueService')
+            ->andReturn($this->jiraIssueService)
+            ->once();
+
+        $ticket = new Ticket('summary', 'description');
+
+        $issue = new Issue();
+        $issueField = new IssueField();
+        $issue->fields = $issueField;
+
+        $this->jiraIssueService
+            ->shouldReceive('create')
+            ->with($issueField)
+            ->andReturn($issue);
+
+        $this->ticketFactory
+            ->shouldReceive('fromTicket')
+            ->with($ticket)
+            ->andReturn($issueField);
+
+        $jiraIssue = $this->service->createIssue($ticket);
+
+        $this->assertInstanceOf(Issue::class, $jiraIssue);
+    }
+}


### PR DESCRIPTION
Using the php-jira-rest-client, a Jira issue creation service has been built to provide proof of concept. 
This service for now is able to create a simple jira ticket. The final implementation awaits input from the product owners.

https://www.pivotaltracker.com/story/show/162191079