### PR TITLE
Correctly publish OIDC redirectUris to Manage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next release
 
+**Bugfix**
+ - Correctly publish OIDC redirect URIs to Manage #233
+
 **Improvement**
  - Provide a custom service overview for admin #234
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
@@ -267,6 +267,7 @@ class JsonGenerator implements GeneratorInterface
     {
         $metadata['clientId'] = str_replace('://', '@//', $entity->getEntityId());
         $metadata['clientSecret'] = $entity->getClientSecret();
+        // Reset the redirect URI list in order to get a correct JSON formatting (See #163646662)
         $metadata['redirectUris'] = $entity->getRedirectUris();
         $metadata['grantType'] = $entity->getGrantType()->getGrantType();
         $metadata['scope'] = ['openid'];

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
@@ -975,7 +975,7 @@ class Entity
      */
     public function setRedirectUris($redirectUris)
     {
-        $this->redirectUris = $redirectUris;
+        $this->redirectUris = array_values($redirectUris);
     }
 
     /**

--- a/tests/unit/Application/Metadata/JsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/JsonGeneratorTest.php
@@ -467,10 +467,10 @@ class JsonGeneratorTest extends MockeryTestCase
                             'clientSecret' => 'test',
                             'redirectUris' =>
                                 array (
-                                    0 => 'uri1',
-                                    1 => 'uri2',
-                                    2 => 'uri3',
-                                    3 => 'http://playground-test',
+                                    'uri1',
+                                    'uri2',
+                                    'uri3',
+                                    'http://playground-test',
                                 ),
                             'grantType' => 'implicit',
                             'scope' =>
@@ -628,7 +628,7 @@ CERT
         $entity->setOrganizationUrlNl('http://orgnl');
 
         $entity->setClientSecret('test');
-        $entity->setRedirectUris(['uri1','uri2', 'uri3']);
+        $entity->setRedirectUris([0 => 'uri1', 2 => 'uri2', 8 => 'uri3']);
         $entity->setGrantType(new OidcGrantType('implicit'));
         $entity->setEnablePlayground(true);
 


### PR DESCRIPTION
The array that is passed along to manage should be a list, not a map.
If the php indexes are updated along the way, by adding/removing items
from the form. The index order might not be sequentially pristine. This
causes JSON encode to generate a map instead of a list.

By resetting the list before publishing, this problem should be remedied

https://www.pivotaltracker.com/story/show/163646662