### PR TITLE
Replace environment with status

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Dto/EntityDto.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Dto/EntityDto.php
@@ -74,8 +74,8 @@ class EntityDto
         return new self(
             $manageResponse->getId(),
             $manageResponse->getMetaData()->getEntityId(),
-            'published',
-            'test'
+            'test',
+            'published'
         );
     }
 
@@ -84,8 +84,8 @@ class EntityDto
         return new self(
             $manageResponse->getId(),
             $manageResponse->getMetaData()->getEntityId(),
-            'published',
-            'production'
+            'production',
+            'published'
         );
     }
 


### PR DESCRIPTION
The env and status fields where entered into the EntityDto the other
way around. Causing the donut to not correctly display entity
publication states.

https://www.pivotaltracker.com/story/show/163732191