### PR TITLE
Update translations for SAML20 and OIDC

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcEntityType.php
@@ -248,7 +248,7 @@ class OidcEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.oidc.givenNameAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.givenNameAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.oidc.givenNameAttribute'],
                         ]
                     )
                     ->add(
@@ -258,7 +258,7 @@ class OidcEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.oidc.surNameAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.surNameAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.oidc.surNameAttribute'],
                         ]
                     )
                     ->add(
@@ -268,7 +268,7 @@ class OidcEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.oidc.commonNameAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.commonNameAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.oidc.commonNameAttribute'],
                         ]
                     )
                     ->add(
@@ -278,7 +278,7 @@ class OidcEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.oidc.displayNameAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.displayNameAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.oidc.displayNameAttribute'],
                         ]
                     )
                     ->add(
@@ -288,7 +288,7 @@ class OidcEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.oidc.emailAddressAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.emailAddressAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.oidc.emailAddressAttribute'],
                         ]
                     )
                     ->add(
@@ -298,7 +298,7 @@ class OidcEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.oidc.organizationAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.organizationAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.oidc.organizationAttribute'],
                         ]
                     )
                     ->add(
@@ -308,7 +308,7 @@ class OidcEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.oidc.organizationTypeAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.organizationTypeAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.oidc.organizationTypeAttribute'],
                         ]
                     )
                     ->add(
@@ -318,7 +318,7 @@ class OidcEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.oidc.affiliationAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.affiliationAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.oidc.affiliationAttribute'],
                         ]
                     )
                     ->add(
@@ -328,7 +328,7 @@ class OidcEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.oidc.entitlementAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.entitlementAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.oidc.entitlementAttribute'],
                         ]
                     )
                     ->add(
@@ -338,7 +338,7 @@ class OidcEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.oidc.principleNameAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.principleNameAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.oidc.principleNameAttribute'],
                         ]
                     )
                     ->add(
@@ -348,7 +348,7 @@ class OidcEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.oidc.uidAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.uidAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.oidc.uidAttribute'],
                         ]
                     )
                     ->add(
@@ -358,7 +358,7 @@ class OidcEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.oidc.preferredLanguageAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.preferredLanguageAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.oidc.preferredLanguageAttribute'],
                         ]
                     )
                     ->add(
@@ -368,7 +368,7 @@ class OidcEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.oidc.personalCodeAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.personalCodeAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.oidc.personalCodeAttribute'],
                         ]
                     )
                     ->add(
@@ -378,7 +378,7 @@ class OidcEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.oidc.scopedAffiliationAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.scopedAffiliationAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.oidc.scopedAffiliationAttribute'],
                         ]
                     )
                     ->add(
@@ -388,7 +388,7 @@ class OidcEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.oidc.eduPersonTargetedIDAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.eduPersonTargetedIDAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.oidc.eduPersonTargetedIDAttribute'],
                         ]
                     )
             )

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
@@ -263,7 +263,7 @@ class SamlEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.saml20.givenNameAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.givenNameAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.saml20.givenNameAttribute'],
                         ]
                     )
                     ->add(
@@ -273,7 +273,7 @@ class SamlEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.saml20.surNameAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.surNameAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.saml20.surNameAttribute'],
                         ]
                     )
                     ->add(
@@ -283,7 +283,7 @@ class SamlEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.saml20.commonNameAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.commonNameAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.saml20.commonNameAttribute'],
                         ]
                     )
                     ->add(
@@ -293,7 +293,7 @@ class SamlEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.saml20.displayNameAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.displayNameAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.saml20.displayNameAttribute'],
                         ]
                     )
                     ->add(
@@ -303,7 +303,7 @@ class SamlEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.saml20.emailAddressAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.emailAddressAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.saml20.emailAddressAttribute'],
                         ]
                     )
                     ->add(
@@ -313,7 +313,7 @@ class SamlEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.saml20.organizationAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.organizationAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.saml20.organizationAttribute'],
                         ]
                     )
                     ->add(
@@ -323,7 +323,7 @@ class SamlEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.saml20.organizationTypeAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.organizationTypeAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.saml20.organizationTypeAttribute'],
                         ]
                     )
                     ->add(
@@ -333,7 +333,7 @@ class SamlEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.saml20.affiliationAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.affiliationAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.saml20.affiliationAttribute'],
                         ]
                     )
                     ->add(
@@ -343,7 +343,7 @@ class SamlEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.saml20.entitlementAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.entitlementAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.saml20.entitlementAttribute'],
                         ]
                     )
                     ->add(
@@ -353,7 +353,7 @@ class SamlEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.saml20.principleNameAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.principleNameAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.saml20.principleNameAttribute'],
                         ]
                     )
                     ->add(
@@ -363,7 +363,7 @@ class SamlEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.saml20.uidAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.uidAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.saml20.uidAttribute'],
                         ]
                     )
                     ->add(
@@ -373,7 +373,7 @@ class SamlEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.saml20.preferredLanguageAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.preferredLanguageAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.saml20.preferredLanguageAttribute'],
                         ]
                     )
                     ->add(
@@ -383,7 +383,7 @@ class SamlEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.saml20.personalCodeAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.personalCodeAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.saml20.personalCodeAttribute'],
                         ]
                     )
                     ->add(
@@ -393,7 +393,7 @@ class SamlEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.saml20.scopedAffiliationAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.scopedAffiliationAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.saml20.scopedAffiliationAttribute'],
                         ]
                     )
                     ->add(
@@ -403,7 +403,7 @@ class SamlEntityType extends AbstractType
                             'label' => 'entity.edit.form.attributes.saml20.eduPersonTargetedIDAttribute',
                             'by_reference' => false,
                             'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.eduPersonTargetedIDAttribute'],
+                            'attr' => ['data-help' => 'entity.edit.information.saml20.eduPersonTargetedIDAttribute'],
                         ]
                     )
             )

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -19,11 +19,13 @@ entity:
   detail:
     title: Entity details
     info:
-      title: Information
-      html: <strong>information about this view</strong>
+      saml20:
+        title: Information
+        html: <strong>information about this view</strong>
+      oidc:
+        title: Information
+        html: <strong>information about this view</strong>
     metadata:
-      title: Metadata
-      html: <strong>information about the metadata fields</strong>
       metadata_url: Metadata URL
       acs_location: ACS location
       entity_id: Entity ID
@@ -36,9 +38,13 @@ entity:
       description_en: Description EN
       application_url: Application URL
       eula_url: EULA URL
+      saml20:
+        title: Metadata
+        html: <strong>information about the metadata fields</strong>
+      oidc:
+        title: Metadata
+        html: <strong>information about the metadata fields</strong>
     contact:
-      title: Contact information
-      html: <strong>information about the contact information fields</strong>
       administrative: Administrative contact
       technical: Technical contact
       support: Support contact
@@ -46,11 +52,17 @@ entity:
       last_name: Last name
       email: Email
       phone: Phone
+      saml20:
+        title: Contact information
+        html: <strong>information about the contact information fields</strong>
+      oidc:
+        title: Contact information
+        html: <strong>information about the contact information fields</strong>
     attribute:
+      motivation: Motivation
       saml20:
         title: Attributes
         html: <strong>information about the attribute fields</strong>
-        motivation: Motivation
         given_name: Given name
         surname: Surname
         common_name: Common name attribute
@@ -69,7 +81,6 @@ entity:
       oidc:
         title: Attributes
         html: <strong>information about the attribute fields</strong>
-        motivation: Motivation
         given_name: Given name
         surname: Surname
         common_name: Common name attribute
@@ -244,21 +255,36 @@ entity.edit.information.eulaUrl: Text should be set in web translations
 entity.edit.information.administrativeContact: Text should be set in web translations
 entity.edit.information.supportContact: Text should be set in web translations
 entity.edit.information.technicalContact: Text should be set in web translations
-entity.edit.information.givenNameAttribute: Text should be set in web translations
-entity.edit.information.surNameAttribute: Text should be set in web translations
-entity.edit.information.commonNameAttribute: Text should be set in web translations
-entity.edit.information.displayNameAttribute: Text should be set in web translations
-entity.edit.information.emailAddressAttribute: Text should be set in web translations
-entity.edit.information.organizationAttribute: Text should be set in web translations
-entity.edit.information.organizationTypeAttribute: Text should be set in web translations
-entity.edit.information.affiliationAttribute: Text should be set in web translations
-entity.edit.information.entitlementAttribute: Text should be set in web translations
-entity.edit.information.principleNameAttribute: Text should be set in web translations
-entity.edit.information.uidAttribute: Text should be set in web translations
-entity.edit.information.preferredLanguageAttribute: Text should be set in web translations
-entity.edit.information.personalCodeAttribute: Text should be set in web translations
-entity.edit.information.scopedAffiliationAttribute: Text should be set in web translations
-entity.edit.information.eduPersonTargetedIDAttribute: Text should be set in web translations
+entity.edit.information.saml20.givenNameAttribute: Text should be set in web translations
+entity.edit.information.saml20.surNameAttribute: Text should be set in web translations
+entity.edit.information.saml20.commonNameAttribute: Text should be set in web translations
+entity.edit.information.saml20.displayNameAttribute: Text should be set in web translations
+entity.edit.information.saml20.emailAddressAttribute: Text should be set in web translations
+entity.edit.information.saml20.organizationAttribute: Text should be set in web translations
+entity.edit.information.saml20.organizationTypeAttribute: Text should be set in web translations
+entity.edit.information.saml20.affiliationAttribute: Text should be set in web translations
+entity.edit.information.saml20.entitlementAttribute: Text should be set in web translations
+entity.edit.information.saml20.principleNameAttribute: Text should be set in web translations
+entity.edit.information.saml20.uidAttribute: Text should be set in web translations
+entity.edit.information.saml20.preferredLanguageAttribute: Text should be set in web translations
+entity.edit.information.saml20.personalCodeAttribute: Text should be set in web translations
+entity.edit.information.saml20.scopedAffiliationAttribute: Text should be set in web translations
+entity.edit.information.saml20.eduPersonTargetedIDAttribute: Text should be set in web translations
+entity.edit.information.oidc.givenNameAttribute: Text should be set in web translations
+entity.edit.information.oidc.surNameAttribute: Text should be set in web translations
+entity.edit.information.oidc.commonNameAttribute: Text should be set in web translations
+entity.edit.information.oidc.displayNameAttribute: Text should be set in web translations
+entity.edit.information.oidc.emailAddressAttribute: Text should be set in web translations
+entity.edit.information.oidc.organizationAttribute: Text should be set in web translations
+entity.edit.information.oidc.organizationTypeAttribute: Text should be set in web translations
+entity.edit.information.oidc.affiliationAttribute: Text should be set in web translations
+entity.edit.information.oidc.entitlementAttribute: Text should be set in web translations
+entity.edit.information.oidc.principleNameAttribute: Text should be set in web translations
+entity.edit.information.oidc.uidAttribute: Text should be set in web translations
+entity.edit.information.oidc.preferredLanguageAttribute: Text should be set in web translations
+entity.edit.information.oidc.personalCodeAttribute: Text should be set in web translations
+entity.edit.information.oidc.scopedAffiliationAttribute: Text should be set in web translations
+entity.edit.information.oidc.eduPersonTargetedIDAttribute: Text should be set in web translations
 entity.edit.information.comments: Text should be set in web translations
 entity.edit.information.nameIdFormat: Text should be set in web translations
 entity.edit.motivation.keep_talking: 'Please provide a more detailed motivation.'

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detail.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detail.html.twig
@@ -9,13 +9,13 @@
         {% include '@Dashboard/EntityActions/actionsForDetail.html.twig' with {entity: entity.actions} %}
     </div>
     <div class="fieldset card">
-        <h2>{{ 'entity.detail.info.title'|trans }}</h2>
-        <div class="wysiwyg">{{ 'entity.detail.info.html'|trans|raw }}</div>
+        <h2>{{ ('entity.detail.info.' ~ type ~ '.title')|trans }}</h2>
+        <div class="wysiwyg">{{ ('entity.detail.info.' ~ type ~ '.html')|trans|raw }}</div>
     </div>
 
     <div class="fieldset card">
-        <h2>{{ 'entity.detail.metadata.title'|trans }}</h2>
-        <div class="wysiwyg">{{ 'entity.detail.metadata.html'|trans|raw }}</div>
+        <h2>{{ ('entity.detail.metadata.' ~ type ~ '.title')|trans }}</h2>
+        <div class="wysiwyg">{{ ('entity.detail.metadata.' ~ type ~ '.html')|trans|raw }}</div>
 
         {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.metadata_url'|trans, value: entity.metadataUrl, informationPopup: 'entity.edit.information.metadataUrl'} %}
         {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.acs_location'|trans, value: entity.acsLocation, informationPopup: 'entity.edit.information.acsLocation'} %}
@@ -33,8 +33,8 @@
     </div>
 
     <div class="fieldset card">
-        <h2>{{ 'entity.detail.contact.title'|trans }}</h2>
-        <div class="wysiwyg">{{ 'entity.detail.contact.html'|trans|raw }}</div>
+        <h2>{{ ('entity.detail.contact.' ~ type ~ '.title')|trans }}</h2>
+        <div class="wysiwyg">{{ ('entity.detail.contact.' ~ type ~ '.html')|trans|raw }}</div>
 
         {% include '@Dashboard/EntityDetail/detailContactField.html.twig' with {label: 'entity.detail.contact.administrative'|trans, value: entity.administrativeContact, informationPopup: 'entity.edit.information.administrativeContact'} %}
         {% include '@Dashboard/EntityDetail/detailContactField.html.twig' with {label: 'entity.detail.contact.technical'|trans, value: entity.technicalContact, informationPopup: 'entity.edit.information.technicalContact'} %}
@@ -43,8 +43,8 @@
     </div>
 
     <div class="fieldset card">
-        <h2>{{ 'entity.detail.attribute.title'|trans }}</h2>
-        <div class="wysiwyg">{{ 'entity.detail.attribute.html'|trans|raw }}</div>
+        <h2>{{ ('entity.detail.attribute.' ~ type ~ '.title')|trans }}</h2>
+        <div class="wysiwyg">{{ ('entity.detail.attribute.' ~ type ~ '.html')|trans|raw }}</div>
 
         {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.given_name')|trans, value: entity.givenNameAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.givenNameAttribute'} %}
         {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.surname')|trans, value: entity.surNameAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.surNameAttribute'} %}


### PR DESCRIPTION
Translations are no longer reused between the two entity types. This was fixed for the attribute information balloon translations and several titles on the entity detail screens.

Note to the releaser/reviewer.

The original attribute information balloon texts have been removed / replaced with saml20 and oidc counterparts. For example: 

`entity.edit.information.givenNameAttribute` is broken up into: `entity.edit.information.saml20.givenNameAttribute` and `entity.edit.information.oidc.givenNameAttribute`