### PR TITLE
Fix oidc clientId when publishing to production

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcEntityCommand.php
@@ -74,7 +74,7 @@ class SaveOidcEntityCommand implements Command
      * @Assert\Url()
      * @SpDashboardAssert\ValidClientId()
      */
-    private $clientId;
+    private $entityId;
 
     /**
      * @var string
@@ -372,7 +372,7 @@ class SaveOidcEntityCommand implements Command
         $command->service = $entity->getService();
         $command->archived = $entity->isArchived();
         $command->environment = $entity->getEnvironment();
-        $command->clientId = $entity->getEntityId();
+        $command->entityId = $entity->getEntityId();
         $command->clientSecret = $entity->getClientSecret();
         $command->redirectUris = $entity->getRedirectUris();
         $command->grantType = $entity->getGrantType();
@@ -482,17 +482,25 @@ class SaveOidcEntityCommand implements Command
     /**
      * @return string
      */
-    public function getClientId()
+    public function getEntityId()
     {
-        return $this->clientId;
+        return $this->entityId;
     }
 
     /**
-     * @param string $clientId
+     * @param string $entityId
      */
-    public function setClientId($clientId)
+    public function setEntityId($entityId)
     {
-        $this->clientId = $clientId;
+        $this->entityId = $entityId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClientId()
+    {
+        return str_replace('://', '@//', $this->entityId);
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcEntityCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcEntityCommandHandler.php
@@ -87,7 +87,7 @@ class SaveOidcEntityCommandHandler implements CommandHandler
         $entity->setManageId($command->getManageId());
         $entity->setArchived($command->isArchived());
         $entity->setEnvironment($command->getEnvironment());
-        $entity->setEntityId($command->getClientId());
+        $entity->setEntityId($command->getEntityId());
         $entity->setProtocol(Entity::TYPE_OPENID_CONNECT);
         $entity->setRedirectUris($command->getRedirectUris());
         $entity->setGrantType(new OidcGrantType($command->getGrantType()));

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
@@ -265,7 +265,7 @@ class JsonGenerator implements GeneratorInterface
      */
     private function generateOidcClient(Entity $entity)
     {
-        $metadata['clientId'] = $entity->getEntityId();
+        $metadata['clientId'] = str_replace('://', '@//', $entity->getEntityId());
         $metadata['clientSecret'] = $entity->getClientSecret();
         $metadata['redirectUris'] = $entity->getRedirectUris();
         $metadata['grantType'] = $entity->getGrantType()->getGrantType();

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Entity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Entity.php
@@ -138,14 +138,9 @@ class Entity
     {
         $formattedContact = self::formatManageContact($result);
 
-        $entityId = $result->getMetaData()->getEntityId();
-        if ($result->getProtocol() == DomainEntity::TYPE_OPENID_CONNECT) {
-            $entityId = $result->getOidcClient()->getClientId();
-        }
-
         return new self(
             $result->getId(),
-            $entityId,
+            $result->getMetaData()->getEntityId(),
             $serviceId,
             $result->getMetaData()->getNameEn(),
             $formattedContact,
@@ -176,14 +171,9 @@ class Entity
             $status = DomainEntity::STATE_PUBLICATION_REQUESTED;
         }
 
-        $entityId = $result->getMetaData()->getEntityId();
-        if ($result->getProtocol() == DomainEntity::TYPE_OPENID_CONNECT) {
-            $entityId = $result->getOidcClient()->getClientId();
-        }
-
         return new self(
             $result->getId(),
-            $entityId,
+            $result->getMetaData()->getEntityId(),
             $serviceId,
             $result->getMetaData()->getNameEn(),
             $formattedContact,
@@ -238,7 +228,10 @@ class Entity
      */
     public function getEntityId()
     {
-        return $this->entityId;
+        if ($this->getProtocol() !== DomainEntity::TYPE_OPENID_CONNECT) {
+            return $this->entityId;
+        }
+        return str_replace('://', '@//', $this->entityId);
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
@@ -443,8 +443,6 @@ class Entity
             $entity->setRedirectUris($oidcClient->getRedirectUris());
             $entity->setGrantType(new OidcGrantType($oidcClient->getGrantType()));
 
-            $entity->setEntityId($oidcClient->getClientId());
-
             $playGroundUri = ($environment == self::ENVIRONMENT_PRODUCTION ? $playGroundUriProd : $playGroundUriTest);
             $entity->setEnablePlayground(false);
             if (in_array($playGroundUri, $oidcClient->getRedirectUris())) {
@@ -1054,16 +1052,6 @@ class Entity
     public function getEntityId()
     {
         return $this->entityId;
-    }
-
-    /**
-     * The client id is the entity id where the semicolon in the protocol has been replaced with an at sign.
-     *
-     * @return string
-     */
-    public function getClientId()
-    {
-        return str_replace('://', '@//', $this->entityId);
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcEntityType.php
@@ -54,6 +54,7 @@ class OidcEntityType extends AbstractType
                 'clientId',
                 TextType::class,
                 [
+                    'property_path' => 'entityId',
                     'required' => false,
                     'attr' => [
                         'data-help' => 'entity.edit.information.clientId',
@@ -72,6 +73,7 @@ class OidcEntityType extends AbstractType
                     TextType::class,
                     [
                         'required' => false,
+                        'validation_groups' => false,
                         'disabled' => true,
                         'attr' => [
                             'readonly' => 'readonly',

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/oidcConfirmationModal.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/oidcConfirmationModal.html.twig
@@ -8,7 +8,7 @@
 
     <div class="row oidc-confirmation">
         {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.list.modal.oidc_confirmation.client_secret.label'|trans, value: entity.clientSecret} %}
-        {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.list.modal.oidc_confirmation.client_id.label'|trans, value: entity.clientId} %}
+        {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.list.modal.oidc_confirmation.client_id.label'|trans, value: entity.entityId} %}
 
         <div class="button-row">
             <a href="#close" class="button pull-right" rel="modal:close">Close</a>

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php
@@ -77,7 +77,7 @@ class PublishEntityClient implements PublishEntityRepositoryInterface
                 );
             }
 
-            if (isset($response['status']) && $response['status'] == 400) {
+            if (isset($response['status']) && $response['status'] != "OK") {
                 throw new PublishMetadataException('Unable to publish the metadata to Manage');
             }
 

--- a/tests/unit/Application/Metadata/JsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/JsonGeneratorTest.php
@@ -223,7 +223,7 @@ class JsonGeneratorTest extends MockeryTestCase
         $this->assertEquals('telephonenumber', $fields['contacts:0:telephoneNumber']);
 
         $this->assertEquals([
-            'clientId' => 'http://entityid',
+            'clientId' => 'http@//entityid',
             'clientSecret' => 'test',
             'redirectUris' => ['uri1','uri2','uri3','http://playground-test'],
             'grantType' => 'implicit',
@@ -463,7 +463,7 @@ class JsonGeneratorTest extends MockeryTestCase
                         ),
                     'oidcClient' =>
                         array (
-                            'clientId' => 'http://entityid',
+                            'clientId' => 'http@//entityid',
                             'clientSecret' => 'test',
                             'redirectUris' =>
                                 array (
@@ -532,7 +532,7 @@ class JsonGeneratorTest extends MockeryTestCase
                 array (
                     'oidcClient' =>
                         array (
-                            'clientId' => 'http://entityid',
+                            'clientId' => 'http@//entityid',
                             'clientSecret' => 'test',
                             'redirectUris' =>
                                 array (

--- a/tests/webtests/EntityCreateOidcTest.php
+++ b/tests/webtests/EntityCreateOidcTest.php
@@ -104,7 +104,7 @@ class EntityOidcCreateTest extends WebTestCase
 
         // Assert the entity id is in one of the td's of the first table row.
         $entityTr = $crawler->filter('.page-container table tbody tr')->first();
-        $this->assertRegexp('/https:\/\/entity-id/', $entityTr->text());
+        $this->assertRegexp('/https@\/\/entity-id/', $entityTr->text());
     }
 
     public function test_it_can_publish_the_form()
@@ -229,7 +229,7 @@ class EntityOidcCreateTest extends WebTestCase
         // Assert the entity is saved for the production environment.
         $row = $crawler->filter('table tbody tr')->eq(1);
 
-        $this->assertEquals('https://entity-id', $row->filter('td')->eq(1)->text(), 'Entity ID not found in entity list');
+        $this->assertEquals('https@//entity-id', $row->filter('td')->eq(1)->text(), 'Entity ID not found in entity list');
     }
 
     private function buildValidFormData()


### PR DESCRIPTION
The clientId when publishing the entity to production had a : replaced
with @. This shouldn't be done, and this commit will fix that behaviour.