### PR TITLE
Prevent a space in the secret when copying

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detailTextField.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detailTextField.html.twig
@@ -5,7 +5,6 @@
             <i class="fa fa-question-circle"></i>
         </span>
     {% endif %}
-    <label>{{ label }}</label>
-    <span>{{ value }}</span>
+    <label>{{ label }}</label><span>{{ value }}</span>
 </div>
 {% endif %}


### PR DESCRIPTION
When clicking on the secret to copy it a space was selected before the
secret and this is very helpful. Therefore removed the spacing.