### PR TITLE
Add oidc confirmation screen after publish

### DIFF
--- a/app/js/components/modal.ts
+++ b/app/js/components/modal.ts
@@ -5,3 +5,7 @@ $.modal.defaults = {
   // Dont show the close button, a cancel button on the modal should perform this task
   showClose: false,
 };
+
+if ($('#oidc-published-popup').length) {
+  $('#oidc-published-popup').modal();
+}

--- a/app/js/type_definitions.ts
+++ b/app/js/type_definitions.ts
@@ -3,3 +3,7 @@ interface JQueryStatic {
   // The modal function is used to override the modal default configuration settings: `$.modal.defaults = {}`
   modal: any;
 }
+
+interface JQuery {
+  modal(): JQueryStatic;
+}

--- a/app/scss/components/modal.scss
+++ b/app/scss/components/modal.scss
@@ -24,3 +24,27 @@
     padding: 15px 30px;
   }
 }
+
+.oidc-confirmation {
+  .detail {
+    margin-bottom: 0.3em;
+    label {
+      font-weight: bold;
+      text-transform: none;
+      width: 100px;
+      display: inline-block;
+    }
+  }
+  .button-row {
+    height: 3em;
+  }
+}
+
+.warning {
+  margin-bottom: 1em;
+  font-weight: bolder;
+  i {
+    color: $orange;
+    margin-right: 0.5em;
+  }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcEntityCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcEntityCommandHandler.php
@@ -83,7 +83,6 @@ class SaveOidcEntityCommandHandler implements CommandHandler
         $entity->setEnvironment($command->getEnvironment());
         $entity->setEntityId($command->getClientId());
         $entity->setProtocol(Entity::TYPE_OPENID_CONNECT);
-        $entity->setClientSecret('');
         $entity->setRedirectUris($command->getRedirectUris());
         $entity->setGrantType(new OidcGrantType($command->getGrantType()));
         $entity->setEnablePlayground($command->isEnablePlayground());

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
@@ -1053,6 +1053,16 @@ class Entity
     }
 
     /**
+     * The client id is the entity id where the semicolon in the protocol has been replaced with an at sign.
+     *
+     * @return string
+     */
+    public function getClientId()
+    {
+        return str_replace('://', '@//', $this->entityId);
+    }
+
+    /**
      * @return string
      */
     public function getCertificate()

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityListController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityListController.php
@@ -24,6 +24,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Surfnet\ServiceProviderDashboard\Application\Service\EntityService;
 use Surfnet\ServiceProviderDashboard\Application\Service\ServiceService;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AuthorizationService;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
@@ -99,11 +100,21 @@ class EntityListController extends Controller
             $serviceName = $service->getName();
         }
 
+        // Try to get a published entity from the session, if there is one, we just published an entity and might need
+        // to display the oidc confirmation popup.
+        $publishedEntity = $this->get('session')->get('published.entity.clone');
+        $showOidcPopup = false;
+        if ($publishedEntity && $publishedEntity->getProtocol() === Entity::TYPE_OPENID_CONNECT) {
+            $showOidcPopup = true;
+        }
+
         return [
             'no_service_selected' => empty($service),
             'production_entities_enabled' => $productionEntitiesEnabled,
             'entity_list' => $entityList,
             'serviceName' => $serviceName,
+            'showOidcPopup' => $showOidcPopup,
+            'publishedEntity' => $publishedEntity
         ];
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityPublishedController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityPublishedController.php
@@ -46,7 +46,7 @@ class EntityPublishedController extends Controller
         // Redirects OIDC published entity confirmations to the entity list page and shows a confirmation dialog in a
         // modal window that renders the oidcConfirmationModalAction
         if ($entity->getProtocol() === Entity::TYPE_OPENID_CONNECT) {
-            return $this->redirectToRoute('entity_list');
+            return $this->redirectToRoute('entity_list', ['serviceId' => $entity->getService()->getId()]);
         }
 
         $parameters = ['entityName' => $entity->getNameEn()];

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityPublishedController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityPublishedController.php
@@ -41,6 +41,13 @@ class EntityPublishedController extends Controller
     {
         /** @var Entity $entity */
         $entity = $this->get('session')->get('published.entity.clone');
+
+        // Redirects OIDC published entity confirmations to the entity list page and shows a confirmation dialog in a
+        // modal window that renders the oidcConfirmationModalAction
+        if ($entity->getProtocol() === Entity::TYPE_OPENID_CONNECT) {
+            return $this->redirectToRoute('entity_list');
+        }
+
         return [
             'entityName' => $entity->getNameEn(),
         ];
@@ -57,8 +64,37 @@ class EntityPublishedController extends Controller
         /** @var Entity $entity */
         $entity = $this->get('session')->get('published.entity.clone');
 
+        // Redirects OIDC published entity confirmations to the entity list page and shows a confirmation dialog in a
+        // modal window that renders the oidcConfirmationModalAction
+        if ($entity->getProtocol() === Entity::TYPE_OPENID_CONNECT) {
+            return $this->redirectToRoute('entity_list');
+        }
+
         return [
             'entityName' => $entity->getNameEn(),
         ];
+    }
+
+    /**
+     * Show the confirmation popup for an OpenID connect entity
+     *
+     * In this popup the client id and the secret are displayed (once)
+     *
+     * This action is rendered inside a modal window, and is triggered from the
+     * entity list action.
+     *
+     * @Method("GET")
+     * @Security("has_role('ROLE_USER')")
+     * @Template()
+     */
+    public function oidcConfirmationModalAction()
+    {
+        /** @var Entity $entity */
+        $entity = $this->get('session')->get('published.entity.clone');
+
+        // Show the confirmation modal only once in this request
+        $this->get('session')->remove('published.entity.clone');
+
+        return ['entity' => $entity];
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityPublishedController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityPublishedController.php
@@ -34,32 +34,11 @@ class EntityPublishedController extends Controller
     /**
      * @Method("GET")
      * @Route("/entity/published/production", name="entity_published_production")
-     * @Security("has_role('ROLE_USER')")
-     * @Template()
-     */
-    public function publishedProductionAction()
-    {
-        /** @var Entity $entity */
-        $entity = $this->get('session')->get('published.entity.clone');
-
-        // Redirects OIDC published entity confirmations to the entity list page and shows a confirmation dialog in a
-        // modal window that renders the oidcConfirmationModalAction
-        if ($entity->getProtocol() === Entity::TYPE_OPENID_CONNECT) {
-            return $this->redirectToRoute('entity_list');
-        }
-
-        return [
-            'entityName' => $entity->getNameEn(),
-        ];
-    }
-
-    /**
-     * @Method("GET")
      * @Route("/entity/published/test", name="entity_published_test")
      * @Security("has_role('ROLE_USER')")
      * @Template()
      */
-    public function publishedTestAction()
+    public function publishedAction()
     {
         /** @var Entity $entity */
         $entity = $this->get('session')->get('published.entity.clone');
@@ -70,9 +49,12 @@ class EntityPublishedController extends Controller
             return $this->redirectToRoute('entity_list');
         }
 
-        return [
-            'entityName' => $entity->getNameEn(),
-        ];
+        $parameters = ['entityName' => $entity->getNameEn()];
+
+        if ($entity->getEnvironment() === Entity::ENVIRONMENT_TEST) {
+            return $this->render('@Dashboard/EntityPublished/publishedTest.html.twig', $parameters);
+        }
+        return $this->render('@Dashboard/EntityPublished/publishedProduction.html.twig', $parameters);
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -84,6 +84,14 @@ entity.list.action.edit: Edit
 entity.list.action.copy: Copy
 entity.list.action.delete: Delete
 entity.list.action.copy_to_production: Copy to production
+entity.list.modal.oidc_confirmation:
+  title: Confirmation
+  client_id:
+    label: ClientID
+  client_secret:
+    label: Secret
+  warning: This message will be displayed only once
+  info.html: <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 entity.edit.error.publish: "Unable to publish the entity, try again later"
 entity.edit.error.push: "Unable to publish the entity, try again later"
 entity.edit.title: Service Provider registration form

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityList/list.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityList/list.html.twig
@@ -82,4 +82,10 @@
         {{ render(controller('DashboardBundle:EntityCreate:type', {targetEnvironment: "production"})) }}
     </div>
 
+    {% if showOidcPopup %}
+    <div class="modal" id="oidc-published-popup">
+        {{ render(controller('DashboardBundle:EntityPublished:oidcConfirmationModal')) }}
+    </div>
+    {% endif %}
+
 {% endblock %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/oidcConfirmationModal.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/oidcConfirmationModal.html.twig
@@ -1,0 +1,18 @@
+{% extends '::modal.html.twig' %}
+
+{% block page_heading %} {{ 'entity.list.modal.oidc_confirmation.title'|trans }} {% endblock %}
+
+{% block body %}
+    <div class="warning"><i class="fa fa-exclamation-triangle"></i>{{ 'entity.list.modal.oidc_confirmation.warning'|trans|raw }}</div>
+    <div class="wysiwyg">{{ 'entity.list.modal.oidc_confirmation.info.html'|trans|raw }}</div>
+
+    <div class="row oidc-confirmation">
+        {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.list.modal.oidc_confirmation.client_secret.label'|trans, value: entity.clientSecret} %}
+        {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.list.modal.oidc_confirmation.client_id.label'|trans, value: entity.clientId} %}
+
+        <div class="button-row">
+            <a href="#close" class="button pull-right" rel="modal:close">Close</a>
+        </div>
+    </div>
+
+{% endblock %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityType/type.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityType/type.html.twig
@@ -18,5 +18,6 @@
         </div>
 
         {{ form_end(form) }}
+    </div>
 
 {% endblock %}


### PR DESCRIPTION
The modal window is displayed after a successful publication to manage.
This is done only once. After the action was performed, the in memory
(session) clone is removed from the session.

This PR are the commits from #195 after the add oidc changes were finished.