### PR TITLE
Fix to generate only once per environment a client secret

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcEntityCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcEntityCommandHandler.php
@@ -61,13 +61,15 @@ class SaveOidcEntityCommandHandler implements CommandHandler
                 );
             }
 
-            $secret = new Secret(20);
-
             $entity = new Entity();
             $entity->setId($id);
             $entity->setService($command->getService());
-            $entity->setClientSecret($secret->getSecret());
             $command->setId($id);
+
+            if (empty($command->getManageId())) {
+                $secret = new Secret(20);
+                $entity->setClientSecret($secret->getSecret());
+            }
         } else {
             $entity = $this->repository->findById($command->getId());
         }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityListController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityListController.php
@@ -102,9 +102,10 @@ class EntityListController extends Controller
 
         // Try to get a published entity from the session, if there is one, we just published an entity and might need
         // to display the oidc confirmation popup.
+        /** @var Entity $publishedEntity */
         $publishedEntity = $this->get('session')->get('published.entity.clone');
         $showOidcPopup = false;
-        if ($publishedEntity && $publishedEntity->getProtocol() === Entity::TYPE_OPENID_CONNECT) {
+        if ($publishedEntity && $publishedEntity->getProtocol() === Entity::TYPE_OPENID_CONNECT && $publishedEntity->getClientSecret()) {
             $showOidcPopup = true;
         }
 


### PR DESCRIPTION
The client secret needs to be generated only once per environment.
Currently this is done on every publish action. This should not happen.