### PR TITLE
Improve Jira error reporting to end users

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -7,6 +7,7 @@ error.404.text: "Oops, we were unable to find the page."
 entity.delete.title: "Delete entity"
 entity.delete.confirmation: "You are about to delete '%name%'. This is a '%status%' entity, are you sure?"
 entity.delete.request.confirmation: "You are about to request to remove '%name%'. The service desk will be informed. Are you sure?"
+entity.delete.request.failed: "Oops, creating the delete request failed. Our ticket service might have been offline. Please try again at a later time."
 entity.list.title: Entities of service '%serviceName%'
 entity.list.title_no_service_selected: No service selected
 entity.list.empty: There are no entities configured

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityList/list.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityList/list.html.twig
@@ -24,6 +24,12 @@
     </div>
     {% endif %}
 
+    {% for type, messages in app.session.flashbag.all %}
+        {% for message in messages %}
+            <div class="message {{ type }}">{{ message|trans }}</div>
+        {% endfor %}
+    {% endfor %}
+
     {% if no_service_selected %}
         {{ 'entity.list.no_service_selected'|trans }}
     {% elseif entity_list.entities is empty %}


### PR DESCRIPTION
The Jira service might throw an exception whenever it was unable to
create/connect/.. these exceptions where not yet caught by the command
handler. They now are, and a flash message is shown to the user. The
original log message is saved with the logger.