### PR TITLE
Fix routes missing services

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityDeleteController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityDeleteController.php
@@ -26,6 +26,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\DeleteCommandFactory;
 use Surfnet\ServiceProviderDashboard\Application\Service\EntityService;
+use Surfnet\ServiceProviderDashboard\Application\Service\ServiceService;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity\DeleteEntityType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AuthorizationService;
@@ -56,19 +57,22 @@ class EntityDeleteController extends Controller
     private $authorizationService;
 
     /**
-     * @param CommandBus $commandBus
+     * @var ServiceService
      */
+    private $serviceService;
 
     public function __construct(
         CommandBus $commandBus,
         EntityService $entityService,
         DeleteCommandFactory $commandFactory,
-        AuthorizationService $authorizationService
+        AuthorizationService $authorizationService,
+        ServiceService $serviceService
     ) {
         $this->commandBus = $commandBus;
         $this->entityService = $entityService;
         $this->authorizationService = $authorizationService;
         $this->commandFactory = $commandFactory;
+        $this->serviceService = $serviceService;
     }
 
     /**
@@ -109,7 +113,7 @@ class EntityDeleteController extends Controller
     /**
      * @Method({"GET", "POST"})
      * @Route(
-     *     "/entity/delete/published/{manageId}/{environment}",
+     *     "/entity/delete/published/{serviceId}/{manageId}/{environment}",
      *     name="entity_delete_published",
      *     defaults={
      *          "manageId": null,
@@ -120,11 +124,14 @@ class EntityDeleteController extends Controller
      * @Security("has_role('ROLE_USER')")
      * @param Request $request
      *
-     * @param $manageId
-     * @param $environment
+     * @param int $serviceId
+     * @param string|null $manageId
+     * @param string|null$environment
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|Response
+     * @throws \Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException
+     * @throws \Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\QueryServiceProviderException
      */
-    public function deletePublishedAction(Request $request, $manageId, $environment)
+    public function deletePublishedAction(Request $request, $serviceId, $manageId, $environment)
     {
         $this->isGranted("MANAGE_ENTITY_ACCESS", ['manageId' => $manageId, 'environment' => $environment]);
 
@@ -144,9 +151,8 @@ class EntityDeleteController extends Controller
                 $this->commandBus->handle($command);
             }
 
-            $serviceId = $this->authorizationService->getActiveServiceId();
-
-            return $this->redirectToRoute('entity_list', ['serviceId' => $serviceId]);
+            $service = $this->authorizationService->getServiceById($serviceId);
+            return $this->redirectToRoute('entity_list', ['serviceId' => $service->getId()]);
         }
 
         return [
@@ -160,7 +166,7 @@ class EntityDeleteController extends Controller
     /**
      * @Method({"GET", "POST"})
      * @Route(
-     *     "/entity/delete/request/{manageId}/{environment}",
+     *     "/entity/delete/request/{serviceId}/{manageId}/{environment}",
      *     name="entity_delete_request",
      *     defaults={
      *          "manageId": null,
@@ -171,11 +177,14 @@ class EntityDeleteController extends Controller
      * @Security("has_role('ROLE_USER')")
      *
      * @param Request $request
-     * @param $manageId
-     * @param $environment
+     * @param int $serviceId
+     * @param string|null $manageId
+     * @param string|null $environment
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|Response
+     * @throws \Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException
+     * @throws \Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\QueryServiceProviderException
      */
-    public function deleteRequestAction(Request $request, $manageId, $environment)
+    public function deleteRequestAction(Request $request, $serviceId, $manageId, $environment)
     {
         $this->isGranted("MANAGE_ENTITY_ACCESS", ['manageId' => $manageId, 'environment' => $environment]);
 
@@ -197,9 +206,8 @@ class EntityDeleteController extends Controller
                     )
                 );
             }
-            $serviceId = $this->authorizationService->getActiveServiceId();
-
-            return $this->redirectToRoute('entity_list', ['serviceId' => $serviceId]);
+            $service = $this->authorizationService->getServiceById($serviceId);
+            return $this->redirectToRoute('entity_list', ['serviceId' => $service->getId()]);
         }
 
         return [

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityDetailController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityDetailController.php
@@ -23,8 +23,8 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Surfnet\ServiceProviderDashboard\Application\Service\EntityServiceInterface;
-use Surfnet\ServiceProviderDashboard\Application\Service\ServiceService;
 use Surfnet\ServiceProviderDashboard\Application\ViewObject\EntityDetail;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AuthorizationService;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
 class EntityDetailController extends Controller
@@ -34,14 +34,14 @@ class EntityDetailController extends Controller
      */
     private $entityService;
     /**
-     * @var ServiceService
+     * @var AuthorizationService
      */
-    private $serviceService;
+    private $authorizationService;
 
-    public function __construct(EntityServiceInterface $entityService, ServiceService $serviceService)
+    public function __construct(EntityServiceInterface $entityService, AuthorizationService $authorizationService)
     {
         $this->entityService = $entityService;
-        $this->serviceService = $serviceService;
+        $this->authorizationService = $authorizationService;
     }
 
     /**
@@ -57,10 +57,11 @@ class EntityDetailController extends Controller
      */
     public function detailAction($id, $serviceId, $manageTarget)
     {
+        $service = $this->authorizationService->getServiceById($serviceId);
+
         // First try to read the entity from the local storage
         $entity = $this->entityService->getEntityById($id);
         if (!$entity) {
-            $service = $this->serviceService->getServiceById($serviceId);
             $entity = $this->entityService->getEntityByIdAndTarget($id, $manageTarget, $service);
         }
         $viewObject = EntityDetail::fromEntity($entity);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/PrivacyQuestionsController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/PrivacyQuestionsController.php
@@ -68,22 +68,11 @@ class PrivacyQuestionsController extends Controller
      */
     public function privacyAction($serviceId)
     {
-        $serviceOptions = $this->authorizationService->getAllowedServiceNamesById();
-        // Test if the active user is allowed to access privacy questions of this service
-        if (!isset($serviceOptions[$serviceId])) {
-            throw $this->createNotFoundException('Unable to open the privacy questions for this service');
-        }
-
-        // Activate the service
-        $this->authorizationService->setSelectedServiceId($serviceId);
+        $service = $this->authorizationService->getServiceById($serviceId);
 
         if (!$this->authorizationService->hasActivatedPrivacyQuestions()) {
             throw $this->createNotFoundException('Privacy questions are disabled');
         }
-
-        $service = $this->serviceService->getServiceById(
-            $this->authorizationService->getActiveServiceId()
-        );
 
         // Test if the questions have already been filled
         if ($service->getPrivacyQuestions() instanceof PrivacyQuestions) {
@@ -103,13 +92,7 @@ class PrivacyQuestionsController extends Controller
      */
     public function createAction(Request $request, $serviceId)
     {
-        $serviceOptions = $this->authorizationService->getAllowedServiceNamesById();
-        // Test if the active user is allowed to access privacy questions of this service
-        if (!isset($serviceOptions[$serviceId])) {
-            throw $this->createNotFoundException('Unable to create privacy questions for this service');
-        }
-
-        $service = $this->serviceService->getServiceById($serviceId);
+        $service = $this->authorizationService->getServiceById($serviceId);
 
         $command = PrivacyQuestionsCommand::fromService($service);
 
@@ -127,13 +110,8 @@ class PrivacyQuestionsController extends Controller
      */
     public function editAction(Request $request, $serviceId)
     {
-        $serviceOptions = $this->authorizationService->getAllowedServiceNamesById();
-        // Test if the active user is allowed to access privacy questions of this service
-        if (!isset($serviceOptions[$serviceId])) {
-            throw $this->createNotFoundException('Unable to edit the privacy questions for this service');
-        }
-
         $service = $this->serviceService->getServiceById($serviceId);
+
         $questions = $service->getPrivacyQuestions();
 
         $command = PrivacyQuestionsCommand::fromQuestions($questions);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -175,21 +175,11 @@ class ServiceController extends Controller
      */
     public function editAction(Request $request, $serviceId)
     {
-        $serviceOptions = $this->authorizationService->getAllowedServiceNamesById();
-        // Test if the active user is allowed to view entities of this service
-        if (!isset($serviceOptions[$serviceId])) {
-            throw $this->createNotFoundException('You are not allowed to edit this service');
-        }
-
-        // Activate the service
-        $this->authorizationService->setSelectedServiceId($serviceId);
+        $service = $this->authorizationService->getServiceById($serviceId);
 
         $this->get('session')->getFlashBag()->clear();
         /** @var LoggerInterface $logger */
         $logger = $this->get('logger');
-        $service = $this->serviceService->getServiceById(
-            $this->authorizationService->getActiveServiceId()
-        );
 
         $command = new EditServiceCommand(
             $service->getId(),
@@ -245,26 +235,14 @@ class ServiceController extends Controller
      */
     public function deleteAction(Request $request, $serviceId)
     {
-        $serviceOptions = $this->authorizationService->getAllowedServiceNamesById();
-        // Test if the active user is allowed to view entities of this service
-        if (!isset($serviceOptions[$serviceId])) {
-            throw $this->createNotFoundException('You are not allowed to delete this service');
-        }
-        // Activate the service
-        $this->authorizationService->setSelectedServiceId($serviceId);
+        $service = $this->authorizationService->getServiceById($serviceId);
 
         $form = $this->createForm(DeleteServiceType::class);
         $form->handleRequest($request);
 
-        $service = $this->serviceService->getServiceById(
-            $this->authorizationService->getActiveServiceId()
-        );
-
         if ($form->isSubmitted() && $form->isValid()) {
             if ($form->getClickedButton()->getName() === 'delete') {
-                $service = $this->serviceService->getServiceById(
-                    $this->authorizationService->getActiveServiceId()
-                );
+                $service = $this->serviceService->getServiceById($serviceId);
 
                 // Remove the service
                 $contact = $this->authorizationService->getContact();

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityActions/cloneAction.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityActions/cloneAction.html.twig
@@ -1,6 +1,6 @@
 {% if action.allowCloneAction %}
     <li>
-        <a href="{{ path('entity_copy', {manageId: action.id, targetEnvironment: 'production', sourceEnvironment: 'production'}) }}">
+        <a href="{{ path('entity_copy', {manageId: action.id, serviceId: action.serviceId, targetEnvironment: 'production', sourceEnvironment: 'production'}) }}">
             <i class="fa fa-copy" aria-hidden="true"></i>
             {{ 'entity.list.action.copy'|trans }}
         </a>

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityActions/copyAction.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityActions/copyAction.html.twig
@@ -1,6 +1,6 @@
 {% if action.allowCopyToProductionAction %}
     <li>
-        <a href="{{ path('entity_copy', {manageId: action.id, targetEnvironment: 'production'}) }}">
+        <a href="{{ path('entity_copy', {manageId: action.id, serviceId: action.serviceId, targetEnvironment: 'production'}) }}">
             <i class="fa fa-copy" aria-hidden="true"></i>
             {{ 'entity.list.action.copy_to_production'|trans }}
         </a>

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityActions/deleteAction.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityActions/deleteAction.html.twig
@@ -1,9 +1,9 @@
 {% if action.allowDeleteAction %}
     <li>
         {% if action.isPublishedToProduction %}
-        <a href="{{ path('entity_delete_request', {manageId: action.id}) }}">
+        <a href="{{ path('entity_delete_request', {serviceId: action.serviceId, manageId: action.id}) }}">
         {% elseif action.isPublished or action.isRequested %}
-        <a href="{{ path('entity_delete_published', {manageId: action.id, environment: action.environment}) }}">
+        <a href="{{ path('entity_delete_published', {serviceId: action.serviceId, manageId: action.id, environment: action.environment}) }}">
         {% else %}
         <a href="{{ path('entity_delete', {id: action.id}) }}">
         {% endif %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityActions/editAction.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityActions/editAction.html.twig
@@ -7,7 +7,7 @@
     </li>
 {% elseif action.allowCopyAction %}
     <li>
-        <a href="{{ path('entity_copy', {manageId: action.id, targetEnvironment: action.environment, sourceEnvironment: action.environment}) }}">
+        <a href="{{ path('entity_copy', {manageId: action.id, serviceId: action.serviceId, targetEnvironment: action.environment, sourceEnvironment: action.environment}) }}">
             <i class="fa fa-pencil-square" aria-hidden="true"></i>
             {{ 'entity.list.action.edit'|trans }}
         </a>

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityList/list.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityList/list.html.twig
@@ -156,11 +156,11 @@
     {% endif %}
 
     <div class="modal" id="add-for-test">
-        {{ render(controller('DashboardBundle:EntityCreate:type', {targetEnvironment: "test"})) }}
+        {{ render(controller('DashboardBundle:EntityCreate:type', {serviceId: service.id, targetEnvironment: "test"})) }}
     </div>
 
     <div class="modal" id="add-for-production">
-        {{ render(controller('DashboardBundle:EntityCreate:type', {targetEnvironment: "production"})) }}
+        {{ render(controller('DashboardBundle:EntityCreate:type', {serviceId: service.id, targetEnvironment: "production"})) }}
     </div>
 
     {% if showOidcPopup %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityType/type.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityType/type.html.twig
@@ -9,7 +9,7 @@
     <div class="wysiwyg">{{ 'entity.type.description.html'|trans|raw }}</div>
 
     <div class="row entity-type">
-        {{ form_start(form, {'action': path('entity_type', {'targetEnvironment': environment})}) }}
+        {{ form_start(form, {'action': path('entity_type', {'serviceId': serviceId, 'targetEnvironment': environment})}) }}
         {{ form_widget(form) }}
 
         <div class="button-row">

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/AuthorizationService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/AuthorizationService.php
@@ -18,6 +18,7 @@
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service;
 
 use RuntimeException;
+use Surfnet\ServiceProviderDashboard\Application\Exception\ServiceNotFoundException;
 use Surfnet\ServiceProviderDashboard\Application\Service\ServiceService;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Identity;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -227,7 +228,26 @@ class AuthorizationService
     }
 
     /**
+     * @param $serviceId
+     * @return \Surfnet\ServiceProviderDashboard\Domain\Entity\Service
+     * @throws ServiceNotFoundException
+     */
+    public function getServiceById($serviceId)
+    {
+        $service = $this->serviceService->getServiceById($serviceId);
+
+        if (!$service || !$this->hasAccessToService($serviceId)) {
+            throw new ServiceNotFoundException('Unable to find service.');
+        }
+
+        $this->setSelectedServiceId($service->getId());
+
+        return $service;
+    }
+
+    /**
      * @param string $serviceId
+     * @return bool
      */
     private function hasAccessToService($serviceId)
     {

--- a/tests/webtests/EntityCopyTest.php
+++ b/tests/webtests/EntityCopyTest.php
@@ -19,10 +19,16 @@
 namespace Surfnet\ServiceProviderDashboard\Webtests;
 
 use GuzzleHttp\Psr7\Response;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class EntityCopyTest extends WebTestCase
 {
+    /**
+     * @var Service
+     */
+    private $service;
+
     public function setUp()
     {
         parent::setUp();
@@ -44,7 +50,7 @@ class EntityCopyTest extends WebTestCase
         $this->testMockHandler->append(new Response(200, [], $response));
         $this->prodMockHandler->append(new Response(200, [], $response));
 
-        $crawler = $this->client->request('GET', "/entity/copy/d645ddf7-1246-4224-8e14-0d5c494fd9ad");
+        $crawler = $this->client->request('GET', "/entity/copy/{$this->service->getId()}/d645ddf7-1246-4224-8e14-0d5c494fd9ad");
 
         $this->prodMockHandler->append(new Response(200, [], '[]'));
 
@@ -160,7 +166,7 @@ class EntityCopyTest extends WebTestCase
         $this->testMockHandler->append(new Response(200, [], $response));
         $this->testMockHandler->append(new Response(200, [], $response));
 
-        $crawler = $this->client->request('GET', "/entity/copy/d645ddf7-1246-4224-8e14-0d5c494fd9ad");
+        $crawler = $this->client->request('GET', "/entity/copy/{$this->service->getId()}/d645ddf7-1246-4224-8e14-0d5c494fd9ad");
 
         $formData = [
             'dashboard_bundle_entity_type' => [

--- a/tests/webtests/EntityCreateOidcTest.php
+++ b/tests/webtests/EntityCreateOidcTest.php
@@ -19,10 +19,16 @@
 namespace Surfnet\ServiceProviderDashboard\Webtests;
 
 use GuzzleHttp\Psr7\Response;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class EntityOidcCreateTest extends WebTestCase
 {
+    /**
+     * @var Service
+     */
+    private $service;
+
     public function setUp()
     {
         parent::setUp();
@@ -31,14 +37,18 @@ class EntityOidcCreateTest extends WebTestCase
 
         $this->logIn('ROLE_ADMINISTRATOR');
 
+        $this->service = $this->getServiceRepository()->findByName('Ibuildings B.V.');
+
         $this->getAuthorizationService()->setSelectedServiceId(
-            $this->getServiceRepository()->findByName('Ibuildings B.V.')->getId()
+            $this->service->getId()
         );
+
+        $this->service = $this->getServiceRepository()->findByName('SURFnet');
     }
 
     public function test_it_renders_the_form()
     {
-        $crawler = $this->client->request('GET', "/entity/create/oidc/test");
+        $crawler = $this->client->request('GET', "/entity/create/oidc/2/test");
         $form = $crawler->filter('.page-container')
             ->selectButton('Save')
             ->form();
@@ -54,7 +64,7 @@ class EntityOidcCreateTest extends WebTestCase
 
     public function test_it_can_cancel_out_of_the_form()
     {
-        $crawler = $this->client->request('GET', "/entity/create/oidc/test");
+        $crawler = $this->client->request('GET', "/entity/create/oidc/2/test");
         $form = $crawler
             ->selectButton('Cancel')
             ->form();
@@ -82,7 +92,7 @@ class EntityOidcCreateTest extends WebTestCase
     {
         $formData = $this->buildValidFormData();
 
-        $crawler = $this->client->request('GET', "/entity/create/oidc/test");
+        $crawler = $this->client->request('GET', "/entity/create/oidc/2/test");
 
         $form = $crawler
             ->selectButton('Save')
@@ -111,7 +121,7 @@ class EntityOidcCreateTest extends WebTestCase
     {
         $formData = $this->buildValidFormData();
 
-        $crawler = $this->client->request('GET', "/entity/create/oidc/test");
+        $crawler = $this->client->request('GET', "/entity/create/oidc/2/test");
 
         $form = $crawler
             ->selectButton('Publish')
@@ -151,7 +161,7 @@ class EntityOidcCreateTest extends WebTestCase
     {
         $formData = $this->buildValidFormData();
 
-        $crawler = $this->client->request('GET', "/entity/create/oidc/test");
+        $crawler = $this->client->request('GET', "/entity/create/oidc/2/test");
 
         $form = $crawler
             ->selectButton('Publish')
@@ -192,21 +202,16 @@ class EntityOidcCreateTest extends WebTestCase
             $this->getServiceRepository()->findByName('SURFnet')->getId()
         );
 
-        $crawler = $this->client->request('GET', '/entity/create/oidc/production');
+        $crawler = $this->client->request('GET', "/entity/create/oidc/1/production");
 
         $this->assertEquals(403, $this->client->getResponse()->getStatusCode());
     }
 
     public function test_a_privileged_user_can_create_a_production_draft()
     {
-        // Ibuildings is allowed to create production entities.
-        $this->getAuthorizationService()->setSelectedServiceId(
-            $this->getServiceRepository()->findByName('Ibuildings B.V.')->getId()
-        );
-
         $formData = $this->buildValidFormData();
 
-        $crawler = $this->client->request('GET', '/entity/create/oidc/production');
+        $crawler = $this->client->request('GET', "/entity/create/oidc/2/production");
 
         $form = $crawler
             ->selectButton('Save')

--- a/tests/webtests/EntityCreateSamlTest.php
+++ b/tests/webtests/EntityCreateSamlTest.php
@@ -40,7 +40,7 @@ class EntitySamlCreateSamlTest extends WebTestCase
 
     public function test_it_renders_the_form()
     {
-        $crawler = $this->client->request('GET', "/entity/create/saml20/test");
+        $crawler = $this->client->request('GET', "/entity/create/saml20/2/test");
         $form = $crawler->filter('.page-container')
             ->selectButton('Save')
             ->form();
@@ -70,7 +70,7 @@ class EntitySamlCreateSamlTest extends WebTestCase
             ],
         ];
 
-        $crawler = $this->client->request('GET', "/entity/create/saml20/test");
+        $crawler = $this->client->request('GET', "/entity/create/saml20/2/test");
 
         $form = $crawler
             ->selectButton('Import')
@@ -93,7 +93,7 @@ class EntitySamlCreateSamlTest extends WebTestCase
 
     public function test_it_can_cancel_out_of_the_form()
     {
-        $crawler = $this->client->request('GET', "/entity/create/saml20/test");
+        $crawler = $this->client->request('GET', "/entity/create/saml20/2/test");
         $form = $crawler
             ->selectButton('Cancel')
             ->form();
@@ -121,7 +121,7 @@ class EntitySamlCreateSamlTest extends WebTestCase
     {
         $formData = $this->buildValidFormData();
 
-        $crawler = $this->client->request('GET', "/entity/create/saml20/test");
+        $crawler = $this->client->request('GET', "/entity/create/saml20/2/test");
 
         $form = $crawler
             ->selectButton('Save')
@@ -153,7 +153,7 @@ class EntitySamlCreateSamlTest extends WebTestCase
         // manually (not using the import feature).
         unset($formData['dashboard_bundle_entity_type']['nameIdFormat']);
 
-        $crawler = $this->client->request('GET', "/entity/create/saml20/test");
+        $crawler = $this->client->request('GET', "/entity/create/saml20/2/test");
 
         $form = $crawler
             ->selectButton('Save')
@@ -178,7 +178,7 @@ class EntitySamlCreateSamlTest extends WebTestCase
     {
         $formData = $this->buildValidFormData();
 
-        $crawler = $this->client->request('GET', "/entity/create/saml20/test");
+        $crawler = $this->client->request('GET', "/entity/create/saml20/2/test");
 
         $form = $crawler
             ->selectButton('Publish')
@@ -211,7 +211,7 @@ class EntitySamlCreateSamlTest extends WebTestCase
     {
         $formData = $this->buildValidFormData();
 
-        $crawler = $this->client->request('GET', "/entity/create/saml20/test");
+        $crawler = $this->client->request('GET', "/entity/create/saml20/2/test");
 
         $form = $crawler
             ->selectButton('Publish')
@@ -254,7 +254,7 @@ class EntitySamlCreateSamlTest extends WebTestCase
             ],
         ];
 
-        $crawler = $this->client->request('GET', "/entity/create/saml20/test");
+        $crawler = $this->client->request('GET', "/entity/create/saml20/2/test");
 
         $form = $crawler
             ->selectButton('Import')
@@ -297,7 +297,7 @@ class EntitySamlCreateSamlTest extends WebTestCase
             $this->getServiceRepository()->findByName('SURFnet')->getId()
         );
 
-        $crawler = $this->client->request('GET', '/entity/create/saml20/production');
+        $crawler = $this->client->request('GET', '/entity/create/saml20/1/production');
 
         $this->assertEquals(403, $this->client->getResponse()->getStatusCode());
     }
@@ -311,7 +311,7 @@ class EntitySamlCreateSamlTest extends WebTestCase
 
         $formData = $this->buildValidFormData();
 
-        $crawler = $this->client->request('GET', '/entity/create/saml20/production');
+        $crawler = $this->client->request('GET', '/entity/create/saml20/2/production');
 
         $form = $crawler
             ->selectButton('Save')
@@ -348,7 +348,7 @@ class EntitySamlCreateSamlTest extends WebTestCase
                 ],
             ],
         ];
-        $crawler = $this->client->request('GET', "/entity/create/saml20/test");
+        $crawler = $this->client->request('GET', "/entity/create/saml20/2/test");
 
         $form = $crawler
             ->selectButton('Import')
@@ -376,7 +376,7 @@ class EntitySamlCreateSamlTest extends WebTestCase
                 ],
             ],
         ];
-        $crawler = $this->client->request('GET', "/entity/create/saml20/test");
+        $crawler = $this->client->request('GET', "/entity/create/saml20/2/test");
 
         $form = $crawler
             ->selectButton('Import')

--- a/tests/webtests/EntityDeleteTest.php
+++ b/tests/webtests/EntityDeleteTest.php
@@ -121,7 +121,7 @@ class EntityDeleteTest extends WebTestCase
         // Successfull deleting an entity from manage results in return type boolean : true
         $this->testMockHandler->append(new Response(200, [], json_encode(true)));
 
-        $crawler = $this->client->request('GET', "/entity/delete/published/a8e7cffd-0409-45c7-a37a-000000000000");
+        $crawler = $this->client->request('GET', "/entity/delete/published/1/a8e7cffd-0409-45c7-a37a-000000000000");
 
         $pageTitle = $crawler->filter('.page-container h1');
 
@@ -133,8 +133,9 @@ class EntityDeleteTest extends WebTestCase
 
         $this->client->submit($form);
 
+        $response = $this->client->getResponse();
         $this->assertTrue(
-            $this->client->getResponse() instanceof RedirectResponse,
+            $response instanceof RedirectResponse,
             'Expecting a redirect response after editing an entity'
         );
     }
@@ -167,7 +168,7 @@ class EntityDeleteTest extends WebTestCase
         // Successfull deleting an entity from manage results in return type boolean : true
         $this->prodMockHandler->append(new Response(200, [], json_encode(true)));
 
-        $crawler = $this->client->request('GET', "/entity/delete/published/a8e7cffd-0409-45c7-a37a-000000000000/production");
+        $crawler = $this->client->request('GET', "/entity/delete/published/1/a8e7cffd-0409-45c7-a37a-000000000000/production");
 
         $pageTitle = $crawler->filter('.page-container h1');
 
@@ -221,7 +222,7 @@ class EntityDeleteTest extends WebTestCase
         $this->prodMockHandler->append(new Response(200, [], '[]'));
         $this->prodMockHandler->append(new Response(200, [], '[]'));
 
-        $crawler = $this->client->request('GET', "/entity/delete/request/a8e7cffd-0409-45c7-a37a-000000000000");
+        $crawler = $this->client->request('GET', "/entity/delete/request/1/a8e7cffd-0409-45c7-a37a-000000000000");
 
         $pageTitle = $crawler->filter('h1');
 

--- a/tests/webtests/EntityListTest.php
+++ b/tests/webtests/EntityListTest.php
@@ -210,8 +210,8 @@ class EntityListTest extends WebTestCase
         $testAction = $modalTest->first()->attr('action');
         $prodAction = $modalProd->first()->attr('action');
 
-        $this->assertEquals('/entity/create/type', $testAction);
-        $this->assertEquals('/entity/create/type/production', $prodAction);
+        $this->assertEquals('/entity/create/type/2', $testAction);
+        $this->assertEquals('/entity/create/type/2/production', $prodAction);
 
         // Now submit one of the forms and ascertain we ended up on the edit entity form
         $form = $crawler->filter('#add-for-test')
@@ -223,7 +223,7 @@ class EntityListTest extends WebTestCase
             'Expected a redirect to the /entity/create/type action'
         );
 
-        $this->assertRegExp('/\/entity\/create\/type/', $this->client->getRequest()->getRequestUri());
+        $this->assertRegExp('/\/entity\/create\/type\/2/', $this->client->getRequest()->getRequestUri());
 
         // TODO: test submitting to the openidconnect form that is yet to be created
     }


### PR DESCRIPTION
The given service of an entity is not set for certain entity routes
which will throw an exception because a service is needed. This was not
an issue before because the active service was set in the session. But
because we now have overview pages with multiple services. We should
add the service to the route to know the active service on forehand.