### PR TITLE
Add transactions middleware to commandbus

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -149,3 +149,10 @@ dashboard_saml:
         max_absolute_lifetime: "%session_max_absolute_lifetime%"
         max_relative_lifetime: "%session_max_relative_lifetime%"
     administrator_teams: "%administrator_teams%"
+
+tactician:
+    commandbus:
+        default:
+            middleware:
+                - surfnet.dashboard.middleware.doctrine_transaction
+                - tactician.middleware.command_handler

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
@@ -140,7 +140,7 @@ class Service
     /**
      * @var \Doctrine\Common\Collections\ArrayCollection
      *
-     * @ORM\OneToMany(targetEntity="Entity", mappedBy="service", cascade={"persist"}, orphanRemoval=true)
+     * @ORM\OneToMany(targetEntity="Entity", mappedBy="service", cascade={"persist"})
      */
     private $entities;
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityControllerTrait.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityControllerTrait.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Controller;
 
+use Exception;
 use League\Tactician\CommandBus;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\DeleteDraftEntityCommand;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\LoadMetadataCommand;
@@ -119,6 +120,8 @@ trait EntityControllerTrait
             }
         } catch (InvalidArgumentException $e) {
             $this->addFlash('error', 'entity.edit.metadata.invalid.exception');
+        } catch (Exception $e) {
+            $this->addFlash('error', 'entity.edit.metadata.unknown.exception');
         }
 
         $form = $this->createForm(SamlEntityType::class, $command);
@@ -150,7 +153,11 @@ trait EntityControllerTrait
                 break;
         }
 
-        $this->commandBus->handle($publishEntityCommand);
+        try {
+            $this->commandBus->handle($publishEntityCommand);
+        } catch (Exception $e) {
+            $flashBag->add('error', 'entity.edit.error.publish');
+        }
 
         if (!$flashBag->has('error')) {
             // A clone is saved in session temporarily, to be able to report which entity was removed on the reporting

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Middleware/DoctrineTransactionMiddleware.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Middleware/DoctrineTransactionMiddleware.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Middleware;
+
+use Doctrine\ORM\EntityManager;
+use League\Tactician\Middleware;
+use Exception;
+use Throwable;
+
+class DoctrineTransactionMiddleware implements Middleware
+{
+    /**
+     * @var EntityManager
+     */
+    private $entityManager;
+
+    public function __construct(EntityManager $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    public function execute($command, callable $next)
+    {
+        $this->entityManager->beginTransaction();
+        try {
+            $returnValue = $next($command);
+            $this->entityManager->flush();
+            $this->entityManager->commit();
+        } catch (Exception $e) {
+            $this->entityManager->rollback();
+            throw $e;
+        } catch (Throwable $e) {
+            $this->entityManager->rollback();
+            throw $e;
+        }
+        return $returnValue;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -10,6 +10,9 @@ services:
         resource: '../../Security/Voter'
         tags: ['security.voter']
 
+    surfnet.dashboard.middleware.doctrine_transaction:
+        class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Middleware\DoctrineTransactionMiddleware
+
     surfnet.dashboard.command_handler.create_service:
         class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Service\CreateServiceCommandHandler
         public: true

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -203,6 +203,7 @@ entity.edit.metadata.saml20.html: "Please provide the metadata URL of your entit
 entity.edit.metadata.oidc.html: "Please provide the metadata URL of your entity. The URL will be validated and the fields below will be filled in automatically (when available in the metadata). <strong>If the input is not correct please change the settings in your SAML enabled software.</strong> Note that the fields with a * are required and need to be correctly configured. Check the following page for more information: <a href=\"https://wiki.surfnet.nl/x/vclWAw\">https://wiki.surfnet.nl/x/vclWAw</a>."
 entity.edit.metadata.invalid.exception: "An error occurred while importing the metadata."
 entity.edit.metadata.validation-failed: "Warning! Some entries are missing or incorrect. Please review and fix those entries below."
+entity.edit.metadata.unknown.exception: "An unknown error occurred while importing the metadata."
 entity.edit.metadata.saml20.title: Metadata
 entity.edit.metadata.oidc.title: Metadata
 entity.edit.metadata.parse.exception: "The provided metadata is invalid."

--- a/tests/unit/Infrastructure/DashboardBundle/Middleware/DoctrineTransactionMiddlewareTest.php
+++ b/tests/unit/Infrastructure/DashboardBundle/Middleware/DoctrineTransactionMiddlewareTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\DashboardBundle\Middleware;
+
+use Doctrine\ORM\EntityManager;
+use Exception;
+use League\Tactician\CommandBus;
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveSamlEntityCommand;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Middleware\DoctrineTransactionMiddleware;
+
+class DoctrineTransactionMiddlewareTest extends MockeryTestCase
+{
+    private $entityManager;
+
+    /**
+     * @var DoctrineTransactionMiddleware
+     */
+    private $middleware;
+
+    public function setUp()
+    {
+        $this->entityManager = m::mock(EntityManager::class);
+        $this->middleware = new DoctrineTransactionMiddleware($this->entityManager);
+    }
+
+    /**
+     * Simulation of a command that is executed without problem
+     */
+    public function test_command_execution()
+    {
+        $next = function ($command) {
+            $bus = m::mock(CommandBus::class);
+            $bus->shouldReceive('execute');
+        };
+
+        $command = m::mock(SaveSamlEntityCommand::class);
+        $this->entityManager->shouldReceive('beginTransaction');
+        $this->entityManager->shouldReceive('flush');
+        $this->entityManager->shouldReceive('commit');
+
+        $this->middleware->execute($command, $next);
+    }
+
+
+    /**
+     * Simulation of a command that yields an exception
+     */
+    public function test_command_execution_raises_exception()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Beep');
+
+        $next = function ($command) {
+            throw new Exception('Beep');
+        };
+
+        $command = m::mock(SaveSamlEntityCommand::class);
+        $this->entityManager->shouldReceive('beginTransaction');
+        $this->entityManager->shouldReceive('rollback');
+
+        $this->middleware->execute($command, $next);
+    }
+}


### PR DESCRIPTION
Add transactions to the command bus. This, to prevent duplicate entities when storing entities and an unexpected exception occurs.