### PR TITLE
Import correct invalid argument and throw it

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Value/DateTime.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Value/DateTime.php
@@ -20,7 +20,7 @@ namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Va
 
 use DateInterval;
 use DateTime as CoreDateTime;
-use InvalidArgumentException;
+use Surfnet\SamlBundle\Exception\InvalidArgumentException;
 
 /**
  * @SuppressWarnings(PHPMD.TooManyPublicMethods) due to comparison methods
@@ -59,7 +59,7 @@ class DateTime
     public static function fromString($string)
     {
         if (!is_string($string)) {
-            InvalidArgumentException::invalidType('string', 'string', $string);
+            throw InvalidArgumentException::invalidType('string', 'string', $string);
         }
 
         $dateTime = CoreDateTime::createFromFormat(self::FORMAT, $string);


### PR DESCRIPTION
During a migration an incorrect invalidArgument was imported, resulting
in a fatal error if a non string was passed into the method.

The error was also never thrown, which is now also fixed