### PR TITLE
 Ensure Jira tickets are created once 

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -151,10 +151,6 @@
     <target name="security-tests">
         <exec executable="vendor/bin/security-checker" failonerror="true">
             <arg line="security:check" />
-            <!-- Downgrading to HTTP is a (temporary) fix and should be removed once TLS is supported on Travis -->
-            <!-- https://github.com/travis-ci/travis-ci/issues/6339 -->
-            <!-- https://github.com/sensiolabs/security-checker/pull/77#issuecomment-290733113 -->
-            <arg line="--end-point=http://security.sensiolabs.org/check_lock" />
         </exec>
 
         <exec executable="yarn" failonerror="true">

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityProductionCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityProductionCommandHandler.php
@@ -149,8 +149,15 @@ class PublishEntityProductionCommandHandler implements CommandHandler
         );
 
         try {
-            $issue = $this->ticketService->createIssueFrom($ticket);
-            $this->logger->info(sprintf('Created Jira issue with key: %s', $issue->key));
+            // Before creating an issue, test if we didn't previously create this ticket (users can apply changes to
+            // requested published entities).
+            $issue = $this->ticketService->findByManageIdAndIssueType($entity->getManageId(), $this->issueType);
+            if (is_null($issue)) {
+                $issue = $this->ticketService->createIssueFrom($ticket);
+                $this->logger->info(sprintf('Created Jira issue with key: %s', $issue->key));
+            } else {
+                $this->logger->info(sprintf('Found existing Jira issue with key: %s', $issue->key));
+            }
         } catch (Exception $e) {
             $this->logger->critical('Unable to create the Jira issue.', [$e->getMessage()]);
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/TicketService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/TicketService.php
@@ -57,4 +57,9 @@ class TicketService implements TicketServiceInterface
     {
         $this->issueRepository->delete($issueKey);
     }
+
+    public function findByManageIdAndIssueType($manageId, $issueType)
+    {
+        return $this->issueRepository->findByManageIdAndIssueType($manageId, $issueType);
+    }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/TicketServiceInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/TicketServiceInterface.php
@@ -47,6 +47,15 @@ interface TicketServiceInterface
     public function findByManageId($id);
 
     /**
+     * Find a Jira issue by issue type and manage id.
+     *
+     * @param $manageId
+     * @param $issueType
+     * @return mixed
+     */
+    public function findByManageIdAndIssueType($manageId, $issueType);
+
+    /**
      * @param string $issueKey
      */
     public function delete($issueKey);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/IssueRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/IssueRepository.php
@@ -141,6 +141,33 @@ class IssueRepository implements TicketServiceInterface
     }
 
     /**
+     * @param string $manageId
+     * @param string $issueType
+     * @return Issue|null
+     * @throws JiraException
+     * @throws JsonMapper_Exception
+     */
+    public function findByManageIdAndIssueType($manageId, $issueType)
+    {
+        $issueService = $this->jiraFactory->buildIssueService();
+        // Search CTX: "$issueType" issues with manage id as provided in the $manageId parameter
+        $issues = $issueService->search(
+            sprintf(
+                'project = %s AND issuetype = %s AND "%s" ~ %s',
+                $this->projectKey,
+                $issueType,
+                $this->manageIdFieldLabel,
+                $manageId
+            )
+        );
+        $result = reset($issues->issues);
+        if ($result instanceof Issue) {
+            return $result;
+        }
+        return null;
+    }
+
+    /**
      * Create a Jira issue from a Ticket VO
      *
      * @param Ticket $ticket

--- a/tests/integration/Application/CommandHandler/Entity/PublishEntityProductionCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/PublishEntityProductionCommandHandlerTest.php
@@ -127,11 +127,85 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
             ->shouldReceive('getEntityId')
             ->andReturn('https://app.example.com/');
         $entity
+            ->shouldReceive('getManageId')
+            ->andReturn('the-manage-id');
+        $entity
             ->shouldReceive('setStatus')
             ->with(Entity::STATE_PUBLISHED);
 
         $issue = m::mock(Issue::class)->makePartial();
         $issue->key = 'CXT-999';
+
+        $this->ticketService
+            ->shouldReceive('createIssueFrom')
+            ->andReturn($issue);
+
+        $this->ticketService
+            ->shouldReceive('findByManageIdAndIssueType')
+            ->andReturn(null);
+
+        $this->repository
+            ->shouldReceive('findById')
+            ->with('d6f394b2-08b1-4882-8b32-81688c15c489')
+            ->andReturn($entity);
+
+        $this->repository
+            ->shouldReceive('save')
+            ->with($entity);
+
+        $this->publishEntityClient
+            ->shouldReceive('publish')
+            ->once()
+            ->with($entity)
+            ->andReturn([
+                'id' => 123,
+            ]);
+
+        $this->logger
+            ->shouldReceive('info')
+            ->times(4);
+
+
+        $applicant = new Contact('john:doe', 'john@example.com', 'John Doe');
+        $command = new PublishEntityProductionCommand('d6f394b2-08b1-4882-8b32-81688c15c489', $applicant);
+        $this->commandHandler->handle($command);
+    }
+
+    /**
+     * Republishing an entity should not result in the creation of a new Jira ticket. The existing ticket should
+     * be retrieved and used in the further logging.
+     */
+    public function test_it_can_republish()
+    {
+        $contact = new Contact('nameid', 'name@example.org', 'display name');
+        $user = new Identity($contact);
+
+        $token = new SamlToken([]);
+        $token->setUser($user);
+
+        $entity = m::mock(Entity::class);
+        $entity
+            ->shouldReceive('getId')
+            ->andReturn('123');
+        $entity
+            ->shouldReceive('getNameEn')
+            ->andReturn('Test Entity Name');
+        $entity
+            ->shouldReceive('getEntityId')
+            ->andReturn('https://app.example.com/');
+        $entity
+            ->shouldReceive('getManageId')
+            ->andReturn('the-manage-id');
+        $entity
+            ->shouldReceive('setStatus')
+            ->with(Entity::STATE_PUBLISHED);
+
+        $issue = m::mock(Issue::class)->makePartial();
+        $issue->key = 'CXT-999';
+
+        $this->ticketService
+            ->shouldReceive('findByManageIdAndIssueType')
+            ->andReturn($issue);
 
         $this->ticketService
             ->shouldReceive('createIssueFrom')
@@ -182,6 +256,9 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
         $entity
             ->shouldReceive('getEntityId')
             ->andReturn('https://app.example.com/');
+        $entity
+            ->shouldReceive('getManageId')
+            ->andReturn('the-manage-id');
 
         $this->repository
             ->shouldReceive('findById')
@@ -234,9 +311,16 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
         $entity
             ->shouldReceive('getEntityId')
             ->andReturn('https://app.example.com/');
+        $entity
+            ->shouldReceive('getManageId')
+            ->andReturn('the-manage-id');
 
         $issue = m::mock(Issue::class)->makePartial();
         $issue->key = 'CXT-999';
+
+        $this->ticketService
+            ->shouldReceive('findByManageIdAndIssueType')
+            ->andReturn(null);
 
         $this->ticketService
             ->shouldReceive('createIssueFrom')


### PR DESCRIPTION
When re-publishing an entity that was previously published to production
(with a Jira ticket for the SD), the ticket must not be created for a
second time.

By trying to find the ticket before creating a new one we can prevent
the creation of duplicates.

https://www.pivotaltracker.com/story/show/163385254