### PR TITLE
Prevent new entities for checking Jira ticket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next release
 
+**Bugfix**
+ - Prevent new entities for checking Jira ticket #232
+
 ## 2.0.2
 
 The main focus of this release was to fix some minor bugs to make a production ready release.

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityProductionCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityProductionCommandHandler.php
@@ -149,9 +149,12 @@ class PublishEntityProductionCommandHandler implements CommandHandler
         );
 
         try {
-            // Before creating an issue, test if we didn't previously create this ticket (users can apply changes to
-            // requested published entities).
-            $issue = $this->ticketService->findByManageIdAndIssueType($entity->getManageId(), $this->issueType);
+            $issue = null;
+            if ($entity->getManageId()) {
+                // Before creating an issue, test if we didn't previously create this ticket (users can apply changes to
+                // requested published entities).
+                $issue = $this->ticketService->findByManageIdAndIssueType($entity->getManageId(), $this->issueType);
+            }
             if (is_null($issue)) {
                 $issue = $this->ticketService->createIssueFrom($ticket);
                 $this->logger->info(sprintf('Created Jira issue with key: %s', $issue->key));


### PR DESCRIPTION
When a new entity is published, the manage id is not yet known and
a Jira issue is not previously published. This commit ensures we only
try to find a jira issue of the manage id is set.

https://www.pivotaltracker.com/story/show/163385254/comments/198784169