### PR TITLE
Provide a custom service overview for admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next release
 
+**Improvement**
+ - Provide a custom service overview for admin #234
 
 ## 2.0.3
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -115,6 +115,10 @@ class ServiceController extends Controller
             return $this->redirectToRoute('service_add');
         }
 
+        if ($this->isGranted('ROLE_ADMINISTRATOR')) {
+            return $this->render("@Dashboard/Service/admin_overview.html.twig");
+        }
+
         $serviceObjects = [];
         foreach ($services as $service) {
             $entityList = $this->entityService->getEntityListForService($service);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -310,6 +310,11 @@ privacy.information.snDpaWhyNot: What items of the SURF model Data Processing Ag
 privacy.information.surfmarketDpaAgreement: Did you agree a Data Processing Agreement with SURFmarket?
 privacy.information.surfnetDpaAgreement: Are you willing to sign the model SURF Data Processing Agreement?
 privacy.information.whatData: Describe what (kind of) data is processed in the service, and pay specific attention to possible processing of personal data.
+service:
+  admin_overview:
+    title: Service overview
+    introduction:
+      html: "Please use the service switcher to manage the entities of one of the services."
 service.create.title: Add new service
 service.edit.title: Edit service
 service.delete.title: "Delete service"

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/admin_overview.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/admin_overview.html.twig
@@ -1,0 +1,10 @@
+{% extends '::base.html.twig' %}
+
+{% block body_container %}
+    <h1>{% block page_heading %}{{ 'service.admin_overview.title'|trans }}{%endblock%}</h1>
+
+    <div class="fieldset card">
+        <div class="wysiwyg">{{ 'service.admin_overview.introduction.html'|trans|raw }}</div>
+    </div>
+
+{% endblock %}

--- a/tests/webtests/ServiceOverviewTest.php
+++ b/tests/webtests/ServiceOverviewTest.php
@@ -161,16 +161,14 @@ class ServiceOverviewTest extends WebTestCase
 
     public function test_service_overview_shows_message_when_no_service_selected()
     {
-        $this->markTestSkipped('TODO: Determine what the Administrator should see when authenticated');
-
         $this->loadFixtures();
         $this->logIn('ROLE_ADMINISTRATOR');
 
         $this->client->request('GET', '/');
         $response = $this->client->getResponse();
 
-        $this->assertContains('No service selected', $response->getContent());
-        $this->assertContains('Please select a service', $response->getContent());
+        $this->assertContains('Service overview', $response->getContent());
+        $this->assertContains('Please use the service switcher to manage the entities of one of the services.', $response->getContent());
     }
 
 


### PR DESCRIPTION
The admin user now is faced with a potential 504 error after logging on
to the application. As the service overview page is causing much data
to load for the admin user. In production, over 150 SP's are loaded on
this page including all their entity information.

This does not work out! The easy fix for now is simply rendering a
blank page with a small instruction to the admin user, to use the
service switcher and switch to the desired service that way.

For now the simplest of solutions is chosen (render a different template
if you are an admin user. This could and will be improved upon in an
upcoming development effort.

https://www.pivotaltracker.com/story/show/163691688