### PR TITLE
Fix the dump method in twig template for prod

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Mail/jiraPublicationFailed.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Mail/jiraPublicationFailed.html.twig
@@ -8,7 +8,6 @@ Hi,<br/>
 
 <pre>
     {{ exception.message }}
-    {{ dump(exception.trace) }}
 </pre>
 
 <p>


### PR DESCRIPTION
In the mail template to notify the support desk when a publication
has failed there is a `dump` method. However this method is not
supported in the prod environment. So this is removed.