### PR TITLE
Fix oidc client id on confirmation popup

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityOidcConfirmation.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityOidcConfirmation.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Surfnet\ServiceProviderDashboard\Application\ViewObject;
+
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity as DomainEntity;
+
+class EntityOidcConfirmation
+{
+    /**
+     * @var string
+     */
+    private $entityId;
+
+    /**
+     * @var string
+     */
+    private $clientSecret;
+
+    /**
+     * @param string $entityId
+     * @param string $clientSecret
+     */
+    public function __construct(
+        $entityId,
+        $clientSecret
+    ) {
+        $this->entityId = $entityId;
+        $this->clientSecret = $clientSecret;
+    }
+
+    public static function fromEntity(DomainEntity $entity)
+    {
+        return new self(
+            $entity->getEntityId(),
+            $entity->getClientSecret()
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getEntityId()
+    {
+        return str_replace('://', '@//', $this->entityId);
+    }
+
+    /**
+     * @return string
+     */
+    public function getClientSecret()
+    {
+        return $this->clientSecret;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityPublishedController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityPublishedController.php
@@ -19,16 +19,13 @@
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Controller;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Application\ViewObject\EntityOidcConfirmation;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
-/**
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
- */
 class EntityPublishedController extends Controller
 {
     /**
@@ -77,6 +74,8 @@ class EntityPublishedController extends Controller
         // Show the confirmation modal only once in this request
         $this->get('session')->remove('published.entity.clone');
 
-        return ['entity' => $entity];
+        $viewObject = EntityOidcConfirmation::fromEntity($entity);
+
+        return ['entity' => $viewObject];
     }
 }


### PR DESCRIPTION
The : in an oidc entityId should be replaced with a @. This was done
on other views except for the oidc confirmation popup were it was
missing in the corresponding viewobject.

https://www.pivotaltracker.com/story/show/163417513