### PR TITLE
Temporarily disable the oidc entity type in modal

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/ChooseEntityTypeType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/ChooseEntityTypeType.php
@@ -28,6 +28,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class ChooseEntityTypeType extends AbstractType
 {
     /**
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable) $key, $index are never used in the choice_attr callback
      * @param FormBuilderInterface $builder
      * @param array $options
      */
@@ -39,6 +40,12 @@ class ChooseEntityTypeType extends AbstractType
                     'SAML 2.0' => Entity::TYPE_SAML,
                     'OpenID Connect' => Entity::TYPE_OPENID_CONNECT
                 ],
+                'choice_attr' => function ($val, $key, $index) {
+                    if ($val == Entity::TYPE_OPENID_CONNECT) {
+                        return ['disabled' => 'disabled'];
+                    }
+                    return [];
+                },
                 'label' => false,
                 'expanded' => true,
                 'multiple' => false,


### PR DESCRIPTION
Because oidc is currently not supported it shouldn't temporarily
be possible to select oidc as an option.