### PR TITLE
Fix playground redirect uri

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
@@ -31,6 +31,7 @@ use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\QueryServiceProviderException;
 use Symfony\Component\Routing\RouterInterface;
+use Webmozart\Assert\Assert;
 
 class EntityService implements EntityServiceInterface
 {
@@ -72,6 +73,9 @@ class EntityService implements EntityServiceInterface
         $oidcPlaygroundUriTest,
         $oidcPlaygroundUriProd
     ) {
+        Assert::stringNotEmpty($oidcPlaygroundUriTest, 'Please set "playground_uri_test" in parameters.yml');
+        Assert::stringNotEmpty($oidcPlaygroundUriProd, 'Please set "playground_uri_prod" in parameters.yml');
+
         $this->queryRepositoryProvider = $entityQueryRepositoryProvider;
         $this->ticketService = $ticketService;
         $this->router = $router;

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/LoadEntityService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/LoadEntityService.php
@@ -26,6 +26,7 @@ use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityRepository;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient as ManageClient;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\Coin;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\QueryServiceProviderException;
+use Webmozart\Assert\Assert;
 
 class LoadEntityService
 {
@@ -73,6 +74,9 @@ class LoadEntityService
         $oidcPlaygroundUriTest,
         $oidcPlaygroundUriProd
     ) {
+        Assert::stringNotEmpty($oidcPlaygroundUriTest, 'Please set "playground_uri_test" in parameters.yml');
+        Assert::stringNotEmpty($oidcPlaygroundUriProd, 'Please set "playground_uri_prod" in parameters.yml');
+
         $this->entityRepository = $entityRepository;
         $this->manageTestClient = $manageTestClient;
         $this->manageProductionClient = $manageProductionClient;
@@ -130,8 +134,8 @@ class LoadEntityService
             $manageEntity,
             $environment,
             $service,
-            $this->oidcPlaygroundUriProd,
-            $this->oidcPlaygroundUriTest
+            $this->oidcPlaygroundUriTest,
+            $this->oidcPlaygroundUriProd
         );
 
         // Set some defaults


### PR DESCRIPTION
The playground checkbox didn't work as expected and should add a
playground url when checked and should tick the checkbox and remove
the redirect uri from the form when the redirect uri gets returned from
manage.