### PR TITLE
Change the donutstate with empty service

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Assembler/ServiceStatusAssembler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Assembler/ServiceStatusAssembler.php
@@ -194,8 +194,6 @@ class ServiceStatusAssembler
         return $states;
     }
 
-
-
     /**
      * @param array $states
      * @return array

--- a/src/Surfnet/ServiceProviderDashboard/Application/Assembler/ServiceStatusAssembler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Assembler/ServiceStatusAssembler.php
@@ -175,7 +175,7 @@ class ServiceStatusAssembler
             $states[self::SERVICE_STATE_INTAKE_CONDUCTED] = $intakeStatus;
         }
 
-        $states[self::SERVICE_STATE_ENTITY_ON_TEST] = $serviceStatusService->getEntityStatus($service);
+        $states[self::SERVICE_STATE_ENTITY_ON_TEST] = $serviceStatusService->getEntityStatusOnTest($service);
 
         if ($type == Service::SERVICE_TYPE_NON_INSTITUTE) {
             $states[self::SERVICE_STATE_CONTRACT_SIGNED] = $service->getContractSigned();
@@ -193,6 +193,8 @@ class ServiceStatusAssembler
 
         return $states;
     }
+
+
 
     /**
      * @param array $states

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/CreateServiceCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/CreateServiceCommand.php
@@ -81,11 +81,6 @@ class CreateServiceCommand implements Command
     private $connectionStatus = Service::CONNECTION_STATUS_NOT_REQUESTED;
 
     /**
-     * @var string
-     */
-    private $entityPublished = Service::ENTITY_PUBLISHED_NO;
-
-    /**
      * @param string $guid
      */
     public function setGuid($guid)
@@ -252,13 +247,5 @@ class CreateServiceCommand implements Command
     public function hasPrivacyQuestionsAnswered()
     {
         return false;
-    }
-
-    /**
-     * @return string
-     */
-    public function getEntityPublished()
-    {
-        return $this->entityPublished;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/EditServiceCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/EditServiceCommand.php
@@ -90,11 +90,6 @@ class EditServiceCommand implements Command
     private $connectionStatus;
 
     /**
-     * @var string
-     */
-    private $entityPublished;
-
-    /**
      * @SuppressWarnings(PHPMD.ExcessiveParameterList) - Could be decomposed, but for now makes no sense.
      *
      * @param int $id
@@ -109,7 +104,6 @@ class EditServiceCommand implements Command
      * @param string $surfconextRepresentativeApproved
      * @param string $privacyQuestionsAnswered
      * @param string $connectionStatus
-     * @param string $entityPublished
      */
     public function __construct(
         $id,
@@ -123,8 +117,7 @@ class EditServiceCommand implements Command
         $contractSigned,
         $surfconextRepresentativeApproved,
         $privacyQuestionsAnswered,
-        $connectionStatus,
-        $entityPublished
+        $connectionStatus
     ) {
         $this->id = $id;
         $this->guid = $guid;
@@ -138,7 +131,6 @@ class EditServiceCommand implements Command
         $this->surfconextRepresentativeApproved = $surfconextRepresentativeApproved;
         $this->privacyQuestionsAnswered = $privacyQuestionsAnswered;
         $this->connectionStatus = $connectionStatus;
-        $this->entityPublished = $entityPublished;
     }
 
 
@@ -332,13 +324,5 @@ class EditServiceCommand implements Command
     public function isPrivacyQuestionsEnabled()
     {
         return $this->privacyQuestionsEnabled;
-    }
-
-    /**
-     * @return string
-     */
-    public function getEntityPublished()
-    {
-        return $this->entityPublished;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/ServiceStatusService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/ServiceStatusService.php
@@ -56,15 +56,13 @@ class ServiceStatusService
     }
 
     /**
-     * - Status: "No" when no test entity, not production entity and no draft is present
-     * - Status: "In progress" when there is no entity on test or production but a draft entity is present
-     * - Status: "Yes" when either:
-     *   - A test entity is published
-     *   - A production entity is published
+     * - Status: "No" when no test entity, and no draft on test is present
+     * - Status: "In progress" when there is no entity on test but a draft test entity is present
+     * - Status: "Yes" when a test entity is published
      * @param Service $service
      * @return string
      */
-    public function getEntityStatus(Service $service)
+    public function getEntityStatusOnTest(Service $service)
     {
         $entities = $this->entityService->getEntitiesForService($service);
 
@@ -72,13 +70,16 @@ class ServiceStatusService
         $publishedList = [];
 
         foreach ($entities as $entity) {
-            if ($entity->getState() == Entity::STATE_PUBLISHED) {
-                $publishedList[] = $entity;
-            }
-            if ($entity->getState() == Entity::STATE_DRAFT) {
-                $inProgressList[] = $entity;
+            if ($entity->getEnvironment() === Entity::ENVIRONMENT_TEST) {
+                if ($entity->getState() == Entity::STATE_PUBLISHED) {
+                    $publishedList[] = $entity;
+                }
+                if ($entity->getState() == Entity::STATE_DRAFT) {
+                    $inProgressList[] = $entity;
+                }
             }
         }
+
         // Was one of the entities published?
         if (count($publishedList) > 0) {
             return Service::ENTITY_PUBLISHED_YES;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -197,8 +197,7 @@ class ServiceController extends Controller
             $service->getContractSigned(),
             $service->getSurfconextRepresentativeApproved(),
             $this->serviceStatusService->hasPrivacyQuestions($service),
-            $service->getConnectionStatus(),
-            $this->serviceStatusService->getEntityStatus($service)
+            $service->getConnectionStatus()
         );
 
         $form = $this->createForm(EditServiceType::class, $command);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -356,10 +356,6 @@ service.form.label.connection_status_active: Active
 service.form.label.contract_signed: Contract signed
 service.form.label.contract_signed_no: No
 service.form.label.contract_signed_yes: Yes
-service.form.label.entity_published: Entity published?
-service.form.label.entity_published_no: No
-service.form.label.entity_published_in_progress: In progress
-service.form.label.entity_published_yes: Yes
 service.form.label.intake_status: Intake finished
 service.form.label.intake_status_no: No
 service.form.label.intake_status_yes: Yes

--- a/tests/unit/Application/Assembler/ServiceStatusAssemblerTest.php
+++ b/tests/unit/Application/Assembler/ServiceStatusAssemblerTest.php
@@ -107,7 +107,7 @@ class ServiceStatusAssemblerTest extends MockeryTestCase
                     ],
                 ],
                 'statusService' => [
-                    'entityStatus' => Service::ENTITY_PUBLISHED_YES,
+                    'entityStatusTest' => Service::ENTITY_PUBLISHED_YES,
                     'privacyQuestions' => true,
                 ],
                 'result' => '{
@@ -166,7 +166,7 @@ class ServiceStatusAssemblerTest extends MockeryTestCase
                     ],
                 ],
                 'statusService' => [
-                    'entityStatus' => Service::ENTITY_PUBLISHED_YES,
+                    'entityStatusTest' => Service::ENTITY_PUBLISHED_YES,
                     'privacyQuestions' => true,
                 ],
                 'result' => '{
@@ -226,7 +226,7 @@ class ServiceStatusAssemblerTest extends MockeryTestCase
                     ],
                 ],
                 'statusService' => [
-                    'entityStatus' => Service::ENTITY_PUBLISHED_YES,
+                    'entityStatusTest' => Service::ENTITY_PUBLISHED_YES,
                     'privacyQuestions' => true,
                 ],
                 'result' => '{
@@ -283,7 +283,7 @@ class ServiceStatusAssemblerTest extends MockeryTestCase
                     'entities' => [],
                 ],
                 'statusService' => [
-                    'entityStatus' => Service::ENTITY_PUBLISHED_YES,
+                    'entityStatusTest' => Service::ENTITY_PUBLISHED_YES,
                     'privacyQuestions' => false,
                 ],
                 'result' => '{
@@ -338,7 +338,7 @@ class ServiceStatusAssemblerTest extends MockeryTestCase
                     'entities' => [],
                 ],
                 'statusService' => [
-                    'entityStatus' => Service::ENTITY_PUBLISHED_NO,
+                    'entityStatusTest' => Service::ENTITY_PUBLISHED_NO,
                     'privacyQuestions' => false,
                 ],
                 'result' => '{
@@ -395,7 +395,7 @@ class ServiceStatusAssemblerTest extends MockeryTestCase
                     'entities' => [],
                 ],
                 'statusService' => [
-                    'entityStatus' => Service::ENTITY_PUBLISHED_NO,
+                    'entityStatusTest' => Service::ENTITY_PUBLISHED_NO,
                     'privacyQuestions' => false,
                 ],
                 'result' => '
@@ -454,7 +454,7 @@ class ServiceStatusAssemblerTest extends MockeryTestCase
                     'entities' => [],
                 ],
                 'statusService' => [
-                    'entityStatus' => Service::ENTITY_PUBLISHED_IN_PROGRESS,
+                    'entityStatusTest' => Service::ENTITY_PUBLISHED_IN_PROGRESS,
                     'privacyQuestions' => false,
                 ],
                 'result' => '{
@@ -501,8 +501,8 @@ class ServiceStatusAssemblerTest extends MockeryTestCase
 
     private function createStatusServiceMock($data)
     {
-        $this->serviceStatusService->shouldReceive('getEntityStatus')
-            ->andReturn($data['entityStatus']);
+        $this->serviceStatusService->shouldReceive('getEntityStatusOnTest')
+            ->andReturn($data['entityStatusTest']);
 
         $this->serviceStatusService->shouldReceive('hasPrivacyQuestions')
             ->andReturn($data['privacyQuestions']);

--- a/tests/unit/Application/Service/ServiceStatusServiceTest.php
+++ b/tests/unit/Application/Service/ServiceStatusServiceTest.php
@@ -66,44 +66,79 @@ class ServiceStatusServiceTest extends MockeryTestCase
             ->with($service)
             ->andReturn($entities);
 
-        $actualStatus = $this->service->getEntityStatus($service);
+        $actualStatus = $this->service->getEntityStatusOnTest($service);
         $this->assertEquals($expectedStatus, $actualStatus, $dataProviderContext);
     }
 
     public function createEntityStatus()
     {
         return [
+            // TEST entities
             [
                 $this->buildEntities([]),
                 Service::ENTITY_PUBLISHED_NO,
                 'No entities are available for this service, so none are published.',
             ],
             [
-                $this->buildEntities([0 => Entity::STATE_DRAFT]),
+                $this->buildEntities([
+                    0 => [Entity::STATE_DRAFT, Entity::ENVIRONMENT_TEST],
+                ]),
                 Service::ENTITY_PUBLISHED_IN_PROGRESS,
                 'One drafted entity should result in "in progress"',
             ],
             [
-                $this->buildEntities([0 => Entity::STATE_DRAFT, 1 => Entity::STATE_DRAFT, 2 => Entity::STATE_DRAFT]),
+                $this->buildEntities([
+                    0 => [Entity::STATE_DRAFT, Entity::ENVIRONMENT_TEST],
+                    1 => [Entity::STATE_DRAFT, Entity::ENVIRONMENT_TEST],
+                    2 => [Entity::STATE_DRAFT, Entity::ENVIRONMENT_TEST],
+                ]),
                 Service::ENTITY_PUBLISHED_IN_PROGRESS,
                 'Multiple drafted entity should result in "in progress"',
             ],
             [
-                $this->buildEntities([0 => Entity::STATE_PUBLISHED]),
+                $this->buildEntities([
+                    0 => [Entity::STATE_PUBLISHED, Entity::ENVIRONMENT_TEST],
+                ]),
                 Service::ENTITY_PUBLISHED_YES,
                 'One published entity should result in "yes"',
             ],
             [
-                $this->buildEntities([0 => Entity::STATE_PUBLISHED, 1 => Entity::STATE_PUBLISHED]),
+                $this->buildEntities([
+                    0 => [Entity::STATE_PUBLISHED, Entity::ENVIRONMENT_TEST],
+                    1 => [Entity::STATE_PUBLISHED, Entity::ENVIRONMENT_TEST],
+                ]),
                 Service::ENTITY_PUBLISHED_YES,
                 'Multiple published entity should result in "yes"',
             ],
             [
-                $this->buildEntities(
-                    [0 => Entity::STATE_DRAFT, 1 => Entity::STATE_PUBLISHED, 2 => Entity::STATE_DRAFT]
-                ),
+                $this->buildEntities([
+                    0 => [Entity::STATE_DRAFT, Entity::ENVIRONMENT_TEST],
+                    1 => [Entity::STATE_PUBLISHED, Entity::ENVIRONMENT_TEST],
+                    2 => [Entity::STATE_DRAFT, Entity::ENVIRONMENT_TEST],
+                ]),
                 Service::ENTITY_PUBLISHED_YES,
                 'Multiple mixed value published entity should result in "yes"',
+            ],
+
+            // PRODUCTION entities
+            [
+                $this->buildEntities([]),
+                Service::ENTITY_PUBLISHED_NO,
+                'No entities are available for this service, so none are published.',
+            ],
+            [
+                $this->buildEntities([
+                    0 => [Entity::STATE_DRAFT, Entity::ENVIRONMENT_PRODUCTION],
+                ]),
+                Service::ENTITY_PUBLISHED_NO,
+                'No entities are available for this service, so none are published.',
+            ],
+            [
+                $this->buildEntities([
+                    0 => [Entity::STATE_PUBLISHED, Entity::ENVIRONMENT_PRODUCTION],
+                ]),
+                Service::ENTITY_PUBLISHED_NO,
+                'No entities are available for this service, so none are published.',
             ],
         ];
     }
@@ -111,11 +146,14 @@ class ServiceStatusServiceTest extends MockeryTestCase
     private function buildEntities(array $entities)
     {
         $entityList = [];
-        foreach ($entities as $key => $status) {
+        foreach ($entities as $key => $values) {
             $mockEntity = m::mock(EntityDto::class);
             $mockEntity
                 ->shouldReceive('getState')
-                ->andReturn($status);
+                ->andReturn($values[0]);
+            $mockEntity
+                ->shouldReceive('getEnvironment')
+                ->andReturn($values[1]);
 
             $entityList[] = $mockEntity;
         }


### PR DESCRIPTION
If a service has no entities the donut should reflect that. So it
must not look if any progess so far has been made.