### PR TITLE
Prevent oidc clientId from updating

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
@@ -188,21 +188,11 @@ class EntityCreateController extends Controller
 
         $service = $this->getService();
 
-        $entity = $this->entityService->getManageEntityById($manageId, $sourceEnvironment);
+        $entity = $this->loadEntityService->load(null, $manageId, $service, $sourceEnvironment, $targetEnvironment);
 
-        $form = $this->entityTypeFactory->createCreateForm($entity->getProtocol(), $service, $targetEnvironment);
+        // load entity into form
+        $form = $this->entityTypeFactory->createCreateForm($entity->getProtocol(), $service, $targetEnvironment, $entity);
         $command = $form->getData();
-
-        if (!$request->isMethod('post')) {
-            $entityId = $this->entityService->createEntityUuid();
-
-            // load entity
-            $entity = $this->loadEntityService->load($entityId, $manageId, $service, $sourceEnvironment, $targetEnvironment);
-
-            // load entity into form
-            $form = $this->entityTypeFactory->createCreateForm($entity->getProtocol(), $service, $targetEnvironment, $entity);
-            $command = $form->getData();
-        }
 
         // A copy can never be saved as draft: changes are published directly to manage.
         $form->remove('save');

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcEntityType.php
@@ -47,144 +47,150 @@ class OidcEntityType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder
+        $metadata = $builder->create('metadata', FormType::class, ['inherit_data' => true]);
+
+        if ($options['data']->getClientId() == "") {
+            $metadata
+                ->add(
+                    'clientId',
+                    TextType::class,
+                    [
+                        'required' => false,
+                        'attr' => [
+                            'data-help' => 'entity.edit.information.clientId',
+                            'data-parsley-uri' => null,
+                            'data-parsley-trigger' => 'blur',
+                        ],
+                    ]
+                );
+        }
+
+        $metadata
             ->add(
-                $builder->create('metadata', FormType::class, ['inherit_data' => true])
-                    ->add(
-                        'clientId',
-                        TextType::class,
-                        [
-                            'required' => false,
-                            'attr' => [
-                                'data-help' => 'entity.edit.information.clientId',
-                                'data-parsley-uri' => null,
-                                'data-parsley-trigger' => 'blur',
-                            ],
-                        ]
-                    )
-                    ->add(
-                        'redirectUris',
-                        CollectionType::class,
-                        [
-                            'error_bubbling' => false,
-                            'prototype' => true,
-                            'allow_add' => true,
-                            'allow_delete' => true,
-                            'required' => false,
-                            'entry_type' => TextType::class,
-                            'entry_options' => [
-                                'attr' => [
-                                    'data-parsley-redirecturis' => null,
-                                    'data-parsley-uri' => null,
-                                    'data-parsley-trigger' => 'blur',
-                                    'data-parsley-validate-if-empty' => null,
-                                ],
-                            ],
-                            'attr' => [
-                                'data-help' => 'entity.edit.information.redirectUris',
-                            ],
-                        ]
-                    )
-                    ->add(
-                        'grantType',
-                        ChoiceType::class,
-                        [
-                            'expanded' => true,
-                            'multiple' => false,
-                            'choices'  => [
-                                'entity.edit.label.authorization_code' => OidcGrantType::GRANT_TYPE_AUTHORIZATION_CODE,
-                                'entity.edit.label.implicit' => OidcGrantType::GRANT_TYPE_IMPLICIT,
-                            ],
-                            'attr' => [
-                                'data-help' => 'entity.edit.information.grantType',
-                            ],
-                        ]
-                    )
-                    ->add(
-                        'logoUrl',
-                        TextType::class,
-                        [
-                            'required' => false,
-                            'attr' => [
-                                'data-help' => 'entity.edit.information.logoUrl',
-                                'data-parsley-urlstrict' => null,
-                                'data-parsley-trigger' => 'blur',
-                            ],
-                        ]
-                    )
-                    ->add(
-                        'nameNl',
-                        TextType::class,
-                        [
-                            'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.nameNl'],
-                        ]
-                    )
-                    ->add(
-                        'descriptionNl',
-                        TextareaType::class,
-                        [
-                            'required' => false,
-                            'attr' => [
-                                'data-help' => 'entity.edit.information.descriptionNl',
-                                'rows' => 10,
-                            ],
-                        ]
-                    )
-                    ->add(
-                        'nameEn',
-                        TextType::class,
-                        [
-                            'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.nameEn'],
-                        ]
-                    )
-                    ->add(
-                        'descriptionEn',
-                        TextareaType::class,
-                        [
-                            'required' => false,
-                            'attr' => [
-                                'data-help' => 'entity.edit.information.descriptionEn',
-                                'rows' => 10,
-                            ],
-                        ]
-                    )
-                    ->add(
-                        'applicationUrl',
-                        TextType::class,
-                        [
-                            'required' => false,
-                            'attr' => [
-                                'data-help' => 'entity.edit.information.applicationUrl',
-                                'data-parsley-urlstrict' => null,
-                                'data-parsley-trigger' => 'blur',
-                            ],
-                        ]
-                    )
-                    ->add(
-                        'eulaUrl',
-                        TextType::class,
-                        [
-                            'required' => false,
-                            'attr' => [
-                                'data-help' => 'entity.edit.information.eulaUrl',
-                                'data-parsley-urlstrict' => null,
-                                'data-parsley-trigger' => 'blur',
-                            ],
-                        ]
-                    )
-                    ->add(
-                        'enablePlayground',
-                        CheckboxType::class,
-                        [
-                            'required' => false,
-                            'attr' => [
-                                'class' => 'requested'
-                            ]
-                        ]
-                    )
+                'redirectUris',
+                CollectionType::class,
+                [
+                    'error_bubbling' => false,
+                    'prototype' => true,
+                    'allow_add' => true,
+                    'allow_delete' => true,
+                    'required' => false,
+                    'entry_type' => TextType::class,
+                    'entry_options' => [
+                        'attr' => [
+                            'data-parsley-redirecturis' => null,
+                            'data-parsley-uri' => null,
+                            'data-parsley-trigger' => 'blur',
+                            'data-parsley-validate-if-empty' => null,
+                        ],
+                    ],
+                    'attr' => [
+                        'data-help' => 'entity.edit.information.redirectUris',
+                    ],
+                ]
             )
+            ->add(
+                'grantType',
+                ChoiceType::class,
+                [
+                    'expanded' => true,
+                    'multiple' => false,
+                    'choices'  => [
+                        'entity.edit.label.authorization_code' => OidcGrantType::GRANT_TYPE_AUTHORIZATION_CODE,
+                        'entity.edit.label.implicit' => OidcGrantType::GRANT_TYPE_IMPLICIT,
+                    ],
+                    'attr' => [
+                        'data-help' => 'entity.edit.information.grantType',
+                    ],
+                ]
+            )
+            ->add(
+                'logoUrl',
+                TextType::class,
+                [
+                    'required' => false,
+                    'attr' => [
+                        'data-help' => 'entity.edit.information.logoUrl',
+                        'data-parsley-urlstrict' => null,
+                        'data-parsley-trigger' => 'blur',
+                    ],
+                ]
+            )
+            ->add(
+                'nameNl',
+                TextType::class,
+                [
+                    'required' => false,
+                    'attr' => ['data-help' => 'entity.edit.information.nameNl'],
+                ]
+            )
+            ->add(
+                'descriptionNl',
+                TextareaType::class,
+                [
+                    'required' => false,
+                    'attr' => [
+                        'data-help' => 'entity.edit.information.descriptionNl',
+                        'rows' => 10,
+                    ],
+                ]
+            )
+            ->add(
+                'nameEn',
+                TextType::class,
+                [
+                    'required' => false,
+                    'attr' => ['data-help' => 'entity.edit.information.nameEn'],
+                ]
+            )
+            ->add(
+                'descriptionEn',
+                TextareaType::class,
+                [
+                    'required' => false,
+                    'attr' => [
+                        'data-help' => 'entity.edit.information.descriptionEn',
+                        'rows' => 10,
+                    ],
+                ]
+            )
+            ->add(
+                'applicationUrl',
+                TextType::class,
+                [
+                    'required' => false,
+                    'attr' => [
+                        'data-help' => 'entity.edit.information.applicationUrl',
+                        'data-parsley-urlstrict' => null,
+                        'data-parsley-trigger' => 'blur',
+                    ],
+                ]
+            )
+            ->add(
+                'eulaUrl',
+                TextType::class,
+                [
+                    'required' => false,
+                    'attr' => [
+                        'data-help' => 'entity.edit.information.eulaUrl',
+                        'data-parsley-urlstrict' => null,
+                        'data-parsley-trigger' => 'blur',
+                    ],
+                ]
+            )
+            ->add(
+                'enablePlayground',
+                CheckboxType::class,
+                [
+                    'required' => false,
+                    'attr' => [
+                        'class' => 'requested'
+                    ]
+                ]
+            );
+
+        $builder
+            ->add($metadata)
             ->add(
                 $builder->create('contactInformation', FormType::class, ['inherit_data' => true])
                     ->add(


### PR DESCRIPTION
The client id should not be changed. This commit will fix that, so the
clientId could be only set once when adding the oidc entity.