### PR TITLE
Fix the playground url after copy to production

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/LoadEntityService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/LoadEntityService.php
@@ -132,7 +132,7 @@ class LoadEntityService
         // Convert manage entity to domain entity
         $domainEntity = Entity::fromManageResponse(
             $manageEntity,
-            $environment,
+            $sourceEnvironment,
             $service,
             $this->oidcPlaygroundUriTest,
             $this->oidcPlaygroundUriProd


### PR DESCRIPTION
The entity was copied but used the wrong environment so the playground
url from test was added to the redirect uri's and the checkbox was
unchecked.