### PR TITLE
Fix oidc client id on detail page

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityDetail.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityDetail.php
@@ -323,7 +323,10 @@ class EntityDetail
      */
     public function getEntityId()
     {
-        return $this->entityId;
+        if ($this->getProtocol() !== DomainEntity::TYPE_OPENID_CONNECT) {
+            return $this->entityId;
+        }
+        return str_replace('://', '@//', $this->entityId);
     }
 
     /**


### PR DESCRIPTION
The : in an oidc entityId should be replaced with a @. This was done
on other pages except on the entity detail page were it was missing in
the corresponding viewobject.

https://www.pivotaltracker.com/story/show/163417371