### PR TITLE
Uninstall Mailcatcher

### DIFF
--- a/ansible/roles/spdashboard/tasks/spdashboardvm.yml
+++ b/ansible/roles/spdashboard/tasks/spdashboardvm.yml
@@ -7,9 +7,6 @@
     - sqlite-devel
     - ant
 
-- name: Install Mailcatcher
-  action: command gem install mailcatcher creates=/usr/local/bin/mailcatcher
-
 - name: Create SSL key
   copy: content="{{ https_dev_star_private_key }}" dest={{ tls.cert_private_path }}/star.{{ base_domain  }}.key mode=0600 owner=root
   


### PR DESCRIPTION
As we no longer send mail messages from SP Dashboard. The mail catcher
is removed from provisioning.