### PR TITLE
Grey out the clientId if already published

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcEntityType.php
@@ -49,7 +49,7 @@ class OidcEntityType extends AbstractType
     {
         $metadata = $builder->create('metadata', FormType::class, ['inherit_data' => true]);
 
-        if ($options['data']->getClientId() == "") {
+        if ($options['data']->getManageId() == "") {
             $metadata
                 ->add(
                     'clientId',
@@ -57,6 +57,22 @@ class OidcEntityType extends AbstractType
                     [
                         'required' => false,
                         'attr' => [
+                            'data-help' => 'entity.edit.information.clientId',
+                            'data-parsley-uri' => null,
+                            'data-parsley-trigger' => 'blur',
+                        ],
+                    ]
+                );
+        } else {
+            $metadata
+                ->add(
+                    'clientId',
+                    TextType::class,
+                    [
+                        'required' => false,
+                        'disabled' => false,
+                        'attr' => [
+                            'readonly' => 'readonly',
                             'data-help' => 'entity.edit.information.clientId',
                             'data-parsley-uri' => null,
                             'data-parsley-trigger' => 'blur',


### PR DESCRIPTION
The oidc clientId needs to be greyed out if already published to manage.
This is considered to be better UX wise then hiding the element
completely.