### PR TITLE
Fix manage query state for prod

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
@@ -26,6 +26,7 @@ use Surfnet\ServiceProviderDashboard\Application\Dto\EntityDto;
 use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
 use Surfnet\ServiceProviderDashboard\Application\Provider\EntityQueryRepositoryProvider;
 use Surfnet\ServiceProviderDashboard\Application\ViewObject;
+use Surfnet\ServiceProviderDashboard\Application\ViewObject\Manage\Config;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
@@ -66,24 +67,24 @@ class EntityService implements EntityServiceInterface
     private $oidcPlaygroundUriProd;
 
     /**
-     * @var string
+     * @var Config
      */
-    private $testPublishedState;
+    private $testManageConfig;
 
     /**
-     * @var string
+     * @var Config
      */
-    private $prodPublishedState;
+    private $prodManageConfig;
 
     public function __construct(
         EntityQueryRepositoryProvider $entityQueryRepositoryProvider,
         TicketServiceInterface $ticketService,
+        Config $testConfig,
+        Config $productionConfig,
         RouterInterface $router,
         LoggerInterface $logger,
         $oidcPlaygroundUriTest,
-        $oidcPlaygroundUriProd,
-        $testPublishedState,
-        $prodPublishedState
+        $oidcPlaygroundUriProd
     ) {
         Assert::stringNotEmpty($oidcPlaygroundUriTest, 'Please set "playground_uri_test" in parameters.yml');
         Assert::stringNotEmpty($oidcPlaygroundUriProd, 'Please set "playground_uri_prod" in parameters.yml');
@@ -94,8 +95,8 @@ class EntityService implements EntityServiceInterface
         $this->logger = $logger;
         $this->oidcPlaygroundUriTest = $oidcPlaygroundUriTest;
         $this->oidcPlaygroundUriProd = $oidcPlaygroundUriProd;
-        $this->testPublishedState = $testPublishedState;
-        $this->prodPublishedState = $prodPublishedState;
+        $this->testManageConfig = $testConfig;
+        $this->prodManageConfig = $productionConfig;
     }
 
     public function createEntityUuid()
@@ -158,12 +159,18 @@ class EntityService implements EntityServiceInterface
             $entities[] = ViewObject\Entity::fromEntity($entity, $this->router);
         }
 
-        $testEntities = $this->findPublishedTestEntitiesByTeamName($service->getTeamName(), $this->testPublishedState);
+        $testEntities = $this->findPublishedTestEntitiesByTeamName(
+            $service->getTeamName(),
+            $this->testManageConfig->getPublicationStatus()->getCreateStatus()
+        );
         foreach ($testEntities as $result) {
             $entities[] = ViewObject\Entity::fromManageTestResult($result, $this->router, $service->getId());
         }
 
-        $productionEntities = $this->findPublishedProductionEntitiesByTeamName($service->getTeamName(), $this->prodPublishedState);
+        $productionEntities = $this->findPublishedProductionEntitiesByTeamName(
+            $service->getTeamName(),
+            $this->prodManageConfig->getPublicationStatus()->getCreateStatus()
+        );
         foreach ($productionEntities as $result) {
             $entities[] = ViewObject\Entity::fromManageProductionResult($result, $this->router, $service->getId());
         }
@@ -229,7 +236,7 @@ class EntityService implements EntityServiceInterface
     {
         return $this->queryRepositoryProvider
             ->getManageTestQueryClient()
-            ->findByTeamName($teamName, $this->testPublishedState);
+            ->findByTeamName($teamName, $this->testManageConfig->getPublicationStatus()->getCreateStatus());
     }
 
     /**
@@ -246,7 +253,7 @@ class EntityService implements EntityServiceInterface
     {
         $entities = $this->queryRepositoryProvider
             ->getManageProductionQueryClient()
-            ->findByTeamName($teamName, $this->prodPublishedState);
+            ->findByTeamName($teamName, $this->prodManageConfig->getPublicationStatus()->getCreateStatus());
 
         // Try to find the tickets in Jira that match the manageIds. If Jira is down or otherwise unavailable, the
         // entities are returned without updating their status. This might result in a 're request for delete'

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Repository/QueryEntityRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Repository/QueryEntityRepository.php
@@ -42,9 +42,10 @@ interface QueryEntityRepository
     public function getMetadataXmlByManageId($manageId);
 
     /**
-     * @param string $teamname
+     * @param string $teamName
+     * @param string $state
      *
      * @return array|null
      */
-    public function findByTeamName($teamName);
+    public function findByTeamName($teamName, $state);
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -255,6 +255,8 @@ services:
             - '@logger'
             - '%playground_uri_test%'
             - '%playground_uri_prod%'
+            - '%manage_test_publication_status_update%'
+            - '%manage_prod_publication_status_update%'
 
     Surfnet\ServiceProviderDashboard\Application\Service\LoadEntityService:
         arguments:

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -251,12 +251,12 @@ services:
         arguments:
             - '@Surfnet\ServiceProviderDashboard\Application\Provider\EntityQueryRepositoryProvider'
             - '@Surfnet\ServiceProviderDashboard\Application\Service\TicketService'
+            - '@surfnet.manage.configuration.test'
+            - '@surfnet.manage.configuration.production'
             - '@router'
             - '@logger'
             - '%playground_uri_test%'
             - '%playground_uri_prod%'
-            - '%manage_test_publication_status_update%'
-            - '%manage_prod_publication_status_update%'
 
     Surfnet\ServiceProviderDashboard\Application\Service\LoadEntityService:
         arguments:

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/QueryClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/QueryClient.php
@@ -137,18 +137,19 @@ class QueryClient implements QueryEntityRepository
      * Query manage for all test entities by given team name.
      *
      * @param string $teamName
+     * @param string $state
      *
      * @return ManageEntity[]|null
      *
      * @throws QueryServiceProviderException
      */
-    public function findByTeamName($teamName)
+    public function findByTeamName($teamName, $state)
     {
         try {
             // Query manage to get the internal id of every SP entity with given team ID.
             $searchResults = $this->doSearchQuery([
                 'metaDataFields.coin:service_team_id' => $teamName,
-                'state' => 'testaccepted'
+                'state' => $state
             ]);
 
             // For each search result, query manage to get the full SP entity data.

--- a/tests/unit/Application/Service/EntityServiceTest.php
+++ b/tests/unit/Application/Service/EntityServiceTest.php
@@ -75,7 +75,16 @@ class EntityServiceTest extends MockeryTestCase
         $this->router = m::mock(RouterInterface::class);
         $logger = m::mock(LoggerInterface::class);
         $this->ticketService = m::mock(TicketServiceInterface::class);
-        $this->service = new EntityService($provider, $this->ticketService, $this->router, $logger, 'playgroundUriTest', 'playgroundUriProd');
+        $this->service = new EntityService(
+            $provider,
+            $this->ticketService,
+            $this->router,
+            $logger,
+            'playgroundUriTest',
+            'playgroundUriProd',
+            'testaccepted',
+            'prodaccepted'
+        );
     }
 
     public function test_it_can_search_manage_test_by_manage_id()
@@ -133,12 +142,12 @@ class EntityServiceTest extends MockeryTestCase
 
         $this->manageTest
             ->shouldReceive('findByTeamName')
-            ->with($teamName)
+            ->with($teamName, 'testaccepted')
             ->andReturn([]);
 
         $this->manageProd
             ->shouldReceive('findByTeamName')
-            ->with($teamName)
+            ->with($teamName, 'prodaccepted')
             ->andReturn([]);
 
         $this->ticketService

--- a/tests/unit/Application/Service/EntityServiceTest.php
+++ b/tests/unit/Application/Service/EntityServiceTest.php
@@ -26,6 +26,7 @@ use Psr\Log\LoggerInterface;
 use Surfnet\ServiceProviderDashboard\Application\Provider\EntityQueryRepositoryProvider;
 use Surfnet\ServiceProviderDashboard\Application\Service\EntityService;
 use Surfnet\ServiceProviderDashboard\Application\Service\TicketServiceInterface;
+use Surfnet\ServiceProviderDashboard\Application\ViewObject\Manage\Config;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityRepository;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient as ManageQueryClient;
@@ -71,6 +72,16 @@ class EntityServiceTest extends MockeryTestCase
 
         $provider = new EntityQueryRepositoryProvider($this->repository, $this->manageTest, $this->manageProd);
 
+        $manageConfigTest = m::mock(Config::class);
+        $manageConfigTest
+            ->shouldReceive('getPublicationStatus->getCreateStatus')
+            ->andReturn('testaccepted');
+
+        $manageConfigProd = m::mock(Config::class);
+        $manageConfigProd
+            ->shouldReceive('getPublicationStatus->getCreateStatus')
+            ->andReturn('prodaccepted');
+
         $this->router = m::mock(RouterInterface::class);
         $this->router = m::mock(RouterInterface::class);
         $logger = m::mock(LoggerInterface::class);
@@ -78,12 +89,12 @@ class EntityServiceTest extends MockeryTestCase
         $this->service = new EntityService(
             $provider,
             $this->ticketService,
+            $manageConfigTest,
+            $manageConfigProd,
             $this->router,
             $logger,
             'playgroundUriTest',
-            'playgroundUriProd',
-            'testaccepted',
-            'prodaccepted'
+            'playgroundUriProd'
         );
     }
 


### PR DESCRIPTION
All entities were fetched with the 'testaccepted' state. This resulted
in entities not being fetched after they where published with
'prodaccepted'. This fix will get the entities based on the state
configured in the parameters.yml.