### PR TITLE
Fix oidc clientId encoding

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
@@ -265,7 +265,7 @@ class JsonGenerator implements GeneratorInterface
      */
     private function generateOidcClient(Entity $entity)
     {
-        $metadata['clientId'] = $entity->getEntityId();
+        $metadata['clientId'] = str_replace(':', '@', $entity->getEntityId());
         $metadata['clientSecret'] = $entity->getClientSecret();
         $metadata['redirectUris'] = $entity->getRedirectUris();
         $metadata['grantType'] = $entity->getGrantType()->getGrantType();


### PR DESCRIPTION
The character : needs to be replaced by a @ when storing to manage.