### PR TITLE
Make ManageEntityAccessGrantedVoter more robust

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Security/Voter/ManageEntityAccessGrantedVoter.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Security/Voter/ManageEntityAccessGrantedVoter.php
@@ -54,7 +54,7 @@ class ManageEntityAccessGrantedVoter extends Voter
         // Fetch the entity and test if the team associated with the entity is one of the user's teams.
         $entity = $this->entityService->getManageEntityById($subject['manageId'], $subject['environment']);
 
-        if (!empty($entity->getMetaData()->getCoin()->getServiceTeamId())) {
+        if ($entity && !empty($entity->getMetaData()->getCoin()->getServiceTeamId())) {
             $team = $entity->getMetaData()->getCoin()->getServiceTeamId();
             $user = $token->getUser();
             return $user->isPartOfTeam($team);

--- a/tests/unit/Infrastructure/DashboardBundle/Security/Voter/ManageEntityAccessGrantedVoterTest.php
+++ b/tests/unit/Infrastructure/DashboardBundle/Security/Voter/ManageEntityAccessGrantedVoterTest.php
@@ -105,6 +105,14 @@ class ManageEntityAccessGrantedVoterTest extends MockeryTestCase
                 VoterInterface::ACCESS_DENIED,
             ],
             [
+                'non-existing-manage-entity',
+                ['manageId' => 'id', 'environment' => 'test'],
+                [ManageEntityAccessGrantedVoter::MANAGE_ENTITY_ACCESS],
+                $this->buildToken(['ROLE_USER'], true),
+                null,
+                VoterInterface::ACCESS_DENIED,
+            ],
+            [
                 'valid',
                 ['manageId' => 'id', 'environment' => 'test'],
                 [ManageEntityAccessGrantedVoter::MANAGE_ENTITY_ACCESS],


### PR DESCRIPTION
The possibility that a manage entity could be null was not taken into
consideration. This change now tests if the entity was found, if not,
it will deny access.

See https://www.pivotaltracker.com/story/show/162605255