### PR TITLE
Change detailed route on overview page to prevent 403

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
@@ -49,7 +49,7 @@
             <div class="service-status-container">
 
                 <div class="service-status-title">
-                    <a href="{{ path('select_service', {service: service.id }) }}">{{ service.name }}</a>
+                    <a href="{{ path('entity_list', {serviceId: service.id }) }}">{{ service.name }}</a>
                 </div>
                 <div class="service-status-graph" data-service-id="{{ service.id }}"></div>
                 <div class="service-status-entities">

--- a/tests/webtests/ServiceOverviewTest.php
+++ b/tests/webtests/ServiceOverviewTest.php
@@ -173,6 +173,29 @@ class ServiceOverviewTest extends WebTestCase
         $this->assertContains('Please use the service switcher to manage the entities of one of the services.', $response->getContent());
     }
 
+    public function test_users_redirect_to_entity_overview_on_title_click()
+    {
+        $serviceRepository = $this->getServiceRepository();
+        $surfNet = $serviceRepository->findByName('SURFnet');
+
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->prodMockHandler->append(new Response(200, [], '[]'));
+        $this->prodMockHandler->append(new Response(200, [], '[]'));
+
+        $this->logIn('ROLE_USER', [$surfNet]);
+        $crawler = $this->client->request('GET', '/');
+
+        $link = $crawler->filter('.service-status-title > a:nth-child(1)');
+        $this->client->request('GET', $link->attr('href'));
+
+        $uri = $this->client->getRequest()->getRequestUri();
+        $this->assertRegExp(
+            '/\/entities\/1/',
+            $uri,
+            'Visiting the anchor on the service title should end up on the entity detail page'
+        );
+    }
 
     private function rowsToArray(Crawler $crawler)
     {


### PR DESCRIPTION
Change route on overview page for non admins to the entity detail
page. This should be changed because the currently used route should
not be accessible for non admins. This in order to prevent an exception
when trying to access the edit page for non admins when not allowed.