### PR TITLE
Cascade delete privacy questions on service removal

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
@@ -147,7 +147,7 @@ class Service
     /**
      * @var PrivacyQuestions
      *
-     * @ORM\OneToOne(targetEntity="PrivacyQuestions", mappedBy="service")
+     * @ORM\OneToOne(targetEntity="PrivacyQuestions", mappedBy="service", cascade={"remove"}, orphanRemoval=true)
      */
     private $privacyQuestions;
 

--- a/tests/webtests/ServiceDeleteTest.php
+++ b/tests/webtests/ServiceDeleteTest.php
@@ -98,7 +98,7 @@ class ServiceDeleteTest extends WebTestCase
         $this->assertEquals(
             '/',
             $this->client->getRequest()->getRequestUri(),
-            "Expected to be on the service overview page after succesfully removing the service"
+            "Expected to be on the service overview page after successfully removing the service"
         );
 
         // TODO: Find a more robust way to test if the enity was removed.
@@ -110,4 +110,82 @@ class ServiceDeleteTest extends WebTestCase
             "The SURFnet Service has been removed and should no longer be on the service overview page"
         );
     }
+
+    /**
+     * Removing a service with privacy questions should not result in integrity constraint violation errors
+     *
+     * See Pivotal Tracker; https://www.pivotaltracker.com/story/show/165237921
+     */
+    public function test_removing_a_service_with_privacy_questions_is_possible()
+    {
+        $this->logIn('ROLE_ADMINISTRATOR');
+
+        // EntityService::getEntityListForService -> findByTeamName (service/edit first request)
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->prodMockHandler->append(new Response(200, [], '[]'));
+
+        // EntityService::getEntityListForService -> findByTeamName (service/edit after delete button click)
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->prodMockHandler->append(new Response(200, [], '[]'));
+
+        // The entities are listed on the delete confirmation page (page is visited twice)
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->prodMockHandler->append(new Response(200, [], '[]'));
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->prodMockHandler->append(new Response(200, [], '[]'));
+
+        // EntityService::getEntityListForService -> getEntityListForService
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->prodMockHandler->append(new Response(200, [], '[]'));
+
+        $crawler = $this->client->request('GET', '/service/2/edit');
+
+        $form = $crawler
+            ->selectButton('Delete')
+            ->form();
+
+        $this->client->submit($form);
+
+        $this->assertTrue(
+            $this->client->getResponse() instanceof RedirectResponse,
+            'Expecting a redirect response after deleting a service'
+        );
+
+        $crawler = $this->client->followRedirect();
+
+        $this->assertEquals(
+            '/service/2/delete',
+            $this->client->getRequest()->getRequestUri(),
+            "Expected to be on the service delete confirmation page"
+        );
+
+        $form = $crawler
+            ->selectButton('Delete')
+            ->form();
+
+        $this->client->submit($form);
+
+        $this->assertTrue(
+            $this->client->getResponse() instanceof RedirectResponse,
+            'Expecting a redirect response after pressing the delete button on the confirmation page'
+        );
+
+        $crawler = $this->client->followRedirect();
+
+        $this->assertEquals(
+            '/',
+            $this->client->getRequest()->getRequestUri(),
+            "Expected to be on the service overview page after successfully removing the service"
+        );
+
+        // TODO: Find a more robust way to test if the enity was removed.
+        $services = $crawler->filterXPath('//div[@class="service-status-title"]/a/text()')->extract(['_text']);
+
+        $this->assertNotContains(
+            'Ibuildings B.V.',
+            $services,
+            "The Ibuildings B.V. Service has been removed and should no longer be on the service overview page"
+        );
+    }
+
 }

--- a/tests/webtests/ServiceDeleteTest.php
+++ b/tests/webtests/ServiceDeleteTest.php
@@ -187,5 +187,4 @@ class ServiceDeleteTest extends WebTestCase
             "The Ibuildings B.V. Service has been removed and should no longer be on the service overview page"
         );
     }
-
 }


### PR DESCRIPTION
The relationship between service and privacy question is now configured to apply a cascading delete on privacy question entities when a service is removed. In addition, Doctrine is instructed to remove orphaned entities.

**Bugreport:** https://www.pivotaltracker.com/story/show/165237921
**See:** https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/working-with-associations.html#transitive-persistence-cascade-operations
**See:** https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/working-with-associations.html#orphan-removal