### PR TITLE
Make sure Jira log entries are logged correctly

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -306,3 +306,4 @@ services:
             - '%jira_host%'
             - '%jira_username%'
             - '%jira_password%'
+            - '@logger'

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Factory/JiraServiceFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Factory/JiraServiceFactory.php
@@ -20,6 +20,7 @@ namespace Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Factory;
 
 use JiraRestApi\Configuration\ArrayConfiguration;
 use JiraRestApi\Issue\IssueService;
+use Psr\Log\LoggerInterface;
 
 class JiraServiceFactory
 {
@@ -29,11 +30,17 @@ class JiraServiceFactory
     private $config;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param string $host
      * @param string $username
      * @param string $password
+     * @param LoggerInterface $logger
      */
-    public function __construct($host, $username, $password)
+    public function __construct($host, $username, $password, LoggerInterface $logger)
     {
         // Create a IssueService with a Jira connection built in.
         $this->config = new ArrayConfiguration([
@@ -41,10 +48,12 @@ class JiraServiceFactory
             'jiraUser' => $username,
             'jiraPassword' => $password
         ]);
+
+        $this->logger = $logger;
     }
 
     public function buildIssueService()
     {
-        return new IssueService($this->config);
+        return new IssueService($this->config, $this->logger);
     }
 }

--- a/tests/unit/Infrastructure/Jira/Factory/JiraServiceFactoryTest.php
+++ b/tests/unit/Infrastructure/Jira/Factory/JiraServiceFactoryTest.php
@@ -19,6 +19,8 @@
 namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\Jira\Factory;
 
 use JiraRestApi\Issue\IssueService;
+use Mockery as m;
+use Monolog\Logger;
 use PHPUnit_Framework_TestCase;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Factory\JiraServiceFactory;
 
@@ -29,7 +31,7 @@ class JiraServiceFactoryTest extends PHPUnit_Framework_TestCase
         $hostname = 'https://jira.example.com/';
         $username = 'user';
         $password = 'secret';
-        $factory = new JiraServiceFactory($hostname, $username, $password);
+        $factory = new JiraServiceFactory($hostname, $username, $password, m::mock(Logger::class));
 
         $issueService = $factory->buildIssueService();
 


### PR DESCRIPTION
Jira logged to it's own logger instance if no logger instance was passed
to the JiraClients (in our case the IssueService).

The Client (Service) factory is now set up with the application logger
and can pass it to the constructor of the services it will build.

Also see task 4 from https://www.pivotaltracker.com/story/show/162124271