### PR TITLE
Test PHP 7.3 with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: php
 
 php:
   - 5.6
-  - 7.0
-  - 7.1
+  - 7.3
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,14 @@ language: php
 
 php:
   - 5.6
+  - 7.2
   - 7.3
+
+
+matrix:
+  allow_failures:
+    - php: 7.2
+    - php: 7.3
 
 cache:
   directories:


### PR DESCRIPTION
This is done in order to be able to test behavior on php 7.3 to
explore possible php migration issues.