### PR TITLE
Add translatable contact email placeholder

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/ContactType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/ContactType.php
@@ -52,6 +52,7 @@ class ContactType extends AbstractType
                 'required' => false,
                 'attr' => [
                     'data-parsley-trigger' => 'blur',
+                    'placeholder' => 'entity.edit.contact_information.' . $builder->getName().'.email.placeholder',
                 ],
             ]
         );

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -222,6 +222,9 @@ entity.edit.contact_information.html: "
 
 <p><i>Technical and administrative contact details will not be communicated to end-users.</i></p>
 "
+entity.edit.contact_information.administrativeContact.email.placeholder: "Email address of administrative contact"
+entity.edit.contact_information.technicalContact.email.placeholder: "Email address of technical contact"
+entity.edit.contact_information.supportContact.email.placeholder: "Emailsaddress of support contact"
 entity.edit.attribute_input_placeholder: The service will use this attribute to...
 entity.edit.attributes.saml20.title: Attributes
 entity.edit.attributes.saml20.html: "


### PR DESCRIPTION
The placeholders of the contact email address fields should be
translatable. So a placeholder is added and a translation is added.