### PR TITLE
Add translatable footer links

### DIFF
--- a/app/Resources/translations/messages.en.yml
+++ b/app/Resources/translations/messages.en.yml
@@ -1,5 +1,7 @@
 page.footer.contact_link: "#!contact"
 page.footer.privacy_link: "#!privacy"
+page.footer.privacy: Privacy
+page.footer.contact: Contact
 page.header.help: Help
 page.header.help_link: https://wiki.surfnet.nl/
 page.header.logout: Logout

--- a/app/Resources/translations/messages.en.yml
+++ b/app/Resources/translations/messages.en.yml
@@ -1,3 +1,5 @@
+page.footer.contact_link: "#!contact"
+page.footer.privacy_link: "#!privacy"
 page.header.help: Help
 page.header.help_link: https://wiki.surfnet.nl/
 page.header.logout: Logout

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -51,8 +51,8 @@
         </div>
         <div class="footer">
             <div class="footer-inner">
-                <span><a href="{{ 'page.footer.privacy_link'|trans }}" target="_blank">{{ 'page.header.privacy'|trans }}</a></span>
-                <span><a href="{{ 'page.footer.contact_link'|trans }}" target="_blank">{{ 'page.header.contact'|trans }}</a></span>
+                <span><a href="{{ 'page.footer.privacy_link'|trans }}" target="_blank">{{ 'page.footer.privacy'|trans }}</a></span>
+                <span><a href="{{ 'page.footer.contact_link'|trans }}" target="_blank">{{ 'page.footer.contact'|trans }}</a></span>
             </div>
         </div>
         {% block javascripts %}

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -51,8 +51,8 @@
         </div>
         <div class="footer">
             <div class="footer-inner">
-                <span><a href="/" target="_blank">{{ 'page.header.privacy'|trans }}</a></span>
-                <span><a href="/" target="_blank">{{ 'page.header.contact'|trans }}</a></span>
+                <span><a href="{{ 'page.footer.privacy_link'|trans }}" target="_blank">{{ 'page.header.privacy'|trans }}</a></span>
+                <span><a href="{{ 'page.footer.contact_link'|trans }}" target="_blank">{{ 'page.header.contact'|trans }}</a></span>
             </div>
         </div>
         {% block javascripts %}


### PR DESCRIPTION
The `contact` and `privacy` links were set to a hard '/'. This is addressed by setting adding them to the translations. Allowing overriding these URL's from the web translation interface. Some dummy defaults are set in the messages.en.yml.

See: https://www.pivotaltracker.com/story/show/165965469