### PR TITLE
Change the state translations

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Entity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Entity.php
@@ -247,7 +247,7 @@ class Entity
      */
     public function getState()
     {
-        return $this->state;
+        return 'entity.state.'.$this->environment . '.' . str_replace(' ','_', $this->state);
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -314,3 +314,9 @@ mail.confirmation.publish_production.service_name: Service name
 mail.confirmation.publish_production.publish_date: Publish date
 mail.confirmation.publish_production.team_id: Team id
 mail.confirmation.publish_production.subject: 'Production connection has been requested (%entityId%)'
+entity.state.test.draft: draft
+entity.state.test.published: live in test
+entity.state.production.draft: draft
+entity.state.production.published: live
+entity.state.production.requested: under review
+entity.state.production.removal_requested: removal requested

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityList/list.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityList/list.html.twig
@@ -65,7 +65,7 @@
                         <td>{{ entity.entityId }}</td>
                         <td>{{ entity.contact }}</td>
                         <td>{{ entity.protocol }}</td>
-                        <td>{{ entity.state }}</td>
+                        <td>{{ entity.state|trans }}</td>
                         <td>
                             <div class="actions">
                                 <a class="opener" href="#">
@@ -129,7 +129,7 @@
                     <td>{{ entity.entityId }}</td>
                     <td>{{ entity.contact }}</td>
                     <td>{{ entity.protocol }}</td>
-                    <td>{{ entity.state }}</td>
+                    <td>{{ entity.state|trans }}</td>
                     <td>
                         <div class="actions">
                             <a class="opener" href="#">

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
@@ -72,7 +72,7 @@
                                     <td><a href="{{ entity.link }}">{{ entity.name }}</a></td>
                                     <td><a href="{{ entity.link }}">{{ entity.entityId }}</a></td>
                                     <td><a href="{{ entity.link }}">{{ entity.protocol }}</a></td>
-                                    <td><a href="{{ entity.link }}">{{ entity.state }}</a></td>
+                                    <td><a href="{{ entity.link }}">{{ entity.state|trans }}</a></td>
                                 </tr>
                             {% endif %}
                         {% endfor %}
@@ -107,7 +107,7 @@
                                     <td><a href="{{ entity.link }}">{{ entity.name }}</a></td>
                                     <td><a href="{{ entity.link }}">{{ entity.entityId }}</a></td>
                                     <td><a href="{{ entity.link }}">{{ entity.protocol }}</a></td>
-                                    <td><a href="{{ entity.link }}">{{ entity.state }}</a></td>
+                                    <td><a href="{{ entity.link }}">{{ entity.state|trans }}</a></td>
                                 </tr>
                             {% endif %}
                         {% endfor %}


### PR DESCRIPTION
The state translations of the entities should be changed to reflect the
actual state much better for sp's. Therefore translations are added.

The changes from #207 are used to prevent merge conflicts because
the entityties were split based on environment.