### PR TITLE
Fix url in session timeout handler

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Security/Authentication/Handler/ExplicitSessionTimeoutHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Security/Authentication/Handler/ExplicitSessionTimeoutHandler.php
@@ -123,7 +123,7 @@ class ExplicitSessionTimeoutHandler implements AuthenticationHandler
             }
 
             // log the user out using Symfony methodology, see the LogoutListener
-            $event->setResponse(new RedirectResponse($this->router->generate('entity_list')));
+            $event->setResponse(new RedirectResponse($this->router->generate('service_overview')));
 
             $this->sessionLogoutHandler->logout($request, $event->getResponse(), $token);
             $this->cookieClearingLogoutHandler->logout($request, $event->getResponse(), $token);


### PR DESCRIPTION
The url parameter was missing for the entities overview. But now we use
the service overview so that isn't needed anymore.