### PR TITLE
Add oidc specific translations

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityDetail.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityDetail.php
@@ -59,6 +59,11 @@ class EntityDetail
     /**
      * @var string
      */
+    private $protocol;
+
+    /**
+     * @var string
+     */
     private $certificate;
 
     /**
@@ -240,6 +245,7 @@ class EntityDetail
         $entityDetail = new self();
         $entityDetail->id = $entity->getId();
         $entityDetail->manageId = $entity->getManageId();
+        $entityDetail->protocol = $entity->getProtocol();
         $entityDetail->metadataUrl = $entity->getMetadataUrl();
         $entityDetail->acsLocation = $entity->getAcsLocation();
         $entityDetail->entityId = $entity->getEntityId();
@@ -592,5 +598,13 @@ class EntityDetail
     public function getActions()
     {
         return $this->actions;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProtocol()
+    {
+        return $this->protocol;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
@@ -151,6 +151,7 @@ class EntityCreateController extends Controller
 
         return [
             'form' => $form->createView(),
+            'type' => $entity->getProtocol(),
         ];
     }
 
@@ -250,6 +251,7 @@ class EntityCreateController extends Controller
 
         return [
             'form' => $form->createView(),
+            'type' => $entity->getProtocol(),
         ];
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityEditController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityEditController.php
@@ -116,6 +116,7 @@ class EntityEditController extends Controller
 
         return [
             'form' => $form->createView(),
+            'type' => $entity->getProtocol(),
         ];
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcEntityType.php
@@ -212,6 +212,7 @@ class OidcEntityType extends AbstractType
                         'givenNameAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.oidc.givenNameAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.givenNameAttribute'],
@@ -221,6 +222,7 @@ class OidcEntityType extends AbstractType
                         'surNameAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.oidc.surNameAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.surNameAttribute'],
@@ -230,6 +232,7 @@ class OidcEntityType extends AbstractType
                         'commonNameAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.oidc.commonNameAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.commonNameAttribute'],
@@ -239,6 +242,7 @@ class OidcEntityType extends AbstractType
                         'displayNameAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.oidc.displayNameAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.displayNameAttribute'],
@@ -248,6 +252,7 @@ class OidcEntityType extends AbstractType
                         'emailAddressAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.oidc.emailAddressAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.emailAddressAttribute'],
@@ -257,6 +262,7 @@ class OidcEntityType extends AbstractType
                         'organizationAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.oidc.organizationAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.organizationAttribute'],
@@ -266,6 +272,7 @@ class OidcEntityType extends AbstractType
                         'organizationTypeAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.oidc.organizationTypeAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.organizationTypeAttribute'],
@@ -275,6 +282,7 @@ class OidcEntityType extends AbstractType
                         'affiliationAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.oidc.affiliationAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.affiliationAttribute'],
@@ -284,6 +292,7 @@ class OidcEntityType extends AbstractType
                         'entitlementAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.oidc.entitlementAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.entitlementAttribute'],
@@ -293,6 +302,7 @@ class OidcEntityType extends AbstractType
                         'principleNameAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.oidc.principleNameAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.principleNameAttribute'],
@@ -302,6 +312,7 @@ class OidcEntityType extends AbstractType
                         'uidAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.oidc.uidAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.uidAttribute'],
@@ -311,6 +322,7 @@ class OidcEntityType extends AbstractType
                         'preferredLanguageAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.oidc.preferredLanguageAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.preferredLanguageAttribute'],
@@ -320,6 +332,7 @@ class OidcEntityType extends AbstractType
                         'personalCodeAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.oidc.personalCodeAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.personalCodeAttribute'],
@@ -329,6 +342,7 @@ class OidcEntityType extends AbstractType
                         'scopedAffiliationAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.oidc.scopedAffiliationAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.scopedAffiliationAttribute'],
@@ -338,6 +352,7 @@ class OidcEntityType extends AbstractType
                         'eduPersonTargetedIDAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.oidc.eduPersonTargetedIDAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.eduPersonTargetedIDAttribute'],

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
@@ -260,6 +260,7 @@ class SamlEntityType extends AbstractType
                         'givenNameAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.saml20.givenNameAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.givenNameAttribute'],
@@ -269,6 +270,7 @@ class SamlEntityType extends AbstractType
                         'surNameAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.saml20.surNameAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.surNameAttribute'],
@@ -278,6 +280,7 @@ class SamlEntityType extends AbstractType
                         'commonNameAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.saml20.commonNameAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.commonNameAttribute'],
@@ -287,6 +290,7 @@ class SamlEntityType extends AbstractType
                         'displayNameAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.saml20.displayNameAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.displayNameAttribute'],
@@ -296,6 +300,7 @@ class SamlEntityType extends AbstractType
                         'emailAddressAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.saml20.emailAddressAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.emailAddressAttribute'],
@@ -305,6 +310,7 @@ class SamlEntityType extends AbstractType
                         'organizationAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.saml20.organizationAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.organizationAttribute'],
@@ -314,6 +320,7 @@ class SamlEntityType extends AbstractType
                         'organizationTypeAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.saml20.organizationTypeAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.organizationTypeAttribute'],
@@ -323,6 +330,7 @@ class SamlEntityType extends AbstractType
                         'affiliationAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.saml20.affiliationAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.affiliationAttribute'],
@@ -332,6 +340,7 @@ class SamlEntityType extends AbstractType
                         'entitlementAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.saml20.entitlementAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.entitlementAttribute'],
@@ -341,6 +350,7 @@ class SamlEntityType extends AbstractType
                         'principleNameAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.saml20.principleNameAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.principleNameAttribute'],
@@ -350,6 +360,7 @@ class SamlEntityType extends AbstractType
                         'uidAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.saml20.uidAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.uidAttribute'],
@@ -359,6 +370,7 @@ class SamlEntityType extends AbstractType
                         'preferredLanguageAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.saml20.preferredLanguageAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.preferredLanguageAttribute'],
@@ -368,6 +380,7 @@ class SamlEntityType extends AbstractType
                         'personalCodeAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.saml20.personalCodeAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.personalCodeAttribute'],
@@ -377,6 +390,7 @@ class SamlEntityType extends AbstractType
                         'scopedAffiliationAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.saml20.scopedAffiliationAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.scopedAffiliationAttribute'],
@@ -386,6 +400,7 @@ class SamlEntityType extends AbstractType
                         'eduPersonTargetedIDAttribute',
                         AttributeType::class,
                         [
+                            'label' => 'entity.edit.form.attributes.saml20.eduPersonTargetedIDAttribute',
                             'by_reference' => false,
                             'required' => false,
                             'attr' => ['data-help' => 'entity.edit.information.eduPersonTargetedIDAttribute'],

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -47,24 +47,44 @@ entity:
       email: Email
       phone: Phone
     attribute:
-      title: Attributes
-      html: <strong>information about the attribute fields</strong>
-      motivation: Motivation
-      given_name: Given name
-      surname: Surname
-      common_name: Common name attribute
-      display_name: Display name attribute
-      email_address: Email address attribute
-      organization: Organization attribute
-      organization_type: Organization type attribute
-      affiliation: Affiliation attribute
-      entitlement: Entitlement attribute
-      principle_name: Principle name attribute
-      uid: Uid attribute
-      prefered_language: Preferred language attribute
-      personal_code: Personal code attribute
-      scoped_affiliation: Scoped affiliation attribute
-      edu_person_targetted_id: Edu person targeted ID attribute
+      saml20:
+        title: Attributes
+        html: <strong>information about the attribute fields</strong>
+        motivation: Motivation
+        given_name: Given name
+        surname: Surname
+        common_name: Common name attribute
+        display_name: Display name attribute
+        email_address: Email address attribute
+        organization: Organization attribute
+        organization_type: Organization type attribute
+        affiliation: Affiliation attribute
+        entitlement: Entitlement attribute
+        principle_name: Principle name attribute
+        uid: Uid attribute
+        prefered_language: Preferred language attribute
+        personal_code: Personal code attribute
+        scoped_affiliation: Scoped affiliation attribute
+        edu_person_targetted_id: Edu person targeted ID attribute
+      oidc:
+        title: Attributes
+        html: <strong>information about the attribute fields</strong>
+        motivation: Motivation
+        given_name: Given name
+        surname: Surname
+        common_name: Common name attribute
+        display_name: Display name attribute
+        email_address: Email address attribute
+        organization: Organization attribute
+        organization_type: Organization type attribute
+        affiliation: Affiliation attribute
+        entitlement: Entitlement attribute
+        principle_name: Principle name attribute
+        uid: Uid attribute
+        prefered_language: Preferred language attribute
+        personal_code: Personal code attribute
+        scoped_affiliation: Scoped affiliation attribute
+        edu_person_targetted_id: Edu person targeted ID attribute
 
 entity.list.title: Entities of service '%serviceName%'
 entity.list.title_no_service_selected: No service selected
@@ -95,8 +115,42 @@ entity.list.modal.oidc_confirmation:
 entity.edit.error.publish: "Unable to publish the entity, try again later"
 entity.edit.error.push: "Unable to publish the entity, try again later"
 entity.edit.title: Service Provider registration form
-entity.edit.info.title: Info
-entity.edit.info.html: "
+entity.edit.info.saml20.title: Info
+entity.edit.info.saml20.html: "
+<p>Documentation about this SP registration form can be found at:
+<a href=\"https://wiki.surfnet.nl/x/isZWAw\">https://wiki.surfnet.nl/x/isZWAw</a>.</p>
+
+<p>The registration of your Service Provider consists of two parts. A contractual and technical part. This form covers the technical part. The contractual part will be handled by SURFmarket.
+In the following pages we will ask you to submit the necessary information that allows us to create a test connection. With the following details ready we estimate this process will take around 20 minutes to complete. Information we need and collect through this form includes:</p>
+<ul>
+<li>Various contacts responsible for the entity. Support, administrative and technical
+should be present.</li>
+<li>Information about SAML 2.0 configuration.</li>
+<li>Metadata information including URL, certificate and logo of your entity.</li>
+<li>A list of the attributes your Service Provider requires to operate.</li>
+</ul>
+
+<p>
+<strong>Publish</strong>
+When all fields are filled in correctly you can publish the configuration to the SURFconext test environment. The service will be available directly for testing.
+</p>
+
+<p>
+<strong>Update</strong>
+The configuration can be modified whenever you see fit. Just change the fields, press 'update' and 'confirm'. The changes are available instantenously.
+</p>
+
+
+<p>
+<strong>Production</strong>
+When tests are successful you can request a production connection. Simply press the button 'to production' to initiate this process.
+<strong>Note:</strong> your service can get production status only if the required contracts are in place.
+</p>
+
+<p>If there are any questions during completion of the form don’t hesitate to mail to support@surfconext.nl. Please add the ticket number to the subject (CXT-...).</p>
+"
+entity.edit.info.oidc.title: Info
+entity.edit.info.oidc.html: "
 <p>Documentation about this SP registration form can be found at:
 <a href=\"https://wiki.surfnet.nl/x/isZWAw\">https://wiki.surfnet.nl/x/isZWAw</a>.</p>
 
@@ -132,10 +186,12 @@ When tests are successful you can request a production connection. Simply press 
 entity.edit.general.title: General
 entity.edit.general.html: "<p>Enter/edit your contact information below. We will use this information in case we have additional questions.</p>"
 entity.edit.metadata.fetch.exception: "Unable to load the metadata from the provided import url."
-entity.edit.metadata.html: "Please provide the metadata URL of your entity. The URL will be validated and the fields below will be filled in automatically (when available in the metadata). <strong>If the input is not correct please change the settings in your SAML enabled software.</strong> Note that the fields with a * are required and need to be correctly configured. Check the following page for more information: <a href=\"https://wiki.surfnet.nl/x/vclWAw\">https://wiki.surfnet.nl/x/vclWAw</a>."
+entity.edit.metadata.saml20.html: "Please provide the metadata URL of your entity. The URL will be validated and the fields below will be filled in automatically (when available in the metadata). <strong>If the input is not correct please change the settings in your SAML enabled software.</strong> Note that the fields with a * are required and need to be correctly configured. Check the following page for more information: <a href=\"https://wiki.surfnet.nl/x/vclWAw\">https://wiki.surfnet.nl/x/vclWAw</a>."
+entity.edit.metadata.oidc.html: "Please provide the metadata URL of your entity. The URL will be validated and the fields below will be filled in automatically (when available in the metadata). <strong>If the input is not correct please change the settings in your SAML enabled software.</strong> Note that the fields with a * are required and need to be correctly configured. Check the following page for more information: <a href=\"https://wiki.surfnet.nl/x/vclWAw\">https://wiki.surfnet.nl/x/vclWAw</a>."
 entity.edit.metadata.invalid.exception: "An error occurred while importing the metadata."
 entity.edit.metadata.validation-failed: "Warning! Some entries are missing or incorrect. Please review and fix those entries below."
-entity.edit.metadata.title: Metadata
+entity.edit.metadata.saml20.title: Metadata
+entity.edit.metadata.oidc.title: Metadata
 entity.edit.metadata.parse.exception: "The provided metadata is invalid."
 entity.edit.contact_information.title: Contact information
 entity.edit.contact_information.html: "
@@ -150,8 +206,16 @@ entity.edit.contact_information.html: "
 <p><i>Technical and administrative contact details will not be communicated to end-users.</i></p>
 "
 entity.edit.attribute_input_placeholder: The service will use this attribute to...
-entity.edit.attributes.title: Attributes
-entity.edit.attributes.html: "
+entity.edit.attributes.saml20.title: Attributes
+entity.edit.attributes.saml20.html: "
+<p>When an end-user logs in to your SP, SURFconext sends a SAML-assertion to the SP. The SAML-assertion contains statements about the user, including identity and possibly a number of other attributes (see list below). Select the attributes this service requires to operate. For each attribute you request a <strong>valid reason</strong> must be provided which will be reviewed. Note: <strong>every extra attribute you request could complicate the contractual phase</strong>: just one more reason to not select more attributes than you absolutely need. Also note that SURFconext operates with a minimal disclosure principle. This means that only the absolute necessary (personal) information is transferred to a entity. Check this page for more information: <a href=\"https://wiki.surfnet.nl/x/xcpWAw\">https://wiki.surfnet.nl/x/xcpWAw</a>.</p>
+
+<p>Possibly some boxes have already been checked. This information is reused from the metadata.</p>
+
+<p><i>Identity Providers will be informed about the attributes your service requests and must agree to the release of these attributes to your entity.</i></p>
+"
+entity.edit.attributes.oidc.title: Attributes
+entity.edit.attributes.oidc.html: "
 <p>When an end-user logs in to your SP, SURFconext sends a SAML-assertion to the SP. The SAML-assertion contains statements about the user, including identity and possibly a number of other attributes (see list below). Select the attributes this service requires to operate. For each attribute you request a <strong>valid reason</strong> must be provided which will be reviewed. Note: <strong>every extra attribute you request could complicate the contractual phase</strong>: just one more reason to not select more attributes than you absolutely need. Also note that SURFconext operates with a minimal disclosure principle. This means that only the absolute necessary (personal) information is transferred to a entity. Check this page for more information: <a href=\"https://wiki.surfnet.nl/x/xcpWAw\">https://wiki.surfnet.nl/x/xcpWAw</a>.</p>
 
 <p>Possibly some boxes have already been checked. This information is reused from the metadata.</p>
@@ -312,3 +376,35 @@ mail.confirmation.publish_production.service_name: Service name
 mail.confirmation.publish_production.publish_date: Publish date
 mail.confirmation.publish_production.team_id: Team id
 mail.confirmation.publish_production.subject: 'Production connection has been requested (%entityId%)'
+
+entity.edit.form.attributes.oidc.givenNameAttribute: Given name attribute
+entity.edit.form.attributes.oidc.surNameAttribute: Sur name attribute
+entity.edit.form.attributes.oidc.commonNameAttribute: Common name attribute
+entity.edit.form.attributes.oidc.displayNameAttribute: Display name attribute
+entity.edit.form.attributes.oidc.emailAddressAttribute: Email address attribute
+entity.edit.form.attributes.oidc.organizationAttribute: Organization attribute
+entity.edit.form.attributes.oidc.organizationTypeAttribute: Organization type attribute
+entity.edit.form.attributes.oidc.affiliationAttribute: Affiliation attribute
+entity.edit.form.attributes.oidc.entitlementAttribute: Entitlement attribute
+entity.edit.form.attributes.oidc.principleNameAttribute: Principle name attribute
+entity.edit.form.attributes.oidc.uidAttribute: Uid attribute
+entity.edit.form.attributes.oidc.preferredLanguageAttribute: Preferred language attribute
+entity.edit.form.attributes.oidc.personalCodeAttribute: Personal code attribute
+entity.edit.form.attributes.oidc.scopedAffiliationAttribute: Scoped affiliation attribute
+entity.edit.form.attributes.oidc.eduPersonTargetedIDAttribute: Edu person targeted ID attribute
+
+entity.edit.form.attributes.saml20.givenNameAttribute: Given name attribute
+entity.edit.form.attributes.saml20.surNameAttribute: Sur name attribute
+entity.edit.form.attributes.saml20.commonNameAttribute: Common name attribute
+entity.edit.form.attributes.saml20.displayNameAttribute: Display name attribute
+entity.edit.form.attributes.saml20.emailAddressAttribute: Email address attribute
+entity.edit.form.attributes.saml20.organizationAttribute: Organization attribute
+entity.edit.form.attributes.saml20.organizationTypeAttribute: Organization type attribute
+entity.edit.form.attributes.saml20.affiliationAttribute: Affiliation attribute
+entity.edit.form.attributes.saml20.entitlementAttribute: Entitlement attribute
+entity.edit.form.attributes.saml20.principleNameAttribute: Principle name attribute
+entity.edit.form.attributes.saml20.uidAttribute: Uid attribute
+entity.edit.form.attributes.saml20.preferredLanguageAttribute: Preferred language attribute
+entity.edit.form.attributes.saml20.personalCodeAttribute: Personal code attribute
+entity.edit.form.attributes.saml20.scopedAffiliationAttribute: Scoped affiliation attribute
+entity.edit.form.attributes.saml20.eduPersonTargetedIDAttribute: Edu person targeted ID attribute

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detail.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detail.html.twig
@@ -1,3 +1,4 @@
+{% set type = entity.protocol %}
 {% extends '::base.html.twig' %}
 
 {% block body_container %}
@@ -45,21 +46,21 @@
         <h2>{{ 'entity.detail.attribute.title'|trans }}</h2>
         <div class="wysiwyg">{{ 'entity.detail.attribute.html'|trans|raw }}</div>
 
-        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: 'entity.detail.attribute.given_name'|trans, value: entity.givenNameAttribute, informationPopup: 'entity.edit.information.givenNameAttribute'} %}
-        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: 'entity.detail.attribute.surname'|trans, value: entity.surNameAttribute, informationPopup: 'entity.edit.information.surNameAttribute'} %}
-        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: 'entity.detail.attribute.common_name'|trans, value: entity.commonNameAttribute, informationPopup: 'entity.edit.information.commonNameAttribute'} %}
-        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: 'entity.detail.attribute.display_name'|trans, value: entity.displayNameAttribute, informationPopup: 'entity.edit.information.displayNameAttribute'} %}
-        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: 'entity.detail.attribute.email_address'|trans, value: entity.emailAddressAttribute, informationPopup: 'entity.edit.information.emailAddressAttribute'} %}
-        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: 'entity.detail.attribute.organization'|trans, value: entity.organizationAttribute, informationPopup: 'entity.edit.information.organizationAttribute'} %}
-        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: 'entity.detail.attribute.organization_type'|trans, value: entity.organizationTypeAttribute, informationPopup: 'entity.edit.information.organizationTypeAttribute'} %}
-        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: 'entity.detail.attribute.affiliation'|trans, value: entity.affiliationAttribute, informationPopup: 'entity.edit.information.affiliationAttribute'} %}
-        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: 'entity.detail.attribute.entitlement'|trans, value: entity.entitlementAttribute, informationPopup: 'entity.edit.information.entitlementAttribute'} %}
-        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: 'entity.detail.attribute.principle_name'|trans, value: entity.principleNameAttribute, informationPopup: 'entity.edit.information.principleNameAttribute'} %}
-        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: 'entity.detail.attribute.uid'|trans, value: entity.uidAttribute, informationPopup: 'entity.edit.information.uidAttribute'} %}
-        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: 'entity.detail.attribute.prefered_language'|trans, value: entity.preferredLanguageAttribute, informationPopup: 'entity.edit.information.preferredLanguageAttribute'} %}
-        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: 'entity.detail.attribute.personal_code'|trans, value: entity.personalCodeAttribute, informationPopup: 'entity.edit.information.personalCodeAttribute'} %}
-        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: 'entity.detail.attribute.scoped_affiliation'|trans, value: entity.scopedAffiliationAttribute, informationPopup: 'entity.edit.information.scopedAffiliationAttribute'} %}
-        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: 'entity.detail.attribute.edu_person_targetted_id'|trans, value: entity.eduPersonTargetedIDAttribute, informationPopup: 'entity.edit.information.eduPersonTargetedIDAttribute'} %}
+        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.given_name')|trans, value: entity.givenNameAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.givenNameAttribute'} %}
+        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.surname')|trans, value: entity.surNameAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.surNameAttribute'} %}
+        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.common_name')|trans, value: entity.commonNameAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.commonNameAttribute'} %}
+        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.display_name')|trans, value: entity.displayNameAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.displayNameAttribute'} %}
+        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.email_address')|trans, value: entity.emailAddressAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.emailAddressAttribute'} %}
+        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.organization')|trans, value: entity.organizationAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.organizationAttribute'} %}
+        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.organization_type')|trans, value: entity.organizationTypeAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.organizationTypeAttribute'} %}
+        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.affiliation')|trans, value: entity.affiliationAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.affiliationAttribute'} %}
+        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.entitlement')|trans, value: entity.entitlementAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.entitlementAttribute'} %}
+        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.principle_name')|trans, value: entity.principleNameAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.principleNameAttribute'} %}
+        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.uid')|trans, value: entity.uidAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.uidAttribute'} %}
+        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.prefered_language')|trans, value: entity.preferredLanguageAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.preferredLanguageAttribute'} %}
+        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.personal_code')|trans, value: entity.personalCodeAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.personalCodeAttribute'} %}
+        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.scoped_affiliation')|trans, value: entity.scopedAffiliationAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.scopedAffiliationAttribute'} %}
+        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.edu_person_targetted_id')|trans, value: entity.eduPersonTargetedIDAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.eduPersonTargetedIDAttribute'} %}
 
     </div>
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityEdit/edit.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityEdit/edit.html.twig
@@ -17,13 +17,13 @@
 
         {{ form_errors(form) }}
 
-        <h2>{{ 'entity.edit.info.title'|trans }}</h2>
-        <div class="wysiwyg">{{ 'entity.edit.info.html'|trans|raw }}</div>
+        <h2>{{ ('entity.edit.info.' ~ type ~ '.title')|trans }}</h2>
+        <div class="wysiwyg">{{ ('entity.edit.info.' ~ type ~ '.html')|trans|raw }}</div>
     </div>
 
     <div class="fieldset card">
-        <h2>{{ 'entity.edit.metadata.title'|trans }}</h2>
-        <div class="wysiwyg">{{ 'entity.edit.metadata.html'|trans|raw }}</div>
+        <h2>{{ ('entity.edit.metadata.' ~ type ~ '.title')|trans }}</h2>
+        <div class="wysiwyg">{{ ('entity.edit.metadata.' ~ type ~ '.html')|trans|raw }}</div>
         {{ form_widget(form.metadata) }}
     </div>
 
@@ -34,8 +34,8 @@
     </div>
 
     <div class="fieldset card">
-        <h2>{{ 'entity.edit.attributes.title'|trans }}</h2>
-        <div class="wysiwyg">{{ 'entity.edit.attributes.html'|trans|raw }}</div>
+        <h2>{{ ('entity.edit.attributes.' ~ type ~ '.title')|trans }}</h2>
+        <div class="wysiwyg">{{ ('entity.edit.attributes.' ~ type ~ '.html')|trans|raw }}</div>
         {{ form_widget(form.attributes) }}
     </div>
 


### PR DESCRIPTION
Because the entities of oidc and saml are a bit different we need
different translations in order to reflect these differences to the
enduser.