### PR TITLE
Consider IdP workflow state when retrieving IdP's for ACL action

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -132,17 +132,13 @@ dashboard:
                 host: "%manage_test_host%"
                 username: "%manage_test_username%"
                 password: "%manage_test_password%"
-            publication_status:
-                create: "%manage_test_publication_status_create%"
-                update: "%manage_test_publication_status_update%"
+            publication_status: "%manage_test_publication_status%"
         production:
             connection:
                 host: "%manage_prod_host%"
                 username: "%manage_prod_username%"
                 password: "%manage_prod_password%"
-            publication_status:
-                create: "%manage_prod_publication_status_create%"
-                update: "%manage_prod_publication_status_update%"
+            publication_status: "%manage_prod_publication_status%"
 
 dashboard_saml:
     session_lifetimes:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -45,15 +45,13 @@ parameters:
     manage_test_host: 'https://manage.dev.support.surfconext.nl'
     manage_test_username: sp-dashboard
     manage_test_password: secret
-    manage_test_publication_status_create: testaccepted
-    manage_test_publication_status_update: testaccepted
+    manage_test_publication_status: testaccepted
 
     ## Manage production instance
     manage_prod_host: 'https://manage-prod.dev.support.surfconext.nl'
     manage_prod_username: sp-dashboard
     manage_prod_password: secret
-    manage_prod_publication_status_create: prodaccepted
-    manage_prod_publication_status_update: prodaccepted
+    manage_prod_publication_status: prodaccepted
 
     # Mail default settings
     mail_from: support@surfconext.nl

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
@@ -161,7 +161,7 @@ class EntityService implements EntityServiceInterface
 
         $testEntities = $this->findPublishedTestEntitiesByTeamName(
             $service->getTeamName(),
-            $this->testManageConfig->getPublicationStatus()->getCreateStatus()
+            $this->testManageConfig->getPublicationStatus()->getStatus()
         );
         foreach ($testEntities as $result) {
             $entities[] = ViewObject\Entity::fromManageTestResult($result, $this->router, $service->getId());
@@ -169,7 +169,7 @@ class EntityService implements EntityServiceInterface
 
         $productionEntities = $this->findPublishedProductionEntitiesByTeamName(
             $service->getTeamName(),
-            $this->prodManageConfig->getPublicationStatus()->getCreateStatus()
+            $this->prodManageConfig->getPublicationStatus()->getStatus()
         );
         foreach ($productionEntities as $result) {
             $entities[] = ViewObject\Entity::fromManageProductionResult($result, $this->router, $service->getId());
@@ -236,7 +236,7 @@ class EntityService implements EntityServiceInterface
     {
         return $this->queryRepositoryProvider
             ->getManageTestQueryClient()
-            ->findByTeamName($teamName, $this->testManageConfig->getPublicationStatus()->getCreateStatus());
+            ->findByTeamName($teamName, $this->testManageConfig->getPublicationStatus()->getStatus());
     }
 
     /**
@@ -253,7 +253,7 @@ class EntityService implements EntityServiceInterface
     {
         $entities = $this->queryRepositoryProvider
             ->getManageProductionQueryClient()
-            ->findByTeamName($teamName, $this->prodManageConfig->getPublicationStatus()->getCreateStatus());
+            ->findByTeamName($teamName, $this->prodManageConfig->getPublicationStatus()->getStatus());
 
         // Try to find the tickets in Jira that match the manageIds. If Jira is down or otherwise unavailable, the
         // entities are returned without updating their status. This might result in a 're request for delete'

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Manage/ConfigFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Manage/ConfigFactory.php
@@ -34,8 +34,7 @@ class ConfigFactory
         );
 
         $publicationStatus = new PublicationStatus(
-            $config['publication_status']['create'],
-            $config['publication_status']['update']
+            $config['publication_status']
         );
 
         return new Config($environment, $connection, $publicationStatus);

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Manage/PublicationStatus.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Manage/PublicationStatus.php
@@ -25,33 +25,20 @@ class PublicationStatus
     /**
      * @var string
      */
-    private $createStatus;
+    private $status;
 
     /**
-     * @var string
+     * @param string $status
      */
-    private $updateStatus;
-
-    /**
-     * @param string $updateStatus
-     * @param string $createStatus
-     */
-    public function __construct($createStatus = '', $updateStatus = '')
+    public function __construct($status = '')
     {
-        Assert::stringNotEmpty($createStatus, 'Please set the create publication status in parameters.yml');
-        Assert::stringNotEmpty($updateStatus, 'Please set the update publication status in parameters.yml');
+        Assert::stringNotEmpty($status, 'Please set the publication status in parameters.yml');
 
-        $this->createStatus = $createStatus;
-        $this->updateStatus = $updateStatus;
+        $this->status = $status;
     }
 
-    public function getCreateStatus()
+    public function __toString()
     {
-        return $this->createStatus;
-    }
-
-    public function getUpdateStatus()
-    {
-        return $this->updateStatus;
+        return $this->status;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Manage/PublicationStatus.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Manage/PublicationStatus.php
@@ -37,7 +37,7 @@ class PublicationStatus
         $this->status = $status;
     }
 
-    public function __toString()
+    public function getStatus()
     {
         return $this->status;
     }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DependencyInjection/Configuration.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DependencyInjection/Configuration.php
@@ -56,12 +56,7 @@ class Configuration implements ConfigurationInterface
                                 ->scalarNode('password')->end()
                             ->end()
                         ->end()
-                        ->arrayNode('publication_status')
-                            ->children()
-                                ->scalarNode('create')->end()
-                                ->scalarNode('update')->end()
-                            ->end()
-                        ->end()
+                        ->scalarNode('publication_status')->end()
                     ->end()
                 ->end()
             ->end();

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -347,6 +347,7 @@ services:
         class: Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\IdentityProviderClient
         arguments:
             - '@Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Http\HttpClient'
+            - '@surfnet.manage.configuration.test'
 
     surfnet.manage.client.delete_client.prod_environment:
         class: Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\DeleteEntityClient

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/IdentityProviderClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/IdentityProviderClient.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client;
 
+use Surfnet\ServiceProviderDashboard\Application\ViewObject\Manage\Config;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\IdentityProvider;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\IdentityProviderRepository;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\QueryIdentityProviderException;
@@ -26,8 +27,8 @@ use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Http\Exception\HttpEx
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Http\HttpClient;
 
 /**
- * The IdentityProviderClient can be used to perform queries on the manage /manage/api/internal/search/saml20_idp endpoint.
- * Queries will return the domain objects.
+ * The IdentityProviderClient can be used to perform queries on the Manage
+ * /manage/api/internal/search/saml20_idp endpoint. Queries will return the domain objects.
  */
 class IdentityProviderClient implements IdentityProviderRepository
 {
@@ -37,11 +38,17 @@ class IdentityProviderClient implements IdentityProviderRepository
     private $client;
 
     /**
+     * @var Config
+     */
+    private $manageConfig;
+
+    /**
      * @param HttpClient $client
      */
-    public function __construct(HttpClient $client)
+    public function __construct(HttpClient $client, Config $manageConfig)
     {
         $this->client = $client;
+        $this->manageConfig = $manageConfig;
     }
 
     /**
@@ -53,7 +60,7 @@ class IdentityProviderClient implements IdentityProviderRepository
     {
         try {
             $result = $this->doSearchQuery([
-                "state" => "prodaccepted",
+                "state" => (string) $this->manageConfig->getPublicationStatus(),
             ]);
 
             $list = [];

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/IdentityProviderClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/IdentityProviderClient.php
@@ -42,9 +42,6 @@ class IdentityProviderClient implements IdentityProviderRepository
      */
     private $manageConfig;
 
-    /**
-     * @param HttpClient $client
-     */
     public function __construct(HttpClient $client, Config $manageConfig)
     {
         $this->client = $client;
@@ -59,8 +56,9 @@ class IdentityProviderClient implements IdentityProviderRepository
     public function findAll()
     {
         try {
+            // Based on the manage config set (prod or test) we retrieve the correct results from the manage idp client.
             $result = $this->doSearchQuery([
-                "state" => (string) $this->manageConfig->getPublicationStatus(),
+                "state" => $this->manageConfig->getPublicationStatus()->getStatus(),
             ]);
 
             $list = [];

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php
@@ -78,7 +78,7 @@ class PublishEntityClient implements PublishEntityRepositoryInterface
                 $response = $this->client->post(
                     json_encode($this->generator->generateForNewEntity(
                         $entity,
-                        $this->manageConfig->getPublicationStatus()->getCreateStatus()
+                        $this->manageConfig->getPublicationStatus()->getStatus()
                     )),
                     '/manage/api/internal/metadata'
                 );
@@ -88,7 +88,7 @@ class PublishEntityClient implements PublishEntityRepositoryInterface
                 $response = $this->client->put(
                     json_encode($this->generator->generateForExistingEntity(
                         $entity,
-                        $this->manageConfig->getPublicationStatus()->getCreateStatus()
+                        $this->manageConfig->getPublicationStatus()->getStatus()
                     )),
                     '/manage/api/internal/merge'
                 );

--- a/tests/unit/Application/Service/EntityAclServiceTest.php
+++ b/tests/unit/Application/Service/EntityAclServiceTest.php
@@ -18,23 +18,13 @@
 
 namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Application\Service;
 
-use JiraRestApi\Issue\IssueSearchResult;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Mock;
-use Psr\Log\LoggerInterface;
-use Surfnet\ServiceProviderDashboard\Application\Provider\EntityQueryRepositoryProvider;
 use Surfnet\ServiceProviderDashboard\Application\Service\EntityAclService;
-use Surfnet\ServiceProviderDashboard\Application\Service\EntityService;
-use Surfnet\ServiceProviderDashboard\Application\Service\TicketServiceInterface;
-use Surfnet\ServiceProviderDashboard\Application\ViewObject\Manage\Config;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\IdentityProvider;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
-use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityRepository;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\IdentityProviderRepository;
-use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient as ManageQueryClient;
-use Symfony\Component\Routing\RouterInterface;
 
 class EntityAclServiceTest extends MockeryTestCase
 {

--- a/tests/unit/Application/Service/EntityServiceTest.php
+++ b/tests/unit/Application/Service/EntityServiceTest.php
@@ -74,12 +74,12 @@ class EntityServiceTest extends MockeryTestCase
 
         $manageConfigTest = m::mock(Config::class);
         $manageConfigTest
-            ->shouldReceive('getPublicationStatus->getCreateStatus')
+            ->shouldReceive('getPublicationStatus->getStatus')
             ->andReturn('testaccepted');
 
         $manageConfigProd = m::mock(Config::class);
         $manageConfigProd
-            ->shouldReceive('getPublicationStatus->getCreateStatus')
+            ->shouldReceive('getPublicationStatus->getStatus')
             ->andReturn('prodaccepted');
 
         $this->router = m::mock(RouterInterface::class);

--- a/tests/unit/Infrastructure/Manage/Client/IdentityProviderClientTest.php
+++ b/tests/unit/Infrastructure/Manage/Client/IdentityProviderClientTest.php
@@ -21,8 +21,11 @@ namespace Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
+use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery\Mock;
 use Psr\Log\NullLogger;
+use Surfnet\ServiceProviderDashboard\Application\ViewObject\Manage\Config;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\IdentityProvider;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Http\HttpClient;
 
@@ -38,15 +41,22 @@ class IdentityProviderClientTest extends MockeryTestCase
      */
     private $mockHandler;
 
+    /**
+     * @var Config&Mock
+     */
+    private $config;
+
     public function setUp()
     {
+        $this->config = m::mock(Config::class);
         $this->mockHandler = new MockHandler();
         $guzzle = new Client(['handler' => $this->mockHandler]);
         $this->client = new IdentityProviderClient(
             new HttpClient(
                 $guzzle,
                 new NullLogger()
-            )
+            ),
+            $this->config
         );
     }
 
@@ -57,6 +67,11 @@ class IdentityProviderClientTest extends MockeryTestCase
             ->append(
                 new Response(200, [], file_get_contents(__DIR__ . '/fixture/identity_provider_response.json'))
             );
+
+        $this->config
+            ->shouldReceive('getPublicationStatus->getStatus')
+            ->andReturn('testaccepted');
+
         $idps = $this->client->findAll();
         $this->assertCount(4, $idps);
 

--- a/tests/unit/Infrastructure/Manage/Client/PublishEntityClientTest.php
+++ b/tests/unit/Infrastructure/Manage/Client/PublishEntityClientTest.php
@@ -97,7 +97,7 @@ class PublishEntityClientTest extends MockeryTestCase
             ->andReturn(null);
 
         $this->manageConfig
-            ->shouldReceive('getPublicationStatus->getCreateStatus')
+            ->shouldReceive('getPublicationStatus')
             ->once();
 
         $this->logger
@@ -127,7 +127,7 @@ class PublishEntityClientTest extends MockeryTestCase
             ->andReturn('25055635-8c2c-4f54-95a6-68891a554e95');
 
         $this->manageConfig
-            ->shouldReceive('getPublicationStatus->getCreateStatus')
+            ->shouldReceive('getPublicationStatus')
             ->once();
 
         $this->logger
@@ -163,7 +163,7 @@ class PublishEntityClientTest extends MockeryTestCase
             ->andReturn(null);
 
         $this->manageConfig
-            ->shouldReceive('getPublicationStatus->getCreateStatus')
+            ->shouldReceive('getPublicationStatus')
             ->once();
 
         $this->logger

--- a/tests/unit/Infrastructure/Manage/Client/PublishEntityClientTest.php
+++ b/tests/unit/Infrastructure/Manage/Client/PublishEntityClientTest.php
@@ -97,7 +97,7 @@ class PublishEntityClientTest extends MockeryTestCase
             ->andReturn(null);
 
         $this->manageConfig
-            ->shouldReceive('getPublicationStatus')
+            ->shouldReceive('getPublicationStatus->getStatus')
             ->once();
 
         $this->logger
@@ -127,7 +127,7 @@ class PublishEntityClientTest extends MockeryTestCase
             ->andReturn('25055635-8c2c-4f54-95a6-68891a554e95');
 
         $this->manageConfig
-            ->shouldReceive('getPublicationStatus')
+            ->shouldReceive('getPublicationStatus->getStatus')
             ->once();
 
         $this->logger
@@ -163,7 +163,7 @@ class PublishEntityClientTest extends MockeryTestCase
             ->andReturn(null);
 
         $this->manageConfig
-            ->shouldReceive('getPublicationStatus')
+            ->shouldReceive('getPublicationStatus->getStatus')
             ->once();
 
         $this->logger


### PR DESCRIPTION
The `prodaccepted` state was used by default when retrieving IdP entities for display on the ACL screen. Now, we use the configured workflow state to filter the IdP results on.

This PR starts off with some housekeeping. The first commit (390213b) updates the way the workflow is configured. Previously the workflow state could be set for different intentions (create/update). This is not the way we use this feature. Instead of using this approach, setting a single workflow state per environment is now implemented.

The second commit then proceeds to read the configured workflow state from the manage configuration. This configuration is injected on the IdPclient.

See: https://www.pivotaltracker.com/story/show/165965483