### PR TITLE
Show OIDC items on entity details

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityDetail.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityDetail.php
@@ -231,6 +231,21 @@ class EntityDetail
      */
     private $actions;
 
+    /**
+     * @var string[]
+     */
+    private $redirectUris;
+
+    /**
+     * @var string
+     */
+    private $grantType;
+
+    /**
+     * @var bool
+     */
+    private $playgroundEnabled;
+
     private function __construct()
     {
     }
@@ -246,6 +261,11 @@ class EntityDetail
         $entityDetail->id = $entity->getId();
         $entityDetail->manageId = $entity->getManageId();
         $entityDetail->protocol = $entity->getProtocol();
+        if ($entity->getProtocol() == DomainEntity::TYPE_OPENID_CONNECT) {
+            $entityDetail->grantType = $entity->getGrantType()->getGrantType();
+            $entityDetail->redirectUris = $entity->getRedirectUris();
+            $entityDetail->playgroundEnabled = $entity->isEnablePlayground();
+        }
         $entityDetail->metadataUrl = $entity->getMetadataUrl();
         $entityDetail->acsLocation = $entity->getAcsLocation();
         $entityDetail->entityId = $entity->getEntityId();
@@ -615,5 +635,29 @@ class EntityDetail
     public function getProtocol()
     {
         return $this->protocol;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getRedirectUris()
+    {
+        return $this->redirectUris;
+    }
+
+    /**
+     * @return string
+     */
+    public function getGrantType()
+    {
+        return $this->grantType;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPlaygroundEnabled()
+    {
+        return $this->playgroundEnabled;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -29,6 +29,9 @@ entity:
       metadata_url: Metadata URL
       acs_location: ACS location
       entity_id: Entity ID
+      grant_type: Grant type
+      redirect_uris: Redirect URIs
+      playground_enabled: Playground enabled?
       name_id_format: NameID format
       certificate: Certificate
       logo_url: Logo URL

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detail.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detail.html.twig
@@ -20,6 +20,11 @@
         {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.metadata_url'|trans, value: entity.metadataUrl, informationPopup: 'entity.edit.information.metadataUrl'} %}
         {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.acs_location'|trans, value: entity.acsLocation, informationPopup: 'entity.edit.information.acsLocation'} %}
         {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.entity_id'|trans, value: entity.entityId, informationPopup: 'entity.edit.information.entityId'} %}
+        {% if entity.protocol == "oidc" %}
+            {% include '@Dashboard/EntityDetail/detailListField.html.twig' with {label: 'entity.detail.metadata.redirect_uris'|trans, value: entity.redirectUris, informationPopup: 'entity.edit.information.redirectUris'} %}
+            {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.grant_type'|trans, value: ('entity.edit.label.' ~ entity.grantType)|trans, informationPopup: 'entity.edit.information.grantType'} %}
+            {% include '@Dashboard/EntityDetail/detailBooleanField.html.twig' with {label: 'entity.detail.metadata.playground_enabled'|trans, value: entity.playgroundEnabled, informationPopup: 'entity.edit.information.playgroundEnabled'} %}
+        {% endif %}
         {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.name_id_format'|trans, value: entity.nameIdFormat, informationPopup: 'entity.edit.information.nameIdFormat'} %}
         {% include '@Dashboard/EntityDetail/detailFormattedField.html.twig' with {label: 'entity.detail.metadata.certificate'|trans, value: entity.certificate, informationPopup: 'entity.edit.information.certificate'} %}
         {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.logo_url'|trans, value: entity.logoUrl, informationPopup: 'entity.edit.information.logoUrl'} %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detailBooleanField.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detailBooleanField.html.twig
@@ -1,0 +1,15 @@
+{% if value is not empty %}
+<div class="detail">
+    {% if informationPopup is defined %}
+        <span title="{{ informationPopup|trans }}" class="help-button">
+            <i class="fa fa-question-circle"></i>
+        </span>
+    {% endif %}
+    <label>{{ label }}</label>
+    {% if value %}
+        <i class="fa fa-check-square"></i>
+    {% else %}
+        <i class="fa fa-square"></i>
+    {% endif %}
+</div>
+{% endif %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detailListField.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detailListField.html.twig
@@ -1,0 +1,15 @@
+{% if value is not empty %}
+<div class="detail">
+    {% if informationPopup is defined %}
+        <span title="{{ informationPopup|trans }}" class="help-button">
+            <i class="fa fa-question-circle"></i>
+        </span>
+    {% endif %}
+    <label>{{ label }}</label>
+    <ul>
+    {% for listItem in value %}
+        <li>{{ listItem }}</li>
+    {% endfor %}
+    </ul>
+</div>
+{% endif %}


### PR DESCRIPTION
If the entity protocol is oidc, the oidc attributes are shown on the entity detail screen. This entails:

 1. A list of the redirect uris (new: list field)
 2. The grant type (text field)
 3. Playground enabled (new: boolean field)

The field labels are being made into translatable messages. They are key -> translation:

 - entity.detail.metadata.redirect_uris: Redirect URIs
 - entity.detail.metadata.grant_type: Grant type
 - entity.detail.metadata.playground_enabled: Playground enabled?

See: https://www.pivotaltracker.com/story/show/164598856