### PR TITLE
Translate Jira issue summary and description

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Ticket.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Ticket.php
@@ -21,22 +21,26 @@ namespace Surfnet\ServiceProviderDashboard\Domain\ValueObject;
 /**
  * See https://bugs.php.net/bug.php?id=66773
  */
+
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact as Applicant;
 
 class Ticket
 {
     /** @var string */
-    private $description;
-    /** @var string */
     private $entityId;
     /** @var string */
-    private $summary;
+    private $entityName;
+    /** @var string */
+    private $applicantName;
+    /** @var string */
+    private $applicantEmail;
 
-    public function __construct($summary, $description, $entityId)
+    public function __construct($entityId, $nameEn, $applicantName, $applicantEmail)
     {
-        $this->summary = $summary;
-        $this->description = $description;
         $this->entityId = $entityId;
+        $this->entityName = $nameEn;
+        $this->applicantName = $applicantName;
+        $this->applicantEmail = $applicantEmail;
     }
 
     public static function fromManageResponse($entity, Applicant $applicant)
@@ -44,25 +48,7 @@ class Ticket
         $entityId = $entity['data']['entityid'];
         $nameEn = $entity['data']['metaDataFields']['name:en'];
 
-        $summary = sprintf('Request to remove %s from production', $nameEn);
-        $description = sprintf(
-            'h2. Details
-            
-            *Applicant name*: %s
-            *Applicant email*: %s.',
-            $applicant->getDisplayName(),
-            $applicant->getEmailAddress()
-        );
-
-        return new self($summary, $description, $entityId);
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getDescription()
-    {
-        return $this->description;
+        return new self($entityId, $nameEn, $applicant->getDisplayName(), $applicant->getEmailAddress());
     }
 
     /**
@@ -73,11 +59,18 @@ class Ticket
         return $this->entityId;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getSummary()
+    public function getEntityName()
     {
-        return $this->summary;
+        return $this->entityName;
+    }
+
+    public function getApplicantName()
+    {
+        return $this->applicantName;
+    }
+
+    public function getApplicantEmail()
+    {
+        return $this->applicantEmail;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -8,6 +8,12 @@ entity.delete.title: "Delete entity"
 entity.delete.confirmation: "You are about to delete '%name%'. This is a '%status%' entity, are you sure?"
 entity.delete.request.confirmation: "You are about to request to remove '%name%'. The service desk will be informed. Are you sure?"
 entity.delete.request.failed: "Oops, creating the delete request failed. Our ticket service might have been offline. Please try again at a later time."
+entity.delete.request.ticket.summary: "Request to remove %entity_name% from production"
+entity.delete.request.ticket.description: "h2. Details
+
+*Applicant name*: %applicant_name%
+*Applicant email*: %applicant_email%.
+*Entity name (en)*: %entity_name%."
 entity.list.title: Entities of service '%serviceName%'
 entity.list.title_no_service_selected: No service selected
 entity.list.empty: There are no entities configured

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Factory/IssueFieldFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Factory/IssueFieldFactory.php
@@ -20,10 +20,12 @@ namespace Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Factory;
 
 use JiraRestApi\Issue\IssueField;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Ticket;
+use Symfony\Component\Translation\TranslatorInterface;
 use Webmozart\Assert\Assert;
 
 class IssueFieldFactory
 {
+    /**
     /**
      * @var string
      */
@@ -55,15 +57,28 @@ class IssueFieldFactory
     private $reporter;
 
     /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
      * @param string $assignee
      * @param string $entityIdFieldName
      * @param string $issueType
      * @param string $priority
      * @param string $projectKey
      * @param string $reporter
+     * @param TranslatorInterface $translator
      */
-    public function __construct($assignee, $entityIdFieldName, $issueType, $priority, $projectKey, $reporter)
-    {
+    public function __construct(
+        $assignee,
+        $entityIdFieldName,
+        $issueType,
+        $priority,
+        $projectKey,
+        $reporter,
+        TranslatorInterface $translator
+    ) {
         Assert::stringNotEmpty($assignee, 'The assignee may not be empty, configure in parameters.yml');
         Assert::stringNotEmpty(
             $entityIdFieldName,
@@ -80,14 +95,15 @@ class IssueFieldFactory
         $this->priority = $priority;
         $this->projectKey = $projectKey;
         $this->reporter = $reporter;
+        $this->translator = $translator;
     }
 
     public function fromTicket(Ticket $ticket)
     {
         $issueField = new IssueField();
-        $issueField->setProjectKey($this->projectKey)
-            ->setDescription($ticket->getDescription())
-            ->setSummary($ticket->getSummary())
+        $issueField->setProjectKey("CXT")
+            ->setDescription($this->translateDescription($ticket))
+            ->setSummary($this->translateSummary($ticket))
             ->setIssueType($this->issueType)
             ->setPriorityName($this->priority)
             ->setAssigneeName($this->assignee)
@@ -96,5 +112,21 @@ class IssueFieldFactory
         ;
 
         return $issueField;
+    }
+
+    private function translateDescription(Ticket $ticket)
+    {
+        return $this->translator->trans('entity.delete.request.ticket.description', [
+            '%applicant_name%' => $ticket->getApplicantName(),
+            '%applicant_email%' =>  $ticket->getApplicantEmail(),
+            '%entity_name%' => $ticket->getEntityName()
+        ]);
+    }
+
+    private function translateSummary(Ticket $ticket)
+    {
+        return $this->translator->trans('entity.delete.request.ticket.summary', [
+            '%entity_name%' => $ticket->getEntityName()
+        ]);
     }
 }


### PR DESCRIPTION
Both the summary and description have been made translatable. This
allows the application admin to set the translations for these texts
in the translation web  interface.

The description can be set with three parameters:
 - %applicant_name%
 - %applicant_email%
 - %entity_name%

And the summary can use:
 - %entity_name%