### PR TITLE
Do not save a local duplicate upon client reset

### DIFF
--- a/app/scss/components/modal.scss
+++ b/app/scss/components/modal.scss
@@ -37,6 +37,9 @@
   }
   .button-row {
     height: 3em;
+    .button {
+      margin-right: 0.5em;
+    }
   }
 }
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/ResetOidcSecretCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/ResetOidcSecretCommandHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2018 SURFnet B.V.
+ * Copyright 2019 SURFnet B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ class ResetOidcSecretCommandHandler implements CommandHandler
         $secret = new Secret(Entity::OIDC_SECRET_LENGTH);
 
         $entity->setClientSecret($secret->getSecret());
-
+        $entity->setManageId($command->getManageId());
         $this->repository->save($entity);
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detail.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detail.html.twig
@@ -69,7 +69,7 @@
 
     </div>
 
-    <div class="modal" id="reset-secret-confirmation">
+    <div class="modal oidc-confirmation" id="reset-secret-confirmation">
         {% include "@Dashboard/EntityModal/secretResetModal.html.twig" %}
     </div>
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityList/list.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityList/list.html.twig
@@ -169,7 +169,7 @@
         </div>
     {% endif %}
 
-    <div class="modal" id="reset-secret-confirmation">
+    <div class="modal oidc-confirmation" id="reset-secret-confirmation">
         {% include "@Dashboard/EntityModal/secretResetModal.html.twig" %}
     </div>
 

--- a/tests/integration/Application/CommandHandler/Entity/ResetOidcSecretCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/ResetOidcSecretCommandHandlerTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Integration\Application\CommandHandler\Entity;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery\Mock;
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\ResetOidcSecretCommand;
+use Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\ResetOidcSecretCommandHandler;
+use Surfnet\ServiceProviderDashboard\Application\Exception\EntityNotFoundException;
+use Surfnet\ServiceProviderDashboard\Application\Service\LoadEntityService;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityRepository;
+
+class ResetOidcSecretCommandHandlerTest extends MockeryTestCase
+{
+    /**
+     * @var EntityRepository|Mock
+     */
+    private $repository;
+    /**
+     * @var LoadEntityService|Mock
+     */
+    private $loadEntityService;
+
+    /**
+     * @var ResetOidcSecretCommandHandler
+     */
+    private $commandHandler;
+
+    public function setUp()
+    {
+        $this->repository = m::mock(EntityRepository::class);
+        $this->loadEntityService = m::mock(LoadEntityService::class);
+
+        $this->commandHandler = new ResetOidcSecretCommandHandler(
+            $this->repository,
+            $this->loadEntityService
+        );
+    }
+
+    public function test_handle_happy_flow()
+    {
+        $status = Entity::STATE_PUBLISHED;
+        $command = $this->buildCommand(1, 'my-manage-id', Entity::ENVIRONMENT_TEST);
+
+        $entity = $this->expectedEntityFrom($command, $status);
+
+        $this->repository
+            ->shouldReceive('save')
+            ->with($entity);
+
+        $this->commandHandler->handle($command);
+
+        $this->assertEquals('my-manage-id', $entity->getManageId());
+    }
+
+    public function test_handle_entity_not_found()
+    {
+        $command = $this->buildCommand(1, 'my-manage-id', Entity::ENVIRONMENT_TEST);
+
+        $this->loadEntityService
+            ->shouldReceive('load')
+            ->with(
+                $command->getId(),
+                $command->getManageId(),
+                $command->getService(),
+                $command->getEnvironment(),
+                $command->getEnvironment()
+            )
+            ->andReturn(null);
+
+        $this->expectException(EntityNotFoundException::class);
+        $this->expectExceptionMessage('The requested entity could not be found');
+
+        $this->commandHandler->handle($command);
+    }
+
+    public function test_handle_entity_invalid_protocol()
+    {
+        $status = Entity::STATE_PUBLISHED;
+        $command = $this->buildCommand(1, 'my-manage-id', Entity::ENVIRONMENT_TEST);
+
+        $entity = $this->expectedEntityFrom($command, $status);
+        $entity->setProtocol('oauth');
+
+        $this->expectException(EntityNotFoundException::class);
+        $this->expectExceptionMessage('The requested entity could be found, invalid protocol');
+
+        $this->commandHandler->handle($command);
+    }
+
+    public function test_handle_entity_invalid_publication_status()
+    {
+        $status = Entity::STATE_PUBLISHED;
+        $command = $this->buildCommand(1, 'my-manage-id', Entity::ENVIRONMENT_TEST);
+
+        $entity = $this->expectedEntityFrom($command, $status);
+        $entity->setStatus(Entity::STATE_DRAFT);
+
+        $this->expectException(EntityNotFoundException::class);
+        $this->expectExceptionMessage('The requested entity could be found, invalid state');
+
+        $this->commandHandler->handle($command);
+    }
+
+    /**
+     * @return ResetOidcSecretCommand
+     */
+    private function buildCommand($id, $manageId, $environment)
+    {
+        return new ResetOidcSecretCommand($id, $manageId, $environment, m::mock(Service::class));
+    }
+
+    /**
+     * @param ResetOidcSecretCommand $command
+     * @param string $status
+     * @return Entity
+     */
+    private function expectedEntityFrom(ResetOidcSecretCommand $command, $status)
+    {
+        $entity = new Entity();
+        $entity->setId($command->getId());
+        $entity->setService($command->getService());
+        $entity->setStatus($status);
+        $entity->setEnvironment($entity);
+        $entity->setProtocol(Entity::TYPE_OPENID_CONNECT);
+
+
+        $this->loadEntityService
+            ->shouldReceive('load')
+            ->with(
+                $command->getId(),
+                $command->getManageId(),
+                $command->getService(),
+                $command->getEnvironment(),
+                $command->getEnvironment()
+            )
+            ->andReturn($entity);
+
+        return $entity;
+    }
+}


### PR DESCRIPTION
Whenever a published OIDC entity was using the client reset function, a duplicate local entity was saved to the database. This entity could not be removed from the application, as it will attempt to removed from Manage (as the production state is published). To fix this, the manage id had to be set on the local copy that is only temporarily used to carry the new client id secret.

In addition to this bugfix, a visual regression was fixed as well in 40570fc.

See: https://www.pivotaltracker.com/story/show/165673435