### PR TITLE
Show motivationless attributes on entity detail

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -63,6 +63,7 @@ entity:
         html: <strong>information about the contact information fields</strong>
     attribute:
       motivation: Motivation
+      no_motivation_set: No motivation set
       saml20:
         title: Attributes
         html: <strong>information about the attribute fields</strong>

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detailAttributeField.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detailAttributeField.html.twig
@@ -1,12 +1,17 @@
-{% if value is not empty and value.requested %}
-<h3>{{ label }}</h3>
+{% if value and value.requested %}
+<h3 class="attribute-title">{{ label }}</h3>
 <div class="detail attribute">
     {% if informationPopup is defined %}
         <span title="{{ informationPopup|trans }}" class="help-button">
             <i class="fa fa-question-circle"></i>
         </span>
     {% endif %}
+
+    {% if value is not empty %}
     <label>{{ 'entity.detail.attribute.motivation'|trans }}</label>
     <span>{{ value }}</span>
+    {% else %}
+    <span>{{ 'entity.detail.attribute.no_motivation_set'|trans }}</span>
+    {% endif %}
 </div>
 {% endif %}


### PR DESCRIPTION
Attributes without motivation (possible for drafts and test entities)
did not show up on the entity detail screen. They are now displayed.
When no motivation is set, a translatable 'no motivation set' message
is rendered.

See: https://www.pivotaltracker.com/story/show/165597382