### PR TITLE
Set the required Jira ticket fields

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Ticket.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Ticket.php
@@ -20,22 +20,56 @@ namespace Surfnet\ServiceProviderDashboard\Domain\ValueObject;
 
 class Ticket
 {
+    /** @var string */
+    private $applicantEmail;
+    /** @var string */
+    private $applicantName;
+    /** @var string */
+    private $assignee = 'conext-beheer';
+    /** @var string */
+    private $description;
+    /** @var string */
+    private $entityId;
+    /** @var string */
+    private $issueType = 'spd-delete-production-entity';
+    /** @var string */
+    private $priority = 'Medium';
+    /** @var string */
+    private $reporter = 'sp-dashboard';
+    /** @var string */
     private $summary;
 
-    private $description;
-
-    public function __construct($summary, $description)
+    public function __construct($summary, $description, $entityId, $applicantName, $applicantEmail)
     {
         $this->summary = $summary;
         $this->description = $description;
+        $this->entityId = $entityId;
+        $this->applicantName = $applicantName;
+        $this->applicantEmail = $applicantEmail;
     }
 
     /**
-     * @return mixed
+     * @return string
      */
-    public function getSummary()
+    public function getApplicantEmail()
     {
-        return $this->summary;
+        return $this->applicantEmail;
+    }
+
+    /**
+     * @return string
+     */
+    public function getApplicantName()
+    {
+        return $this->applicantName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAssignee()
+    {
+        return $this->assignee;
     }
 
     /**
@@ -44,5 +78,45 @@ class Ticket
     public function getDescription()
     {
         return $this->description;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEntityId()
+    {
+        return $this->entityId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIssueType()
+    {
+        return $this->issueType;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPriority()
+    {
+        return $this->priority;
+    }
+
+    /**
+     * @return string
+     */
+    public function getReporter()
+    {
+        return $this->reporter;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getSummary()
+    {
+        return $this->summary;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Factory/IssueFieldFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Factory/IssueFieldFactory.php
@@ -23,14 +23,24 @@ use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Ticket;
 
 class IssueFieldFactory
 {
+    const CUSTOM_FIELD_ENTITY_ID = 'customfield_13018';
+    const CUSTOM_FIELD_APPLICANT_NAME = 'customfield_11111';
+    const CUSTOM_FIELD_APPLICANT_EMAIL = 'customfield_22222';
+
     public function fromTicket(Ticket $ticket)
     {
         $issueField = new IssueField();
-        $issueField->setProjectKey("CTX")
+        $issueField->setProjectKey("CXT")
+            ->setDescription($ticket->getDescription())
+            ->setIssueType($ticket->getIssueType())
             ->setSummary($ticket->getSummary())
-            ->setPriorityName("Critical")
-            ->setIssueType("Bug")
-            ->setDescription($ticket->getDescription());
+            ->setPriorityName($ticket->getPriority())
+            ->setAssigneeName($ticket->getAssignee())
+            ->setReporterName($ticket->getReporter())
+            ->addCustomField(self::CUSTOM_FIELD_ENTITY_ID, $ticket->getEntityId())
+            ->addCustomField(self::CUSTOM_FIELD_APPLICANT_NAME, $ticket->getApplicantName())
+            ->addCustomField(self::CUSTOM_FIELD_APPLICANT_EMAIL, $ticket->getApplicantEmail())
+        ;
 
         return $issueField;
     }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Service/IssueService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Service/IssueService.php
@@ -21,18 +21,18 @@ namespace Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Service;
 use Psr\Log\LoggerInterface;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\TicketRepository;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Ticket;
-use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Client\IssueFieldFactoryTest;
-use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Client\JiraServiceFactoryTest;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Factory\IssueFieldFactory;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Factory\JiraServiceFactory;
 
 class IssueService implements TicketRepository
 {
     /**
-     * @var JiraServiceFactoryTest
+     * @var JiraServiceFactory
      */
     private $factory;
 
     /**
-     * @var IssueFieldFactoryTest
+     * @var IssueFieldFactory
      */
     private $fieldFactory;
 
@@ -42,13 +42,13 @@ class IssueService implements TicketRepository
     private $logger;
 
     /**
-     * @param JiraServiceFactoryTest $jiraFactory
-     * @param IssueFieldFactoryTest $issueFieldFactory
+     * @param JiraServiceFactory $jiraFactory
+     * @param IssueFieldFactory $issueFieldFactory
      * @param LoggerInterface $logger
      */
     public function __construct(
-        JiraServiceFactoryTest $jiraFactory,
-        IssueFieldFactoryTest $issueFieldFactory,
+        JiraServiceFactory $jiraFactory,
+        IssueFieldFactory $issueFieldFactory,
         LoggerInterface $logger
     ) {
         $this->factory = $jiraFactory;

--- a/tests/unit/Infrastructure/Jira/Factory/IssueFieldFactoryTest.php
+++ b/tests/unit/Infrastructure/Jira/Factory/IssueFieldFactoryTest.php
@@ -36,10 +36,17 @@ class IssueFieldFactoryTest extends PHPUnit_Framework_TestCase
 
     public function test_build_issue_field_from_ticket()
     {
-        $ticket = new Ticket('Summary', 'Description');
+        $ticket = new Ticket('Summary', 'Description', 'https://example.com', 'John Doe', 'john@example.com');
         $issueField = $this->factory->fromTicket($ticket);
 
         $this->assertEquals('Summary', $issueField->summary);
         $this->assertEquals('Description', $issueField->description);
+        $this->assertEquals('https://example.com', $issueField->customFields['customfield_13018']);
+        $this->assertEquals('John Doe', $issueField->customFields['customfield_11111']);
+        $this->assertEquals('john@example.com', $issueField->customFields['customfield_22222']);
+        $this->assertEquals('conext-beheer', $issueField->assignee->name);
+        $this->assertEquals('spd-delete-production-entity', $issueField->getIssueType()->name);
+        $this->assertEquals('Medium', $issueField->priority->name);
+        $this->assertEquals('sp-dashboard', $issueField->reporter->name);
     }
 }

--- a/tests/unit/Infrastructure/Jira/Service/IssueServiceTest.php
+++ b/tests/unit/Infrastructure/Jira/Service/IssueServiceTest.php
@@ -26,8 +26,8 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Mock;
 use Psr\Log\LoggerInterface;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Ticket;
-use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Client\IssueFieldFactoryTest;
-use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Client\JiraServiceFactoryTest;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Factory\IssueFieldFactory;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Factory\JiraServiceFactory;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Service\IssueService;
 
 class IssueServiceTest extends MockeryTestCase
@@ -38,11 +38,11 @@ class IssueServiceTest extends MockeryTestCase
     private $service;
 
     /**
-     * @var JiraServiceFactoryTest|Mock
+     * @var JiraServiceFactory|Mock
      */
     private $factory;
     /**
-     * @var IssueFieldFactoryTest|Mock
+     * @var IssueFieldFactory|Mock
      */
     private $ticketFactory;
 
@@ -58,8 +58,8 @@ class IssueServiceTest extends MockeryTestCase
 
     public function setUp()
     {
-        $this->factory = m::mock(JiraServiceFactoryTest::class);
-        $this->ticketFactory = m::mock(IssueFieldFactoryTest::class);
+        $this->factory = m::mock(JiraServiceFactory::class);
+        $this->ticketFactory = m::mock(IssueFieldFactory::class);
         $this->jiraIssueService = m::mock(JiraIssueService::class);
         $this->logger = m::mock(LoggerInterface::class);
         $this->service = new IssueService($this->factory, $this->ticketFactory, $this->logger);
@@ -78,7 +78,7 @@ class IssueServiceTest extends MockeryTestCase
             ->andReturn($this->jiraIssueService)
             ->once();
 
-        $ticket = new Ticket('summary', 'description');
+        $ticket = new Ticket('Summary', 'Description', 'https://example.com', 'John Doe', 'john@example.com');
 
         $issue = new Issue();
         $issueField = new IssueField();


### PR DESCRIPTION
Nine fields are set on the ticket. This is still a hypothetical change
which has not yet been tested on an actual Jira installation.

The custom fields for the APPLICANT_NAME|EMAIL are still to be set.

See:
https://www.pivotaltracker.com/story/show/162124271/comments/196880347