### PR TITLE
Fix idp validation from manage result

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/UpdateEntityAclCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/UpdateEntityAclCommand.php
@@ -34,7 +34,7 @@ class UpdateEntityAclCommand implements Command
      * @var IdentityProvider[]
      * @Assert\All({
      *     @Assert\NotBlank(),
-     *     @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\IdentityProvider")
+     *     @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\Entity\IdentityProvider")
      * })
      */
     private $selected;

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/IdentityProvider.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/IdentityProvider.php
@@ -49,13 +49,13 @@ class IdentityProvider
     {
         Assert::stringNotEmpty($manageId);
         Assert::stringNotEmpty($entityId);
-        Assert::string($nameNl);
-        Assert::string($nameEn);
+        Assert::nullOrString($nameNl);
+        Assert::stringNotEmpty($nameEn);
 
         $this->manageId = $manageId;
         $this->entityId = $entityId;
-        $this->nameNl = $nameNl;
-        $this->nameEn = $nameEn;
+        $this->nameNl = (string) $nameNl;
+        $this->nameEn = (string) $nameEn;
     }
 
     /**
@@ -95,6 +95,6 @@ class IdentityProvider
      */
     public function getName()
     {
-        return (empty($this->nameEn) ? $this->nameNl: $this->nameEn);
+        return (empty($this->nameNl) ? $this->nameEn : $this->nameNl);
     }
 }

--- a/tests/unit/Infrastructure/Manage/Client/IdentityProviderClientTest.php
+++ b/tests/unit/Infrastructure/Manage/Client/IdentityProviderClientTest.php
@@ -58,14 +58,14 @@ class IdentityProviderClientTest extends MockeryTestCase
                 new Response(200, [], file_get_contents(__DIR__ . '/fixture/identity_provider_response.json'))
             );
         $idps = $this->client->findAll();
-        $this->assertCount(3, $idps);
+        $this->assertCount(4, $idps);
 
         $this->assertInstanceOf(IdentityProvider::class, $idps[0]);
         $this->assertSame('http://mock-idp', $idps[0]->getEntityId());
         $this->assertSame('bfe8f00d-317a-4fbc-9cf8-ad2f3b2af578', $idps[0]->getManageId());
         $this->assertSame('OpenConext Mujina IDP EN', $idps[0]->getNameEn());
         $this->assertSame('OpenConext Mujina IDP NL', $idps[0]->getNameNl());
-        $this->assertSame('OpenConext Mujina IDP EN', $idps[0]->getName());
+        $this->assertSame('OpenConext Mujina IDP NL', $idps[0]->getName());
 
         $this->assertInstanceOf(IdentityProvider::class, $idps[1]);
         $this->assertSame('https://engine.dev.support.surfconext.nl/authentication/idp/metadata', $idps[1]->getEntityId());
@@ -77,8 +77,15 @@ class IdentityProviderClientTest extends MockeryTestCase
         $this->assertInstanceOf(IdentityProvider::class, $idps[2]);
         $this->assertSame('https://engine.dev.support.surfconext.nl/authentication/idp/metadata2', $idps[2]->getEntityId());
         $this->assertSame('0c3febd2-3f67-4b8a-b90d-ce56a3b0abb5', $idps[2]->getManageId());
-        $this->assertSame('', $idps[2]->getNameEn());
+        $this->assertSame(' ', $idps[2]->getNameEn());
         $this->assertSame('OpenConext Engine 2 NL', $idps[2]->getNameNl());
         $this->assertSame('OpenConext Engine 2 NL', $idps[2]->getName());
+
+        $this->assertInstanceOf(IdentityProvider::class, $idps[3]);
+        $this->assertSame('https://engine.dev.support.surfconext.nl/authentication/idp/metadata2', $idps[3]->getEntityId());
+        $this->assertSame('0c3febd2-3f67-4b8a-b90d-ce56a3b0abb6', $idps[3]->getManageId());
+        $this->assertSame('OpenConext Engine 3 EN', $idps[3]->getNameEn());
+        $this->assertSame('', $idps[3]->getNameNl());
+        $this->assertSame('OpenConext Engine 3 EN', $idps[3]->getName());
     }
 }

--- a/tests/unit/Infrastructure/Manage/Client/fixture/identity_provider_response.json
+++ b/tests/unit/Infrastructure/Manage/Client/fixture/identity_provider_response.json
@@ -22,7 +22,6 @@
       "metaDataFields": {
         "name:en": "OpenConext Engine EN",
         "name:nl": ""
-
       }
     }
   },
@@ -34,8 +33,21 @@
       "state": "prodaccepted",
       "notes": null,
       "metaDataFields": {
-        "name:en": "",
+        "name:en": " ",
         "name:nl": "OpenConext Engine 2 NL"
+      }
+    }
+  },
+  {
+    "_id": "0c3febd2-3f67-4b8a-b90d-ce56a3b0abb6",
+    "version": 0,
+    "data": {
+      "entityid": "https://engine.dev.support.surfconext.nl/authentication/idp/metadata2",
+      "state": "prodaccepted",
+      "notes": null,
+      "metaDataFields": {
+        "name:en": "OpenConext Engine 3 EN",
+        "name:nl": null
       }
     }
   }


### PR DESCRIPTION
When testing on the test server it occurred that the `name:en` is
mandatory and `name:nl` optional. This will fix this so it would be
possible to edit acl's if idp's don't have a `name:nl` set.

https://www.pivotaltracker.com/story/show/165965483