### PR TITLE
Fix urn validator regex

### DIFF
--- a/app/js/components/validation.js
+++ b/app/js/components/validation.js
@@ -127,7 +127,7 @@ function validateUrl(value) {
 }
 
 function validateUrn(value) {
-    var regExp = /^urn:[a-z0-9][a-z0-9-]{0,31}:[a-z0-9()+,\-.:=@;$_!*'%/?#]+$/i;
+    var regExp = /^urn:[a-z0-9][a-z0-9-]{0,31}:[a-z0-9()+,\-.:=@;$_!*'%\/?#]+$/i;
 
     return regExp.test(value);
 }


### PR DESCRIPTION
The regex for the URN validator was faulty and a slash was missing
escaping. This resulted in a false negative when validating URN's.