### PR TITLE
Add the entity type dialog screen

### DIFF
--- a/app/Resources/views/modal.html.twig
+++ b/app/Resources/views/modal.html.twig
@@ -1,0 +1,10 @@
+<header>
+    <h1>{% block page_heading %}{% endblock %}</h1>
+</header>
+<div class="modal-container">
+    {% block body_container %}
+    <div class="card">
+        {% block body %}{% endblock %}
+    </div>
+    {% endblock %}
+</div>

--- a/app/js/application.js
+++ b/app/js/application.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import 'jquery';
+import './type_definitions.ts';
 import './components/service_switcher.js';
 import './components/service_form.ts';
 import './components/service_status.ts';
@@ -8,4 +9,4 @@ import './components/validation.js';
 import './components/service_edit_attribute.js';
 import './components/translation_ui.js';
 import './components/tooltips.js';
-import './components/modal.js';
+import './components/modal.ts';

--- a/app/js/application.js
+++ b/app/js/application.js
@@ -8,3 +8,4 @@ import './components/validation.js';
 import './components/service_edit_attribute.js';
 import './components/translation_ui.js';
 import './components/tooltips.js';
+import './components/modal.js';

--- a/app/js/components/modal.js
+++ b/app/js/components/modal.js
@@ -1,0 +1,8 @@
+'use strict';
+
+require('jquery-modal');
+
+$.modal.defaults = {
+    // Dont show the close button, a cancel button on the modal should perform this task
+    showClose: false
+};

--- a/app/js/components/modal.js
+++ b/app/js/components/modal.js
@@ -1,8 +1,0 @@
-'use strict';
-
-require('jquery-modal');
-
-$.modal.defaults = {
-    // Dont show the close button, a cancel button on the modal should perform this task
-    showClose: false
-};

--- a/app/js/components/modal.ts
+++ b/app/js/components/modal.ts
@@ -1,0 +1,7 @@
+import * as $ from 'jquery';
+import 'jquery-modal';
+
+$.modal.defaults = {
+  // Dont show the close button, a cancel button on the modal should perform this task
+  showClose: false,
+};

--- a/app/js/type_definitions.ts
+++ b/app/js/type_definitions.ts
@@ -1,0 +1,5 @@
+interface JQueryStatic {
+  // The jquery.modal type definition.
+  // The modal function is used to override the modal default configuration settings: `$.modal.defaults = {}`
+  modal: any;
+}

--- a/app/scss/components/form.scss
+++ b/app/scss/components/form.scss
@@ -3,6 +3,12 @@ form {
     position: relative;
   }
 
+  .button.blue{
+    background-color: $blue;
+    color: #fff;
+    border: none;
+  }
+
   .help-button {
     i.fa {
       color: $blue;
@@ -23,6 +29,17 @@ form {
       margin-right: 25px;
     }
   }
+
+  div.button-row {
+    display: block;
+    height: 30px;
+    margin: 15px 0;
+
+    .button {
+      margin: 0 15px 0 0;
+    }
+  }
+
 }
 
 .tippy-tooltip.light-theme {

--- a/app/scss/components/modal.scss
+++ b/app/scss/components/modal.scss
@@ -1,0 +1,26 @@
+@import "~jquery-modal/jquery.modal.css";
+
+.blocker {
+  background-color: rgba(95,95,95,.7);
+}
+.modal {
+  background-color: #f5f5f5;
+  border-radius: 3px;
+  outline: none;
+  padding: 0;
+  box-shadow: 1px 1px 6px 0 #5f5f5f;
+  max-width: 600px;
+
+  header {
+    background-color: #4db2cf;
+    padding: 15px;
+    color: #fff;
+    text-transform: uppercase;
+    font-size: large;
+    font-weight: 700;
+  }
+
+  .modal-container {
+    padding: 15px 30px;
+  }
+}

--- a/app/scss/pages/choose_entity_type.scss
+++ b/app/scss/pages/choose_entity_type.scss
@@ -1,0 +1,14 @@
+.entity-type {
+  form {
+    .form-row {
+      .radio-container {
+        width: 40%;
+      }
+    }
+    div {
+      width: 100%;
+      clear: both;
+    }
+  }
+}
+

--- a/app/scss/pages/choose_entity_type.scss
+++ b/app/scss/pages/choose_entity_type.scss
@@ -2,6 +2,7 @@
   form {
     .form-row {
       .radio-container {
+        background-color: white;
         width: 40%;
       }
     }

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,3 +6,4 @@
 3. [Frontend tooling](frontend_tooling.md)
 3. [Translations](translations.md)
 3. [Legacy code](legacy_code.md)
+3. [Third party frontend packages](third_party_packages.md)

--- a/docs/third_party_packages.md
+++ b/docs/third_party_packages.md
@@ -1,0 +1,22 @@
+# Use of third party frontend packages
+
+## Donut charts
+ChartJS is used to render the donut chars on the service overview page.
+- https://www.chartjs.org/
+
+## Form validation
+ParsleyJS is used for advanced form validation
+- http://parsleyjs.org/
+
+## Modal windows
+jQuery modals are used to deal with modal windows.
+- https://github.com/kylefox/jquery-modal
+- http://jquerymodal.com/
+
+## Select element styling
+The service switcher utilizes the Select2 library to provide improved filtering of the select options.
+- https://select2.org/
+
+## Tooltips
+Tippy is used for showing 'on-hover' tooltips.
+- https://atomiks.github.io/tippyjs/)

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/jquery": "^3.3.22",
     "chart.js": "^2.7.3",
     "jquery": "^3.2.1",
+    "jquery-modal": "^0.9.1",
     "parsleyjs": "^2.8.1",
     "select2": "^4.0.3",
     "tippy.js": "^2.0.2"

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
@@ -48,6 +48,9 @@ class Entity
     const STATE_DRAFT = 'draft';
     const STATE_PUBLISHED = 'published';
 
+    const TYPE_SAML = 'saml20';
+    const TYPE_OPENID_CONNECT = 'oidc';
+
     /**
      * @var string
      *

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Command/Entity/ChooseEntityTypeCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Command/Entity/ChooseEntityTypeCommand.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Command\Entity;
+
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+
+class ChooseEntityTypeCommand
+{
+    /**
+     * @var string
+     */
+    private $type;
+
+    public function __construct($type = Entity::TYPE_SAML)
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param string $type
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
@@ -28,6 +28,8 @@ use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentExcept
 use Surfnet\ServiceProviderDashboard\Application\Exception\ServiceNotFoundException;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Command\Entity\ChooseEntityTypeCommand;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity\ChooseEntityTypeType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity\EntityType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\FormInterface;
@@ -44,17 +46,35 @@ class EntityCreateController extends Controller
 
     /**
      * @Method({"GET", "POST"})
-     * @Route("/entity/create/type", name="entity_type")
+     * @Route(
+     *     "/entity/create/type/{targetEnvironment}",
+     *     defaults={
+     *          "targetEnvironment" = "test",
+     *     },
+     *     name="entity_type"
+     * )
      * @Security("has_role('ROLE_USER')")
      * @Template("@Dashboard/EntityType/type.html.twig")
      *
      * @param Request $request
      *
-     * @return Response
+     * @param $targetEnvironment
+     * @return array
      */
-    public function typeAction(Request $request)
+    public function typeAction(Request $request, $targetEnvironment)
     {
-        return [];
+        $command = new ChooseEntityTypeCommand();
+        $form = $this->createForm(ChooseEntityTypeType::class, $command);
+
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+            // forward to create action.
+            return $this->redirectToRoute('entity_add', ['targetEnvironment' => $targetEnvironment]);
+        }
+
+        return [
+            'form' => $form->createView(),
+        ];
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
@@ -43,6 +43,21 @@ class EntityCreateController extends Controller
     use EntityControllerTrait;
 
     /**
+     * @Method({"GET", "POST"})
+     * @Route("/entity/create/type", name="entity_type")
+     * @Security("has_role('ROLE_USER')")
+     * @Template("@Dashboard/EntityType/type.html.twig")
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function typeAction(Request $request)
+    {
+        return [];
+    }
+
+    /**
      * The create action serves two routes.
      *
      *  1. entity_add to create new entities.

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
@@ -74,6 +74,7 @@ class EntityCreateController extends Controller
 
         return [
             'form' => $form->createView(),
+            'environment' => $targetEnvironment,
         ];
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/ChooseEntityTypeType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/ChooseEntityTypeType.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity;
+
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Command\Entity\ChooseEntityTypeCommand;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ChooseEntityTypeType extends AbstractType
+{
+    /**
+     * @param FormBuilderInterface $builder
+     * @param array $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('type', ChoiceType::class, [
+                'choices' => [
+                    'SAML 2.0' => Entity::TYPE_SAML,
+                    'OpenID Connect' => Entity::TYPE_OPENID_CONNECT
+                ],
+                'expanded' => true,
+                'multiple' => false,
+            ])
+            ->add('create', SubmitType::class, ['attr' => ['class' => 'button pull-right']]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => ChooseEntityTypeCommand::class
+        ));
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'dashboard_bundle_choose_entity_type';
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/ChooseEntityTypeType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/ChooseEntityTypeType.php
@@ -22,7 +22,6 @@ use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Command\Entity\ChooseEntityTypeCommand;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -40,10 +39,10 @@ class ChooseEntityTypeType extends AbstractType
                     'SAML 2.0' => Entity::TYPE_SAML,
                     'OpenID Connect' => Entity::TYPE_OPENID_CONNECT
                 ],
+                'label' => false,
                 'expanded' => true,
                 'multiple' => false,
-            ])
-            ->add('create', SubmitType::class, ['attr' => ['class' => 'button pull-right']]);
+            ]);
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -132,6 +132,8 @@ entity.published_production.text.html: "Thanks for publishing \"%entityName%\" t
 entity.published_production.title: "Successfully published the entity to production"
 entity.published_test.text.html: "Thanks for publishing \"%entityName%\" to our test environment."
 entity.published_test.title: "Successfully published the entity to test"
+entity.type.title: New entity?
+entity.type.description.html: "<p><strong>Lorem ipsum dolor sit amet</strong> Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim <strong>ad minim</strong> veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore.<p>"
 privacy.edit.title: GDPR related questions
 privacy.edit.introduction.html: "<p><strong>Pellentesque habitant morbi tristique</strong> senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. <em>Aenean ultricies mi vitae est.</em> Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, <code>commodo vitae</code>, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. <a href=\"#\">Donec non enim</a> in turpis pulvinar facilisis. Ut felis.</p>"
 privacy.form.label.accessData.html: 2. Who can access the data?

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityList/list.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityList/list.html.twig
@@ -11,12 +11,12 @@
 {% block body %}
     {% if not no_service_selected %}
     <div class="add-entity-actions">
-        <a href="{{ path('entity_add') }}">
+        <a href="{{ path('entity_type') }}">
             <i class="fa fa-plus"></i>
             {{ 'entity.list.add_to_test'|trans}}
         </a>
         {% if production_entities_enabled %}
-            <a href="{{ path('entity_add', {targetEnvironment: "production"}) }}">
+            <a href="{{ path('entity_type', {targetEnvironment: "production"}) }}">
                 <i class="fa fa-plus"></i>
                 {{ 'entity.list.add_to_production'|trans}}
             </a>

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityList/list.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityList/list.html.twig
@@ -11,12 +11,12 @@
 {% block body %}
     {% if not no_service_selected %}
     <div class="add-entity-actions">
-        <a href="{{ path('entity_type') }}">
+        <a href="#add-for-test" rel="modal:open">
             <i class="fa fa-plus"></i>
             {{ 'entity.list.add_to_test'|trans}}
         </a>
         {% if production_entities_enabled %}
-            <a href="{{ path('entity_type', {targetEnvironment: "production"}) }}">
+            <a href="#add-for-production" rel="modal:open">
                 <i class="fa fa-plus"></i>
                 {{ 'entity.list.add_to_production'|trans}}
             </a>
@@ -109,5 +109,13 @@
         </tbody>
     </table>
     {% endif %}
+
+    <div class="modal" id="add-for-test">
+        {{ render(controller('DashboardBundle:EntityCreate:type', {targetEnvironment: "test"})) }}
+    </div>
+
+    <div class="modal" id="add-for-production">
+        {{ render(controller('DashboardBundle:EntityCreate:type', {targetEnvironment: "production"})) }}
+    </div>
 
 {% endblock %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityType/type.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityType/type.html.twig
@@ -1,3 +1,5 @@
+{% form_theme form 'form/fields.html.twig' %}
+
 {% extends '::base.html.twig' %}
 
 {% block page_heading %} {{ 'entity.type.title'|trans }} {% endblock %}
@@ -5,5 +7,7 @@
 {% block body %}
 
     <div class="wysiwyg">{{ 'entity.type.description.html'|trans|raw }}</div>
+
+    <div class="row entity-type">{{ form(form, {'attr': {'novalidate': 'novalidate'}}) }}</div>
 
 {% endblock %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityType/type.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityType/type.html.twig
@@ -1,0 +1,9 @@
+{% extends '::base.html.twig' %}
+
+{% block page_heading %} {{ 'entity.type.title'|trans }} {% endblock %}
+
+{% block body %}
+
+    <div class="wysiwyg">{{ 'entity.type.description.html'|trans|raw }}</div>
+
+{% endblock %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityType/type.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityType/type.html.twig
@@ -1,6 +1,6 @@
 {% form_theme form 'form/fields.html.twig' %}
 
-{% extends '::base.html.twig' %}
+{% extends '::modal.html.twig' %}
 
 {% block page_heading %} {{ 'entity.type.title'|trans }} {% endblock %}
 
@@ -8,6 +8,15 @@
 
     <div class="wysiwyg">{{ 'entity.type.description.html'|trans|raw }}</div>
 
-    <div class="row entity-type">{{ form(form, {'attr': {'novalidate': 'novalidate'}}) }}</div>
+    <div class="row entity-type">
+        {{ form_start(form, {'action': path('entity_type', {'targetEnvironment': environment})}) }}
+        {{ form_widget(form) }}
+
+        <div class="button-row">
+            <button type="submit" class="button pull-right blue">Create</button>
+            <a href="#close" class="button pull-right" rel="modal:close">Cancel</a>
+        </div>
+
+        {{ form_end(form) }}
 
 {% endblock %}

--- a/tests/webtests/EntityListTest.php
+++ b/tests/webtests/EntityListTest.php
@@ -166,17 +166,27 @@ class EntityListTest extends WebTestCase
 
         $crawler = $this->client->request('GET', '/entities');
 
-        // Click the add for test link and verify the entity/create/type path is active
-        $link = $crawler->selectLink('Add for test')->link();
-        $this->client->click($link);
+        // Assert the two modal windows are on the page and have a form with appropriate form actions.
+        $modalTest = $crawler->filter('#add-for-test form');
+        $modalProd = $crawler->filter('#add-for-production form');
+        $testAction = $modalTest->first()->attr('action');
+        $prodAction = $modalProd->first()->attr('action');
+
+        $this->assertEquals('/entity/create/type', $testAction);
+        $this->assertEquals('/entity/create/type/production', $prodAction);
+
+        // Now submit one of the forms and ascertain we ended up on the edit entity form
+        $form = $crawler->filter('#add-for-test')
+            ->selectButton('Create')
+            ->form();
+        $this->client->submit($form);
+        $this->assertTrue(
+            $this->client->getResponse() instanceof RedirectResponse,
+            'Expected a redirect to the /entity/create/type action'
+        );
+
         $this->assertRegExp('/\/entity\/create\/type/', $this->client->getRequest()->getRequestUri());
 
-        // Go back to overview page, and click the add for production link
-        $crawler = $this->client->request('GET', '/entities');
-
-        // Click the add for test link and verify the entity/create/type/production path is active
-        $link = $crawler->selectLink('Add for production')->link();
-        $this->client->click($link);
-        $this->assertRegExp('/\/entity\/create\/type\/production/', $this->client->getRequest()->getRequestUri());
+        // TODO: test submitting to the openidconnect form that is yet to be created
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -592,7 +592,6 @@
 "@types/chart.js@^2.7.40":
   version "2.7.40"
   resolved "https://registry.yarnpkg.com/@types/chart.js/-/chart.js-2.7.40.tgz#9e0fbfe8c21fecf1d1549659ede001284ddd636d"
-  integrity sha512-yC8Ff5vsHFTClGCWXoAmNCh33cNYfP2/yFANBLjLiso4jTKsLfQ0KQuBEuKxOWTRoOSLyT6v+ZYcvz0uonvvsA==
 
 "@types/jest@^23.3.2":
   version "23.3.9"
@@ -1657,7 +1656,6 @@ character-reference-invalid@^1.0.0:
 chart.js@^2.7.3:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-2.7.3.tgz#cdb61618830bf216dc887e2f7b1b3c228b73c57e"
-  integrity sha512-3+7k/DbR92m6BsMUYP6M0dMsMVZpMnwkUyNSAbqolHKsbIzH2Q4LWVEHHYq7v0fmEV8whXE0DrjANulw9j2K5g==
   dependencies:
     chartjs-color "^2.1.0"
     moment "^2.10.2"
@@ -1665,14 +1663,12 @@ chart.js@^2.7.3:
 chartjs-color-string@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/chartjs-color-string/-/chartjs-color-string-0.5.0.tgz#8d3752d8581d86687c35bfe2cb80ac5213ceb8c1"
-  integrity sha512-amWNvCOXlOUYxZVDSa0YOab5K/lmEhbFNKI55PWc4mlv28BDzA7zaoQTGxSBgJMHIW+hGX8YUrvw/FH4LyhwSQ==
   dependencies:
     color-name "^1.0.0"
 
 chartjs-color@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/chartjs-color/-/chartjs-color-2.2.0.tgz#84a2fb755787ed85c39dd6dd8c7b1d88429baeae"
-  integrity sha1-hKL7dVeH7YXDndbdjHsdiEKbrq4=
   dependencies:
     chartjs-color-string "^0.5.0"
     color-convert "^0.5.3"
@@ -1823,7 +1819,6 @@ collection-visit@^1.0.0:
 color-convert@^0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-0.5.3.tgz#bdb6c69ce660fadffe0b0007cc447e1b9f7282bd"
-  integrity sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=
 
 color-convert@^1.3.0, color-convert@^1.9.0:
   version "1.9.3"
@@ -4063,7 +4058,6 @@ istanbul-reports@^1.5.1:
 jest-canvas-mock@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-1.1.0.tgz#f6ed0998b6be3ae2b7e095d7173441ae62cc831e"
-  integrity sha512-D2VoKl+L6r9VpqTPygXKvIOQ1aou7gz3PvstlWDZqPT7EVYcSz0Nj+yjJ9G+Y9EqJd2X95f3dzcmmXb2dvQ1DQ==
 
 jest-changed-files@^23.4.2:
   version "23.4.2"
@@ -4355,14 +4349,17 @@ jest@^23.6.0:
     import-local "^1.0.0"
     jest-cli "^23.6.0"
 
+jquery-modal@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/jquery-modal/-/jquery-modal-0.9.1.tgz#f22f13f0efa5ea3f2afaeb7981c1e20114c9d2f2"
+
 jquery-mousewheel@~3.1.13:
   version "3.1.13"
   resolved "https://registry.yarnpkg.com/jquery-mousewheel/-/jquery-mousewheel-3.1.13.tgz#06f0335f16e353a695e7206bf50503cb523a6ee5"
 
-jquery@3.3.1, jquery@>=1.8.0, jquery@^3.2.1:
+jquery@>=1.8.0, jquery@^3.2.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
-  integrity sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==
 
 js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.4.9"
@@ -5104,7 +5101,6 @@ mkdirp@0.5.x, mkdirp@0.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp
 moment@^2.10.2:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
-  integrity sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
In this dialog, the user can select the option to add either a SAML2 or OpenID connect entity.

The scope of this PR is to add the screen and integrate it into the current workflow untill the rendering of the entity create form. This will be taken care of in an upcoming PR.

Details: https://www.pivotaltracker.com/story/show/161720049