### PR TITLE
Change service switcher behavior

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -281,7 +281,7 @@ class ServiceController extends Controller
 
         $this->commandBus->handle($command);
 
-        return $this->redirectToRoute('entity_list', ['serviceId' => $serviceId]);
+        return $this->redirectToRoute('service_admin_overview', ['serviceId' => $serviceId]);
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -296,19 +296,9 @@ class ServiceController extends Controller
      */
     public function adminOverviewAction($serviceId)
     {
-        $allowedServices = $this->authorizationService->getAllowedServiceNamesById();
-        if (!isset($allowedServices[$serviceId])) {
-            throw $this->createNotFoundException(sprintf('Service with id "%s" cannot be found', $serviceId));
-        }
-        $allowedServices = [$serviceId => $allowedServices[$serviceId]];
-        $services = $this->serviceService->getServicesByAllowedServices($allowedServices);
-
-        $serviceObjects = [];
-        foreach ($services as $service) {
-            $entityList = $this->entityService->getEntityListForService($service);
-            $serviceObjects[] = Service::fromService($service, $entityList, $this->router);
-        }
-        $serviceList = new ServiceList($serviceObjects);
+        $service = $this->authorizationService->getServiceById($serviceId);
+        $entityList = $this->entityService->getEntityListForService($service);
+        $serviceList = new ServiceList([Service::fromService($service, $entityList, $this->router)]);
 
         return $this->render('DashboardBundle:Service:overview.html.twig', [
             'services' => $serviceList,

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -281,6 +281,10 @@ class ServiceController extends Controller
 
         $this->commandBus->handle($command);
 
+        if (!$serviceId) {
+            return $this->redirectToRoute('service_overview');
+        }
+
         return $this->redirectToRoute('service_admin_overview', ['serviceId' => $serviceId]);
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Menu/Builder.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Menu/Builder.php
@@ -19,6 +19,7 @@
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Menu;
 
 use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AuthorizationService;
 
 class Builder
@@ -29,6 +30,12 @@ class Builder
         $this->authorizationService = $authorizationService;
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.ElseExpression) Using else in this situation is preferable over another less expressive
+     *                                         solution
+     * @param array $options
+     * @return ItemInterface
+     */
     public function mainMenu(array $options)
     {
         $menu = $this->factory->createItem('root');
@@ -37,8 +44,14 @@ class Builder
             return $menu;
         }
 
-        $menu->addChild('Services', ['route' => 'service_overview']);
-
+        if ($this->authorizationService->isAdministrator() && $this->authorizationService->getActiveServiceId()) {
+            $menu->addChild('Service overview', [
+                'route' => 'service_admin_overview',
+                'routeParameters' => ['serviceId' => $this->authorizationService->getActiveServiceId()],
+            ]);
+        } else {
+            $menu->addChild('Services', ['route' => 'service_overview']);
+        }
         if ($this->authorizationService->isAdministrator()) {
             $menu->addChild('Add new service', array(
                 'route' => 'service_add',

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -346,6 +346,7 @@ service.form.label.representative_approved_yes: Yes
 service.form.label.service_type: Type of service
 service.form.label.service_type_institute: Institute
 service.form.label.service_type_non_institute: Not an institute
+service.admin_overview.title: Service overview
 service.overview.title: My services
 service.overview.action.entityList: Detailed entities overview
 service.overview.action.privacyQuestions: Privacy questions

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
@@ -2,7 +2,12 @@
 
 {% block body_container %}
 
-    <h1>{% block page_heading %}{{ 'service.overview.title'|trans }}{% endblock %}</h1>
+    <h1>{% block page_heading %}{% spaceless %}
+        {% if isAdmin %}
+        {{ 'service.admin_overview.title'|trans }}
+        {% else %}
+        {{ 'service.overview.title'|trans }}
+        {% endif %}{% endspaceless %}{% endblock %}</h1>
 
     {% for service in services %}
         <div class="fieldset card action">

--- a/tests/webtests/ServiceAdminOverviewTest.php
+++ b/tests/webtests/ServiceAdminOverviewTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Webtests;
+
+use GuzzleHttp\Psr7\Response;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+class ServiceAdminOverviewTest extends WebTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->loadFixtures();
+
+        $this->getAuthorizationService()->setSelectedServiceId(
+            $this->getServiceRepository()->findByName('SURFnet')->getId()
+        );
+    }
+
+    /**
+     * Entities of a service are listed on the page
+     */
+    public function test_only_one_service_is_displayed()
+    {
+        $serviceRepository = $this->getServiceRepository();
+        $surfNet = $serviceRepository->findByName('SURFnet');
+        $ibuildings = $serviceRepository->findByName('Ibuildings B.V.');
+
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->prodMockHandler->append(new Response(200, [], '[]'));
+        $this->prodMockHandler->append(new Response(200, [], '[]'));
+
+        $this->logIn('ROLE_ADMINISTRATOR', [$surfNet, $ibuildings]);
+
+        $crawler = $this->client->request('GET', '/service/2');
+
+        // By retrieving the h1 titles (stating the services) we can conclude if the correct data is displayed.
+        $h1 = $crawler->filter('.page-container h1');
+        $this->assertEquals('Service overview', $h1->first()->text());
+
+        $nodes = $crawler->filter('.service-status-container .service-status-title a');
+
+        // One service should be on page: ibuildings
+        $this->assertEquals(1, $nodes->count());
+        $this->assertEquals('Ibuildings B.V.', $nodes->first()->text());
+    }
+}

--- a/tests/webtests/ServiceOverviewTest.php
+++ b/tests/webtests/ServiceOverviewTest.php
@@ -55,6 +55,8 @@ class ServiceOverviewTest extends WebTestCase
         $crawler = $this->client->request('GET', '/');
 
         // By retrieving the h1 titles (stating the services) we can conclude if the correct data is displayed.
+        $h1 = $crawler->filter('.page-container h1');
+        $this->assertContains('My services', $h1->first()->text());
         $nodes = $crawler->filter('.service-status-container .service-status-title');
         $serviceNode = $nodes->first();
 


### PR DESCRIPTION
The service switcher should now redirect to the service overview (donut) overview page for the selected service. This is basically a filtered view on the existing donut overview page which showed all available services for the admin user.

See commits for details about the changes that are introduced.

https://www.pivotaltracker.com/story/show/163752485