### PR TITLE
Rename 'team name' to 'team identifier'

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Service/ServiceType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Service/ServiceType.php
@@ -46,7 +46,7 @@ class ServiceType extends AbstractType
                     ]
                 )
                     ->add('name')
-                    ->add('teamName')
+                    ->add('teamName', null, ['label' => 'team identifier'])
                     ->add(
                         'productionEntitiesEnabled',
                         CheckboxType::class,


### PR DESCRIPTION
The name of the field on the srevie form needs to be changed to be
describe more logically what the purpose of the field is.