### PR TITLE
Optimize to the service overview 'donut' page part II

### DIFF
--- a/app/js/components/service_status.test.ts
+++ b/app/js/components/service_status.test.ts
@@ -63,7 +63,7 @@ jest
 describe('validate donut status graph', function() {
 
     let stateHtml = `
-        <div id="service-states">
+        <div class="fieldset card">
             <div class="service-status-container"> <div class="service-status-graph" data-service-id="2"></div></div>
             <div class="service-status-container"> <div class="service-status-graph" data-service-id="1"></div></div>
         </div>`;
@@ -77,7 +77,7 @@ describe('validate donut status graph', function() {
             <div class="service-status-container"> <div class="service-status-graph" data-service-id="1"><div class="service-status-canvas"><div style="display: block;" class="chartjs-render-monitor"></div></div><div class="service-status-legend"><div class="legend-item" style="background-color: rgb(209, 210, 214);"></div><div class="legend-item" style="background-color: rgb(246, 170, 97);"></div><div class="legend-item" style="background-color: rgb(103, 169, 121);"></div></div><div class="service-status-percentage"></div></div></div>
         `;
 
-        let actual = $('#service-states').html();
+        let actual = $('.fieldset.card').html();
 
         expect(actual).toBe(expected);
     });

--- a/app/js/components/service_status.ts
+++ b/app/js/components/service_status.ts
@@ -259,7 +259,7 @@ export class ServiceStatus {
 }
 
 export function loadServiceStatus() {
-  if ($('#service-states').length > 0) {
+  if ($('.service-status-container').length > 0) {
 
     const elements = document.getElementsByClassName('service-status-graph');
     Array.prototype.forEach.call(elements,  (el: HTMLCanvasElement) => {

--- a/app/scss/components/service_status.scss
+++ b/app/scss/components/service_status.scss
@@ -1,96 +1,50 @@
-#chartjs-tooltip {
-  position: absolute;
+.service-status-container {
   display: block;
-  background: rgba(0,0,0, 0.8);
-  border-radius: 5px;
-  color: #fff;
-  padding: 10px;
-  z-index: 1000;
-  box-shadow: 0 0 3px 0 rgba(0,0,0,0.5);
+  clear: both;
+  height: auto;
+  overflow: auto;
+  border-bottom: 1px solid #4DB2CF;
+  padding: 30px 0 50px;
 
   a {
-    color:#4B9EE6;
-    text-decoration:none;
+    color: #428bca;
+    text-decoration: none;
   }
-  a:hover,a:focus {
-    color:#428bca;
-    text-decoration:underline;
+
+  a:hover, a:focus {
+    color: #2a6496;
+    text-decoration: underline;
   }
-}
 
-#service-states {
+  &:last-child {
+    border: none;
+    padding-bottom: 20px;
+  }
 
-  .service-status-container {
+  .service-status-title {
+    font-size: 25px;
+    margin-bottom: 0;
+  }
+
+  .service-status-graph {
     display: block;
-    clear: both;
-    height: auto;
-    overflow: auto;
-    border-bottom: 1px solid #4DB2CF;
-    padding: 30px 0 50px;
+    position: relative;
+    float: left;
+    width: 400px;
+    height: 450px;
 
-    a {
-      color: #428bca;
-      text-decoration: none;
-    }
-
-    a:hover, a:focus {
-      color: #2a6496;
-      text-decoration: underline;
-    }
-
-    &:last-child {
-      border: none;
-      padding-bottom: 20px;
-    }
-
-    .service-status-title {
-      font-size: 25px;
-      margin-bottom: 0;
-    }
-
-    .service-status-graph {
+    .service-status-legend {
+      clear: both;
       display: block;
-      position: relative;
-      float: left;
-      width: 400px;
-      height: 450px;
+      width: 100%;
 
-      .service-status-legend {
-        clear: both;
-        display: block;
-        width: 100%;
+      text-align: center;
 
-        text-align: center;
-
-        .legend-item {
-          font-size: 12px;
-          display: inline-block;
-          padding: 2px 5px;
-          margin: 0 10px 10px;
-
-          animation: fadein 2s;
-          @keyframes fadein {
-            from {
-              opacity: 0;
-            }
-            to {
-              opacity: 1;
-            }
-          }
-        }
-      }
-
-      .service-status-percentage {
-        display: block;
-        position: absolute;
-        left: 200px;
-        top: 200px;
-        font-size: 25px;
-        width: 200px;
-        margin-left: -100px;
-        line-height: 0;
-        text-align: center;
-        color: #d1d2d6;
+      .legend-item {
+        font-size: 12px;
+        display: inline-block;
+        padding: 2px 5px;
+        margin: 0 10px 10px;
 
         animation: fadein 2s;
         @keyframes fadein {
@@ -104,11 +58,17 @@
       }
     }
 
-    .service-status-entities {
+    .service-status-percentage {
       display: block;
-      float: right;
-      width: 550px;
-      font-weight: bold;
+      position: absolute;
+      left: 200px;
+      top: 200px;
+      font-size: 25px;
+      width: 200px;
+      margin-left: -100px;
+      line-height: 0;
+      text-align: center;
+      color: #d1d2d6;
 
       animation: fadein 2s;
       @keyframes fadein {
@@ -119,20 +79,58 @@
           opacity: 1;
         }
       }
+    }
+  }
 
-      h2 {
-        font-size: 25px;
-        font-weight: normal;
+  .service-status-entities {
+    display: block;
+    float: right;
+    width: 550px;
+    font-weight: bold;
+
+    animation: fadein 2s;
+    @keyframes fadein {
+      from {
+        opacity: 0;
       }
-
-      h3 {
-        font-size: 16px;
-        font-weight: bold;
-      }
-
-      td, th {
-        font-size: 12px;
+      to {
+        opacity: 1;
       }
     }
+
+    h2 {
+      font-size: 25px;
+      font-weight: normal;
+    }
+
+    h3 {
+      font-size: 16px;
+      font-weight: bold;
+    }
+
+    td, th {
+      font-size: 12px;
+    }
+  }
+}
+
+#chartjs-tooltip {
+  position: absolute;
+  display: block;
+  background: rgba(0, 0, 0, 0.8);
+  border-radius: 5px;
+  color: #fff;
+  padding: 10px;
+  z-index: 1000;
+  box-shadow: 0 0 3px 0 rgba(0, 0, 0, 0.5);
+
+  a {
+    color: #4B9EE6;
+    text-decoration: none;
+  }
+
+  a:hover, a:focus {
+    color: #428bca;
+    text-decoration: underline;
   }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
@@ -59,7 +59,7 @@ class EntityService implements EntityServiceInterface
         return $this->queryRepositoryProvider->getEntityRepository()->findById($id);
     }
 
-    public function getEntityByIdAndTarget($id, $manageTarget)
+    public function getEntityByIdAndTarget($id, $manageTarget, $serviceId)
     {
         switch ($manageTarget) {
             case 'production':
@@ -67,13 +67,13 @@ class EntityService implements EntityServiceInterface
                     ->getManageProductionQueryClient()
                     ->findByManageId($id);
 
-                return Entity::fromManageResponse($entity, $manageTarget);
+                return Entity::fromManageResponse($entity, $manageTarget, $serviceId);
                 break;
             case 'test':
                 $entity = $this->queryRepositoryProvider
                     ->getManageTestQueryClient()
                     ->findByManageId($id);
-                return Entity::fromManageResponse($entity, $manageTarget);
+                return Entity::fromManageResponse($entity, $manageTarget, $serviceId);
                 break;
             default:
                 return $this->getEntityById($id);
@@ -92,12 +92,12 @@ class EntityService implements EntityServiceInterface
 
         $testEntities = $this->findPublishedTestEntitiesByTeamName($service->getTeamName());
         foreach ($testEntities as $result) {
-            $entities[] = ViewObject\Entity::fromManageTestResult($result, $this->router);
+            $entities[] = ViewObject\Entity::fromManageTestResult($result, $this->router, $service->getId());
         }
 
         $productionEntities = $this->findPublishedProductionEntitiesByTeamName($service->getTeamName());
         foreach ($productionEntities as $result) {
-            $entities[] = ViewObject\Entity::fromManageProductionResult($result, $this->router);
+            $entities[] = ViewObject\Entity::fromManageProductionResult($result, $this->router, $service->getId());
         }
 
         return new ViewObject\EntityList($entities);

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityServiceInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityServiceInterface.php
@@ -35,9 +35,10 @@ interface EntityServiceInterface
     /**
      * @param string $id
      * @param string $manageTarget
+     * @param int $serviceId
      * @return mixed
      */
-    public function getEntityByIdAndTarget($id, $manageTarget);
+    public function getEntityByIdAndTarget($id, $manageTarget, $serviceId);
 
     /**
      * @param $id

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Entity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Entity.php
@@ -70,14 +70,23 @@ class Entity
     /**
      * @param string $id
      * @param string $entityId
+     * @param int $serviceId
      * @param string $name
      * @param string $contact
      * @param string $state
      * @param string $environment
      * @param RouterInterface $router
      */
-    public function __construct($id, $entityId, $name, $contact, $state, $environment, RouterInterface $router)
-    {
+    public function __construct(
+        $id,
+        $entityId,
+        $serviceId,
+        $name,
+        $contact,
+        $state,
+        $environment,
+        RouterInterface $router
+    ) {
         $this->id = $id;
         $this->entityId = $entityId;
         $this->name = $name;
@@ -85,7 +94,7 @@ class Entity
         $this->state = $state;
         $this->environment = $environment;
         $this->router = $router;
-        $this->actions = new EntityActions($id, $state, $environment);
+        $this->actions = new EntityActions($id, $serviceId, $state, $environment);
     }
 
     public static function fromEntity(DomainEntity $entity, RouterInterface $router)
@@ -101,6 +110,7 @@ class Entity
         return new self(
             $entity->getId(),
             $entity->getEntityId(),
+            $entity->getService()->getId(),
             $entity->getNameEn(),
             $formattedContact,
             $entity->getStatus(),
@@ -109,13 +119,20 @@ class Entity
         );
     }
 
-    public static function fromManageTestResult(ManageEntity $result, RouterInterface $router)
+    /**
+     * @param ManageEntity $result
+     * @param RouterInterface $router
+     * @param int $serviceId
+     * @return Entity
+     */
+    public static function fromManageTestResult(ManageEntity $result, RouterInterface $router, $serviceId)
     {
         $formattedContact = self::formatManageContact($result);
 
         return new self(
             $result->getId(),
             $result->getMetaData()->getEntityId(),
+            $serviceId,
             $result->getMetaData()->getNameEn(),
             $formattedContact,
             'published',
@@ -124,7 +141,13 @@ class Entity
         );
     }
 
-    public static function fromManageProductionResult(ManageEntity $result, RouterInterface $router)
+    /**
+     * @param ManageEntity $result
+     * @param RouterInterface $router
+     * @param int $serviceId
+     * @return Entity
+     */
+    public static function fromManageProductionResult(ManageEntity $result, RouterInterface $router, $serviceId)
     {
         $formattedContact = self::formatManageContact($result);
 
@@ -141,6 +164,7 @@ class Entity
         return new self(
             $result->getId(),
             $result->getMetaData()->getEntityId(),
+            $serviceId,
             $result->getMetaData()->getNameEn(),
             $formattedContact,
             $status,
@@ -262,7 +286,14 @@ class Entity
      */
     public function getLink()
     {
-        return $this->router->generate('entity_detail', ['id' => $this->getId()]);
+        return $this->router->generate(
+            'entity_detail',
+            [
+                'id' => $this->getId(),
+                'serviceId' => $this->getActions()->getServiceId(),
+                'manageTarget' => $this->getEnvironment()
+            ]
+        );
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Entity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Entity.php
@@ -262,23 +262,7 @@ class Entity
      */
     public function getLink()
     {
-        if ($this->getActions()->allowEditAction()) {
-            return $this->router->generate('entity_edit', ['id' => $this->getId()]);
-        } elseif ($this->getActions()->allowCopyAction()) {
-            return $this->router->generate('entity_copy', [
-                'manageId' => $this->getId(),
-                'targetEnvironment' => $this->environment,
-                'sourceEnvironment' => $this->environment,
-            ]);
-        } else if ($this->getActions()->allowCloneAction()) {
-            return $this->router->generate('entity_copy', [
-                'manageId' => $this->getId(),
-                'targetEnvironment' => 'production',
-                'sourceEnvironment' => 'production',
-            ]);
-        }
-
-        return '#';
+        return $this->router->generate('entity_detail', ['id' => $this->getId()]);
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityActions.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityActions.php
@@ -26,6 +26,11 @@ class EntityActions
     private $id;
 
     /**
+     * @var int
+     */
+    private $serviceId;
+
+    /**
      * @var string
      */
     private $status;
@@ -40,9 +45,10 @@ class EntityActions
      * @param string $status
      * @param string $environment
      */
-    public function __construct($id, $status, $environment)
+    public function __construct($id, $serviceId, $status, $environment)
     {
         $this->id = $id;
+        $this->serviceId = $serviceId;
         $this->status = $status;
         $this->environment = $environment;
     }
@@ -50,6 +56,14 @@ class EntityActions
     public function getId()
     {
         return $this->id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getServiceId()
+    {
+        return $this->serviceId;
     }
 
     public function getEnvironment()

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityDetail.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityDetail.php
@@ -281,7 +281,7 @@ class EntityDetail
         if ($entityDetail->isLocalEntity()) {
             $actionId = $entityDetail->id;
         }
-        $entityDetail->actions = new EntityActions($actionId, $entity->getStatus(), $entity->getEnvironment());
+        $entityDetail->actions = new EntityActions($actionId, $entity->getService()->getId(), $entity->getStatus(), $entity->getEnvironment());
         return $entityDetail;
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Service.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Service.php
@@ -33,6 +33,11 @@ class Service
     private $name;
 
     /**
+     * @var bool
+     */
+    private $privacyQuestionsEnabled;
+
+    /**
      * @var EntityList
      */
     private $entityList;
@@ -45,13 +50,15 @@ class Service
     /**
      * @param string $id
      * @param string $name
+     * @param $privacyQuestionsEnabled
      * @param EntityList $entityList
      * @param RouterInterface $router
      */
-    public function __construct($id, $name, EntityList $entityList, RouterInterface $router)
+    public function __construct($id, $name, $privacyQuestionsEnabled, EntityList $entityList, RouterInterface $router)
     {
         $this->id = $id;
         $this->name = $name;
+        $this->privacyQuestionsEnabled = $privacyQuestionsEnabled;
         $this->entityList = $entityList;
         $this->router = $router;
     }
@@ -61,6 +68,7 @@ class Service
         return new self(
             $service->getId(),
             $service->getName(),
+            $service->isPrivacyQuestionsEnabled(),
             $entityList,
             $router
         );
@@ -96,5 +104,13 @@ class Service
     public function getLink()
     {
         return $this->router->generate('select_service', ['service' => $this->getId()]);
+    }
+
+    /**
+     * @return bool
+     */
+    public function arePrivacyQuestionsEnabled()
+    {
+        return $this->privacyQuestionsEnabled;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
@@ -368,9 +368,10 @@ class Entity
     /**
      * @param ManageEntity $manageEntity
      * @param string $environment
+     * @param int $serviceId
      * @return Entity
      */
-    public static function fromManageResponse(ManageEntity $manageEntity, $environment)
+    public static function fromManageResponse(ManageEntity $manageEntity, $environment, $serviceId)
     {
         $metaData = $manageEntity->getMetaData();
         $coin = $metaData->getCoin();
@@ -432,6 +433,10 @@ class Entity
         }
 
         self::setAttributesOn($entity, $arp);
+
+        $service = new Service();
+        $service->setId($serviceId);
+        $entity->setService($service);
 
         return $entity;
     }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
@@ -167,6 +167,14 @@ class Service
     }
 
     /**
+     * @param int $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
      * @return string
      */
     public function getGuid()

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
@@ -164,7 +164,7 @@ class EntityCreateController extends Controller
                     // Only trigger form validation on publish
                     $this->commandBus->handle($command);
 
-                    return $this->redirectToRoute('entity_list');
+                    return $this->redirectToRoute('entity_list', ['serviceId' => $service->getId()]);
                 } elseif ($this->isPublishAction($form)) {
                     // Only trigger form validation on publish
                     if ($form->isValid()) {
@@ -184,7 +184,7 @@ class EntityCreateController extends Controller
                     $this->addFlash('error', 'entity.edit.metadata.validation-failed');
                 } elseif ($this->isCancelAction($form)) {
                     // Simply return to entity list, no entity was saved
-                    return $this->redirectToRoute('entity_list');
+                    return $this->redirectToRoute('entity_list', ['serviceId' => $service->getId()]);
                 }
             } catch (InvalidArgumentException $e) {
                 $this->addFlash('error', 'entity.edit.metadata.invalid.exception');

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityDeleteController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityDeleteController.php
@@ -95,7 +95,7 @@ class EntityDeleteController extends Controller
                 );
             }
 
-            return $this->redirectToRoute('entity_list');
+            return $this->redirectToRoute('entity_list', ['serviceId' => $entity->getService()->getId()]);
         }
 
         return [
@@ -144,7 +144,8 @@ class EntityDeleteController extends Controller
                 $this->commandBus->handle($command);
             }
 
-            return $this->redirectToRoute('entity_list');
+            $serviceId = $this->authorizationService->getActiveServiceId();
+            return $this->redirectToRoute('entity_list', ['serviceId' => $serviceId]);
         }
 
         return [
@@ -180,7 +181,6 @@ class EntityDeleteController extends Controller
         $entity = $this->entityService->getManageEntityById($manageId, $environment);
         $nameEn = $entity->getMetaData()->getNameEn();
 
-
         $form = $this->createForm(DeleteEntityType::class);
         $form->handleRequest($request);
 
@@ -191,8 +191,8 @@ class EntityDeleteController extends Controller
                     $this->commandFactory->buildRequestDeletePublishedEntityCommand($manageId, $contact)
                 );
             }
-
-            return $this->redirectToRoute('entity_list');
+            $serviceId = $this->authorizationService->getActiveServiceId();
+            return $this->redirectToRoute('entity_list', ['serviceId' => $serviceId]);
         }
 
         return [

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityDetailController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityDetailController.php
@@ -40,20 +40,21 @@ class EntityDetailController extends Controller
 
     /**
      * @Method("GET")
-     * @Route("/entity/detail/{id}/{manageTarget}", name="entity_detail", defaults={"manageTarget" = false})
+     * @Route("/entity/detail/{serviceId}/{id}/{manageTarget}", name="entity_detail", defaults={"manageTarget" = false})
      * @Security("has_role('ROLE_USER')")
      * @Template("@Dashboard/EntityDetail/detail.html.twig")
      *
-     * @param $id
-     * @param $manageTarget
+     * @param string $id
+     * @param int $serviceId
+     * @param string $manageTarget
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|array
      */
-    public function detailAction($id, $manageTarget)
+    public function detailAction($id, $serviceId, $manageTarget)
     {
         // First try to read the entity from the local storage
         $entity = $this->entityService->getEntityById($id);
         if (!$entity) {
-            $entity = $this->entityService->getEntityByIdAndTarget($id, $manageTarget);
+            $entity = $this->entityService->getEntityByIdAndTarget($id, $manageTarget, $serviceId);
         }
         $viewObject = EntityDetail::fromEntity($entity);
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityEditController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityEditController.php
@@ -95,7 +95,7 @@ class EntityEditController extends Controller
                 if ($this->isSaveAction($form)) {
                     $this->commandBus->handle($command);
 
-                    return $this->redirectToRoute('entity_list');
+                    return $this->redirectToRoute('entity_list', ['serviceId' => $entity->getService()->getId()]);
                 } elseif ($this->isPublishAction($form)) {
                     // Only trigger form validation on publish
                     $this->commandBus->handle($command);
@@ -110,7 +110,7 @@ class EntityEditController extends Controller
                     $this->addFlash('error', 'entity.edit.metadata.validation-failed');
                 } elseif ($this->isCancelAction($form)) {
                     // Simply return to entity list, no entity was saved
-                    return $this->redirectToRoute('entity_list');
+                    return $this->redirectToRoute('entity_list', ['serviceId' => $entity->getService()->getId()]);
                 }
             } catch (InvalidArgumentException $e) {
                 $this->addFlash('error', 'entity.edit.metadata.invalid.exception');

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityListController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityListController.php
@@ -60,15 +60,22 @@ class EntityListController extends Controller
 
     /**
      * @Method("GET")
-     * @Route("/entities", name="entity_list")
+     * @Route("/entities/{serviceId}", name="entity_list")
      * @Security("has_role('ROLE_USER')")
      * @Template()
      *
+     * @param int $serviceId
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|array
      */
-    public function listAction()
+    public function listAction($serviceId)
     {
         $serviceOptions = $this->authorizationService->getAllowedServiceNamesById();
+        // Test if the active user is allowed to view entities of this service
+        if (!isset($serviceOptions[$serviceId])) {
+            throw $this->createNotFoundException('Unable to open the entity overview for this service');
+        }
+        // Activate the service
+        $this->authorizationService->setSelectedServiceId($serviceId);
 
         if (empty($serviceOptions)) {
             return $this->redirectToRoute('service_add');

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/PrivacyQuestionsController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/PrivacyQuestionsController.php
@@ -63,10 +63,20 @@ class PrivacyQuestionsController extends Controller
      * @Route("/service/privacy", name="privacy_questions")
      * @Security("has_role('ROLE_USER')")
      *
+     * @param int $serviceId
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
-    public function privacyAction()
+    public function privacyAction($serviceId)
     {
+        $serviceOptions = $this->authorizationService->getAllowedServiceNamesById();
+        // Test if the active user is allowed to view entities of this service
+        if (!isset($serviceOptions[$serviceId])) {
+            throw $this->createNotFoundException('Unable to open the privacy questions for this service');
+        }
+
+        // Activate the service
+        $this->authorizationService->setSelectedServiceId($serviceId);
+
         if (!$this->authorizationService->hasActivatedPrivacyQuestions()) {
             throw $this->createNotFoundException('Privacy questions are disabled');
         }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -165,7 +165,7 @@ class ServiceController extends Controller
 
     /**
      * @Method({"GET", "POST"})
-     * @Route("/service/edit/{serviceId}", name="service_edit")
+     * @Route("/service/{serviceId}/edit", name="service_edit")
      * @Security("has_role('ROLE_ADMINISTRATOR')")
      * @Template()
      *
@@ -235,7 +235,7 @@ class ServiceController extends Controller
 
     /**
      * @Method({"GET", "POST"})
-     * @Route("/service/delete/{serviceId}", name="service_delete")
+     * @Route("/service/{serviceId}/delete", name="service_delete")
      * @Security("has_role('ROLE_ADMINISTRATOR')")
      * @Template()
      *

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -115,7 +115,6 @@ class ServiceController extends Controller
             return $this->redirectToRoute('service_add');
         }
 
-
         $serviceObjects = [];
         foreach ($services as $service) {
             $entityList = $this->entityService->getEntityListForService($service);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -123,7 +123,8 @@ class ServiceController extends Controller
         $serviceList = new ServiceList($serviceObjects);
 
         return $this->render('DashboardBundle:Service:overview.html.twig', [
-            'services' => $serviceList
+            'services' => $serviceList,
+            'isAdmin' => $this->authorizationService->isAdministrator()
         ]);
     }
     

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -32,9 +32,9 @@ use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentExcept
 use Surfnet\ServiceProviderDashboard\Application\Service\EntityService;
 use Surfnet\ServiceProviderDashboard\Application\Service\ServiceService;
 use Surfnet\ServiceProviderDashboard\Application\Service\ServiceStatusService;
-use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Command\Service\ResetServiceCommand;
 use Surfnet\ServiceProviderDashboard\Application\ViewObject\Service;
 use Surfnet\ServiceProviderDashboard\Application\ViewObject\ServiceList;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Command\Service\ResetServiceCommand;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Command\Service\SelectServiceCommand;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service\CreateServiceType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service\DeleteServiceType;
@@ -152,7 +152,7 @@ class ServiceController extends Controller
             $logger->info(sprintf('Save new Service, service was created by: %s', '@todo'), (array) $command);
             try {
                 $this->commandBus->handle($command);
-                return $this->redirectToRoute('entity_list');
+                return $this->redirectToRoute('service_overview');
             } catch (InvalidArgumentException $e) {
                 $this->addFlash('error', $e->getMessage());
             }
@@ -165,15 +165,25 @@ class ServiceController extends Controller
 
     /**
      * @Method({"GET", "POST"})
-     * @Route("/service/edit", name="service_edit")
+     * @Route("/service/edit/{serviceId}", name="service_edit")
      * @Security("has_role('ROLE_ADMINISTRATOR')")
      * @Template()
      *
      * @param Request $request
+     * @param int $serviceId
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
      */
-    public function editAction(Request $request)
+    public function editAction(Request $request, $serviceId)
     {
+        $serviceOptions = $this->authorizationService->getAllowedServiceNamesById();
+        // Test if the active user is allowed to view entities of this service
+        if (!isset($serviceOptions[$serviceId])) {
+            throw $this->createNotFoundException('You are not allowed to edit this service');
+        }
+
+        // Activate the service
+        $this->authorizationService->setSelectedServiceId($serviceId);
+
         $this->get('session')->getFlashBag()->clear();
         /** @var LoggerInterface $logger */
         $logger = $this->get('logger');
@@ -204,13 +214,13 @@ class ServiceController extends Controller
             // On delete, forward to the service delete confirmation page.
             if ($this->isDeleteAction($form)) {
                 $logger->info('Forwarding to the delete confirmation page');
-                return $this->redirectToRoute('service_delete');
+                return $this->redirectToRoute('service_delete', ['serviceId' => $serviceId]);
             }
 
             $logger->info(sprintf('Service was edited by: "%s"', '@todo'), (array)$command);
             try {
                 $this->commandBus->handle($command);
-                return $this->redirectToRoute('entity_list');
+                return $this->redirectToRoute('entity_list', ['serviceId' => $serviceId]);
             } catch (InvalidArgumentException $e) {
                 $this->addFlash('error', $e->getMessage());
             } catch (EntityNotFoundException $e) {
@@ -225,14 +235,24 @@ class ServiceController extends Controller
 
     /**
      * @Method({"GET", "POST"})
-     * @Route("/service/delete", name="service_delete")
-     * @Security("has_role('ROLE_USER')")
+     * @Route("/service/delete/{serviceId}", name="service_delete")
+     * @Security("has_role('ROLE_ADMINISTRATOR')")
      * @Template()
      *
+     * @param Request $request
+     * @param $serviceId
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
      */
-    public function deleteAction(Request $request)
+    public function deleteAction(Request $request, $serviceId)
     {
+        $serviceOptions = $this->authorizationService->getAllowedServiceNamesById();
+        // Test if the active user is allowed to view entities of this service
+        if (!isset($serviceOptions[$serviceId])) {
+            throw $this->createNotFoundException('You are not allowed to delete this service');
+        }
+        // Activate the service
+        $this->authorizationService->setSelectedServiceId($serviceId);
+
         $form = $this->createForm(DeleteServiceType::class);
         $form->handleRequest($request);
 
@@ -278,7 +298,7 @@ class ServiceController extends Controller
 
         $this->commandBus->handle($command);
 
-        return $this->redirectToRoute('entity_list');
+        return $this->redirectToRoute('entity_list', ['serviceId' => $serviceId]);
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Menu/Builder.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Menu/Builder.php
@@ -39,29 +39,10 @@ class Builder
 
         $menu->addChild('Services', ['route' => 'service_overview']);
 
-        if ($this->authorizationService->hasActiveServiceId()) {
-            $menu->addChild('My entities', array('route' => 'entity_list'));
-
-            if ($this->authorizationService->hasActivatedPrivacyQuestions()) {
-                $menu->addChild(
-                    'Privacy',
-                    array(
-                        'route' => 'privacy_questions',
-                    )
-                );
-            }
-        }
-
         if ($this->authorizationService->isAdministrator()) {
             $menu->addChild('Add new service', array(
                 'route' => 'service_add',
             ));
-
-            if ($this->authorizationService->hasActiveServiceId()) {
-                $menu->addChild('Edit service', array(
-                    'route' => 'service_edit',
-                ));
-            }
 
             $menu->addChild('Translations', array(
                 'route' => 'lexik_translation_overview',

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -254,13 +254,10 @@ service.form.label.service_type: Type of service
 service.form.label.service_type_institute: Institute
 service.form.label.service_type_non_institute: Not an institute
 service.overview.title: My services
-mail.confirmation.publish_production.comment: Comments
-mail.confirmation.publish_production.entity_id: EntityID
-mail.confirmation.publish_production.entity_name_en: Entity name (en)
-mail.confirmation.publish_production.service_name: Service name
-mail.confirmation.publish_production.publish_date: Publish date
-mail.confirmation.publish_production.team_id: Team id
-mail.confirmation.publish_production.subject: 'Production connection has been requested (%entityId%)'
+service.overview.action.entityList: Detailed entities overview
+service.overview.action.privacyQuestions: Privacy questions
+service.overview.action.serviceEdit: Edit service
+service.overview.action.serviceDelete: Delete service
 service.overview.entitylist.title: Entities of service %name%
 service.overview.entitylist.test.title: Entities @ test environment
 service.overview.entitylist.production.title: Entities @ production environment
@@ -292,3 +289,10 @@ service.overview.progress.tooltip.privacy-questions.info.html: "Are the privacy 
 service.overview.progress.tooltip.production-connection.info.html: "Is a production connection active?"
 service.overview.progress.tooltip.production-connection.in-progress.html: "The deployment to the production environment is in progress"
 service.overview.progress.tooltip.production-connection.success.html: "Thank you\nA production connection is active"
+mail.confirmation.publish_production.comment: Comments
+mail.confirmation.publish_production.entity_id: EntityID
+mail.confirmation.publish_production.entity_name_en: Entity name (en)
+mail.confirmation.publish_production.service_name: Service name
+mail.confirmation.publish_production.publish_date: Publish date
+mail.confirmation.publish_production.team_id: Team id
+mail.confirmation.publish_production.subject: 'Production connection has been requested (%entityId%)'

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityActions/actionsForDetail.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityActions/actionsForDetail.html.twig
@@ -1,6 +1,6 @@
 <ul>
     <li>
-        <a href="{{ path('entity_list') }}">
+        <a href="{{ path('entity_list', {'serviceId': entity.serviceId}) }}">
             <i class="fa fa-arrow-left" aria-hidden="true"></i>
             {{ 'entity.list.action.back'|trans }}
         </a>

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityActions/viewAction.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityActions/viewAction.html.twig
@@ -1,5 +1,5 @@
 <li>
-    <a href="{{ path('entity_detail', {id: action.id, manageTarget: action.environment}) }}">
+    <a href="{{ path('entity_detail', {id: action.id, serviceId: action.serviceId, manageTarget: action.environment}) }}">
         <i class="fa fa-book" aria-hidden="true"></i>
         {{ 'entity.list.action.view'|trans }}
     </a>

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
@@ -13,12 +13,14 @@
                         {{ 'service.overview.action.entityList'|trans }}
                     </a>
                 </li>
+                {% if service.arePrivacyQuestionsEnabled %}
                 <li>
                     <a href="{{ path('privacy_questions', {'serviceId': service.id}) }}">
                         <i class="fa fa-key" aria-hidden="true"></i>
                         {{ 'service.overview.action.privacyQuestions'|trans }}
                     </a>
                 </li>
+                {% endif %}
                 <li>
                     <a href="{{ path('service_edit', {'serviceId': service.id}) }}">
                         <i class="fa fa-pencil-square" aria-hidden="true"></i>

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
@@ -1,91 +1,120 @@
 {% extends '::base.html.twig' %}
 
-{% block body %}
+{% block body_container %}
 
-    <div id="service-states">
+    <h1>{% block page_heading %}{{ 'service.overview.title'|trans }}{% endblock %}</h1>
+
     {% for service in services %}
-        <div class="service-status-container">
-            <div class="service-status-title">
-                <a href="{{ path('select_service', {service: service.id }) }}">{{ service.name }}</a>
-            </div>
-            <div class="service-status-graph" data-service-id="{{ service.id }}"></div>
-            <div class="service-status-entities">
+        <div class="fieldset card action">
+            <ul>
+                <li>
+                    <a href="{{ path('entity_list', {'serviceId': service.id}) }}">
+                        <i class="fa fa-bars" aria-hidden="true"></i>
+                        {{ 'service.overview.action.entityList'|trans }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{{ path('privacy_questions', {'serviceId': service.id}) }}">
+                        <i class="fa fa-key" aria-hidden="true"></i>
+                        {{ 'service.overview.action.privacyQuestions'|trans }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{{ path('service_edit', {'serviceId': service.id}) }}">
+                        <i class="fa fa-pencil-square" aria-hidden="true"></i>
+                        {{ 'service.overview.action.serviceEdit'|trans }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{{ path('service_delete', {'serviceId': service.id}) }}">
+                        <i class="fa fa-trash" aria-hidden="true"></i>
+                        {{ 'service.overview.action.serviceDelete'|trans }}
+                    </a>
+                </li>
+            </ul>
+        </div>
 
-                <h2>{{ 'service.overview.entitylist.title'|trans({'%name%': service.name}) }}</h2>
+        <div class="fieldset card">
 
-                <table>
-                    {# Production entities #}
-                    <tr>
-                        <td colspan="4">
-                            <h3>{{ 'service.overview.entitylist.production.title'|trans }}</h3>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th>{{ 'service.overview.entitylist.name'|trans }}</th>
-                        <th>{{ 'service.overview.entitylist.entityId'|trans }}</th>
-                        <th>{{ 'service.overview.entitylist.protocol'|trans }}</th>
-                        <th>{{ 'service.overview.entitylist.state'|trans }}</th>
-                    </tr>
-                    {% set hasEntities = false %}
-                    {% for entity in service.entityList %}
-                        {% if entity.environment == 'production' %}
-                            {% set hasEntities = true %}
-                            <tr>
-                                <td><a href="{{ entity.link }}">{{ entity.name }}</a></td>
-                                <td><a href="{{ entity.link }}">{{ entity.entityId }}</a></td>
-                                <td><a href="{{ entity.link }}">{{ entity.protocol }}</a></td>
-                                <td><a href="{{ entity.link }}">{{ entity.state }}</a></td>
-                            </tr>
-                        {%  endif %}
-                    {% endfor %}
-                    {% if hasEntities == false %}
+            <div class="service-status-container">
+
+                <div class="service-status-title">
+                    <a href="{{ path('select_service', {service: service.id }) }}">{{ service.name }}</a>
+                </div>
+                <div class="service-status-graph" data-service-id="{{ service.id }}"></div>
+                <div class="service-status-entities">
+
+                    <h2>{{ 'service.overview.entitylist.title'|trans({'%name%': service.name}) }}</h2>
+
+                    <table>
+                        {# Production entities #}
                         <tr>
-                            <td colspan="4">{{ 'service.overview.entitylist.empty'|trans }}</td>
+                            <td colspan="4">
+                                <h3>{{ 'service.overview.entitylist.production.title'|trans }}</h3>
+                            </td>
                         </tr>
-                    {% endif %}
-
-                    {# Spacing #}
-                    <tr>
-                        <td colspan="4"></td>
-                    </tr>
-
-                    {# Test entities #}
-                    <tr>
-                        <td colspan="4">
-                            <h3>{{ 'service.overview.entitylist.test.title'|trans }}</h3>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th>{{ 'service.overview.entitylist.name'|trans }}</th>
-                        <th>{{ 'service.overview.entitylist.entityId'|trans }}</th>
-                        <th>{{ 'service.overview.entitylist.protocol'|trans }}</th>
-                        <th>{{ 'service.overview.entitylist.state'|trans }}</th>
-                    </tr>
-                    {% set hasEntities = false %}
-                    {% for entity in service.entityList %}
-                        {% if entity.environment == 'test' %}
-                            {% set hasEntities = true %}
-                            <tr>
-                                <td><a href="{{ entity.link }}">{{ entity.name }}</a></td>
-                                <td><a href="{{ entity.link }}">{{ entity.entityId }}</a></td>
-                                <td><a href="{{ entity.link }}">{{ entity.protocol }}</a></td>
-                                <td><a href="{{ entity.link }}">{{ entity.state }}</a></td>
-                            </tr>
-                        {%  endif %}
-                    {% endfor %}
-                    {% if hasEntities == false %}
                         <tr>
-                            <td colspan="4">{{ 'service.overview.entitylist.empty'|trans }}</td>
+                            <th>{{ 'service.overview.entitylist.name'|trans }}</th>
+                            <th>{{ 'service.overview.entitylist.entityId'|trans }}</th>
+                            <th>{{ 'service.overview.entitylist.protocol'|trans }}</th>
+                            <th>{{ 'service.overview.entitylist.state'|trans }}</th>
                         </tr>
-                    {% endif %}
-                </table>
+                        {% set hasEntities = false %}
+                        {% for entity in service.entityList %}
+                            {% if entity.environment == 'production' %}
+                                {% set hasEntities = true %}
+                                <tr>
+                                    <td><a href="{{ entity.link }}">{{ entity.name }}</a></td>
+                                    <td><a href="{{ entity.link }}">{{ entity.entityId }}</a></td>
+                                    <td><a href="{{ entity.link }}">{{ entity.protocol }}</a></td>
+                                    <td><a href="{{ entity.link }}">{{ entity.state }}</a></td>
+                                </tr>
+                            {% endif %}
+                        {% endfor %}
+                        {% if hasEntities == false %}
+                            <tr>
+                                <td colspan="4">{{ 'service.overview.entitylist.empty'|trans }}</td>
+                            </tr>
+                        {% endif %}
 
+                        {# Spacing #}
+                        <tr>
+                            <td colspan="4"></td>
+                        </tr>
+
+                        {# Test entities #}
+                        <tr>
+                            <td colspan="4">
+                                <h3>{{ 'service.overview.entitylist.test.title'|trans }}</h3>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th>{{ 'service.overview.entitylist.name'|trans }}</th>
+                            <th>{{ 'service.overview.entitylist.entityId'|trans }}</th>
+                            <th>{{ 'service.overview.entitylist.protocol'|trans }}</th>
+                            <th>{{ 'service.overview.entitylist.state'|trans }}</th>
+                        </tr>
+                        {% set hasEntities = false %}
+                        {% for entity in service.entityList %}
+                            {% if entity.environment == 'test' %}
+                                {% set hasEntities = true %}
+                                <tr>
+                                    <td><a href="{{ entity.link }}">{{ entity.name }}</a></td>
+                                    <td><a href="{{ entity.link }}">{{ entity.entityId }}</a></td>
+                                    <td><a href="{{ entity.link }}">{{ entity.protocol }}</a></td>
+                                    <td><a href="{{ entity.link }}">{{ entity.state }}</a></td>
+                                </tr>
+                            {% endif %}
+                        {% endfor %}
+                        {% if hasEntities == false %}
+                            <tr>
+                                <td colspan="4">{{ 'service.overview.entitylist.empty'|trans }}</td>
+                            </tr>
+                        {% endif %}
+                    </table>
+
+                </div>
             </div>
-
         </div>
     {% endfor %}
-    </div>
-
 {% endblock %}
-
-{% block page_heading %}{{ 'service.overview.title'|trans }}{%endblock%}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
@@ -21,6 +21,8 @@
                     </a>
                 </li>
                 {% endif %}
+
+                {% if isAdmin %}
                 <li>
                     <a href="{{ path('service_edit', {'serviceId': service.id}) }}">
                         <i class="fa fa-pencil-square" aria-hidden="true"></i>
@@ -33,6 +35,7 @@
                         {{ 'service.overview.action.serviceDelete'|trans }}
                     </a>
                 </li>
+                {% endif %}
             </ul>
         </div>
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/AuthorizationService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/AuthorizationService.php
@@ -78,22 +78,6 @@ class AuthorizationService
     }
 
     /**
-     * Does the user have access to a single supplier, or select a supplier in the swithcer?
-     *
-     * @return bool
-     */
-    public function hasActiveServiceId()
-    {
-        if (!$this->isLoggedIn()) {
-            return false;
-        }
-
-        $activeServiceId = $this->getActiveServiceId();
-
-        return !empty($activeServiceId);
-    }
-
-    /**
      * Get the service the user is currently working on.
      *
      * The service can be active in two ways:

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Resources/views/Exception/unknownService.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Resources/views/Exception/unknownService.html.twig
@@ -19,7 +19,7 @@
 
     <br/>
 
-    <a class="btn btn-primary" href="{{ path('entity_list') }}">
+    <a class="btn btn-primary" href="{{ path('service_overview') }}">
         {{ 'saml_authn_failed.button.try_again'|trans }}
     </a>
 

--- a/tests/unit/Application/ViewObject/EntityTest.php
+++ b/tests/unit/Application/ViewObject/EntityTest.php
@@ -99,6 +99,7 @@ class EntityTest extends MockeryTestCase
         return new Entity(
             '116252ea-c19a-4842-9bb1-c8830cca780f',
             'https://example.com/saml/metadata',
+            1,
             'example-entity',
             'John Doe',
             $state,

--- a/tests/webtests/CreatePrivacyQuestionsTest.php
+++ b/tests/webtests/CreatePrivacyQuestionsTest.php
@@ -31,7 +31,7 @@ class CreatePrivacyQuestionsTest extends WebTestCase
 
         $this->logIn('ROLE_USER', [$service]);
 
-        $crawler = $this->client->request('GET', '/service/privacy');
+        $crawler = $this->client->request('GET', '/service/1/privacy');
 
         $this->assertEquals('GDPR related questions', $crawler->filter('h1')->first()->text());
         $formRows = $crawler->filter('div.form-row');
@@ -47,7 +47,7 @@ class CreatePrivacyQuestionsTest extends WebTestCase
 
         $this->logIn('ROLE_USER', [$service]);
 
-        $crawler = $this->client->request('GET', '/service/privacy');
+        $crawler = $this->client->request('GET', '/service/1/privacy');
 
         $form = $crawler
             ->selectButton('Save')

--- a/tests/webtests/EditPrivacyQuestionsTest.php
+++ b/tests/webtests/EditPrivacyQuestionsTest.php
@@ -40,7 +40,7 @@ class EditPrivacyQuestionsTest extends WebTestCase
 
         $this->logIn('ROLE_USER', [$service]);
 
-        $crawler = $this->client->request('GET', '/service/privacy');
+        $crawler = $this->client->request('GET', '/service/1/privacy');
 
         $this->assertEquals('GDPR related questions', $crawler->filter('h1')->first()->text());
         $formRows = $crawler->filter('div.form-row');
@@ -65,7 +65,7 @@ class EditPrivacyQuestionsTest extends WebTestCase
 
         $this->logIn('ROLE_USER', [$service]);
 
-        $crawler = $this->client->request('GET', '/service/privacy');
+        $crawler = $this->client->request('GET', '/service/1/privacy');
 
         $form = $crawler
             ->selectButton('Save')

--- a/tests/webtests/EditServiceTest.php
+++ b/tests/webtests/EditServiceTest.php
@@ -56,7 +56,7 @@ class EditServiceTest extends WebTestCase
         $this->testMockHandler->append(new Response(200, [], '[]'));
         $this->prodMockHandler->append(new Response(200, [], '[]'));
 
-        $crawler = $this->client->request('GET', '/service/edit');
+        $crawler = $this->client->request('GET', '/service/1/edit');
 
         $form = $crawler
             ->selectButton('Save')
@@ -85,7 +85,7 @@ class EditServiceTest extends WebTestCase
         $this->testMockHandler->append(new Response(200, [], '[]'));
         $this->prodMockHandler->append(new Response(200, [], '[]'));
 
-        $crawler = $this->client->request('GET', '/service/edit');
+        $crawler = $this->client->request('GET', '/service/1/edit');
 
         // Step 1: Admin sets privacy questions enabled to false
         $formData = [
@@ -106,12 +106,7 @@ class EditServiceTest extends WebTestCase
         $surfNet = $serviceRepository->findByName('SURFnet');
         $this->logIn('ROLE_USER', [$surfNet]);
 
-        $crawler = $this->client->request('GET', '/');
-        $navTexts = $crawler->filterXPath('//div[@class="navigation"]/ul/li/a/text()')->extract(['_text']);
-
-        $this->assertNotContains('Privacy', $navTexts, 'The Privacy Questions entry should not be in the navigation panel.');
-
-        $this->client->request('GET', '/service/privacy');
+        $this->client->request('GET', '/service/1/privacy');
 
         $this->assertEquals(
             404,
@@ -128,7 +123,7 @@ class EditServiceTest extends WebTestCase
         $this->prodMockHandler->append(new Response(200, [], '[]'));
         $this->prodMockHandler->append(new Response(200, [], '[]'));
 
-        $crawler = $this->client->request('GET', '/service/edit');
+        $crawler = $this->client->request('GET', '/service/1/edit');
 
         $formData = [
             'dashboard_bundle_edit_service_type' => [
@@ -147,13 +142,7 @@ class EditServiceTest extends WebTestCase
         $this->testMockHandler->append(new Response(200, [], '[]'));
         $this->prodMockHandler->append(new Response(200, [], '[]'));
 
-        $crawler = $this->client->followRedirect();
-
-        $navTexts = $crawler->filterXPath('//div[@class="navigation"]/ul/li/a/text()')->extract(['_text']);
-
-        $this->assertContains('Privacy', $navTexts);
-
-        $this->client->request('GET', '/service/privacy');
+        $this->client->request('GET', '/service/1/privacy');
         $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
     }
 
@@ -168,7 +157,7 @@ class EditServiceTest extends WebTestCase
         $this->testMockHandler->append(new Response(200, [], '[]'));
         $this->prodMockHandler->append(new Response(200, [], '[]'));
 
-        $crawler = $this->client->request('GET', '/service/edit');
+        $crawler = $this->client->request('GET', '/service/1/edit');
 
         $radio = $crawler->filter('#dashboard_bundle_edit_service_type_serviceStatus_privacyQuestionsAnswered_1');
         // The checked element should be the 'Yes' radio option as the ibuildings service has a privacy questions entity

--- a/tests/webtests/EntityDetailTest.php
+++ b/tests/webtests/EntityDetailTest.php
@@ -34,7 +34,7 @@ class EntityDetailTest extends WebTestCase
 
         $entity = reset($this->getEntityRepository()->findBy(['nameEn' => 'SP1']));
 
-        $crawler = $this->client->request('GET', sprintf('/entity/detail/%s', $entity->getId()));
+        $crawler = $this->client->request('GET', sprintf('/entity/detail/1/%s', $entity->getId()));
 
         $pageTitle = $crawler->filter('.page-container h1');
 
@@ -71,7 +71,7 @@ class EntityDetailTest extends WebTestCase
             $this->getServiceRepository()->findByName('SURFnet')->getId()
         );
 
-        $crawler = $this->client->request('GET', '/entity/detail/9729d851-cfdd-4283-a8f1-a29ba5036261/production');
+        $crawler = $this->client->request('GET', '/entity/detail/1/9729d851-cfdd-4283-a8f1-a29ba5036261/production');
 
         $pageTitle = $crawler->filter('.page-container h1');
 

--- a/tests/webtests/EntityListTest.php
+++ b/tests/webtests/EntityListTest.php
@@ -35,7 +35,7 @@ class EntityListTest extends WebTestCase
             $this->getServiceRepository()->findByName('SURFnet')->getId()
         );
 
-        $crawler = $this->client->request('GET', '/entities');
+        $crawler = $this->client->request('GET', '/entities/1');
 
         $pageTitle = $crawler->filter('.page-container h1');
 
@@ -87,7 +87,7 @@ class EntityListTest extends WebTestCase
             $this->getServiceRepository()->findByName('SURFnet')->getId()
         );
 
-        $crawler = $this->client->request('GET', '/entities');
+        $crawler = $this->client->request('GET', '/entities/1');
 
         $pageTitle = $crawler->filter('.page-container h1');
 
@@ -117,7 +117,7 @@ class EntityListTest extends WebTestCase
             $service->getId()
         );
 
-        $crawler = $this->client->request('GET', '/entities');
+        $crawler = $this->client->request('GET', '/entities/1');
 
         $actions = $crawler->filter('div.add-entity-actions a');
 
@@ -140,7 +140,7 @@ class EntityListTest extends WebTestCase
             $service->getId()
         );
 
-        $crawler = $this->client->request('GET', '/entities');
+        $crawler = $this->client->request('GET', '/entities/2');
 
         $actions = $crawler->filter('div.add-entity-actions a');
 
@@ -164,7 +164,7 @@ class EntityListTest extends WebTestCase
             $service->getId()
         );
 
-        $crawler = $this->client->request('GET', '/entities');
+        $crawler = $this->client->request('GET', '/entities/2');
 
         // Assert the two modal windows are on the page and have a form with appropriate form actions.
         $modalTest = $crawler->filter('#add-for-test form');

--- a/tests/webtests/ServiceDeleteTest.php
+++ b/tests/webtests/ServiceDeleteTest.php
@@ -50,7 +50,7 @@ class ServiceDeleteTest extends WebTestCase
         $this->testMockHandler->append(new Response(200, [], '[]'));
         $this->prodMockHandler->append(new Response(200, [], '[]'));
 
-        $crawler = $this->client->request('GET', '/service/edit');
+        $crawler = $this->client->request('GET', '/service/1/edit');
 
         $form = $crawler
             ->selectButton('Delete')
@@ -66,7 +66,7 @@ class ServiceDeleteTest extends WebTestCase
         $crawler = $this->client->followRedirect();
 
         $this->assertEquals(
-            '/service/delete',
+            '/service/1/delete',
             $this->client->getRequest()->getRequestUri(),
             "Expected to be on the service delete confirmation page"
         );


### PR DESCRIPTION
The links on the service overview page needed some TLC. This commit
will  address this and will link entities to their respective detail
page. Also per service in th elist a link to the entity list and a link
to the privacy questions is added.

https://www.pivotaltracker.com/story/show/162412857