### PR TITLE
Ensure the issues are indexed on Manage id

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
@@ -268,7 +268,7 @@ class EntityService implements EntityServiceInterface
             // entities
             if (count($issueCollection) > 0) {
                 foreach ($entities as $entity) {
-                    if ($issueCollection->getIssueByKey($entity->getId())) {
+                    if ($issueCollection->getIssueById($entity->getId())) {
                         $entity->updateStatus(Entity::STATE_REMOVAL_REQUESTED);
                     }
                 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/IssueCollection.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/IssueCollection.php
@@ -32,18 +32,18 @@ class IssueCollection implements Countable
      */
     public function __construct(array $issues)
     {
-        foreach ($issues as $issue) {
-            $this->issues[$issue->getKey()] = $issue;
+        foreach ($issues as $id => $issue) {
+            $this->issues[$id] = $issue;
         }
     }
 
     /**
      * @return Issue|null
      */
-    public function getIssueByKey($key)
+    public function getIssueById($id)
     {
-        if (array_key_exists($key, $this->issues)) {
-            return $this->issues[$key];
+        if (array_key_exists($id, $this->issues)) {
+            return $this->issues[$id];
         }
 
         return null;

--- a/tests/unit/Domain/ValueObject/IssueCollectionTest.php
+++ b/tests/unit/Domain/ValueObject/IssueCollectionTest.php
@@ -26,14 +26,16 @@ class IssueCollectionTest extends TestCase
 {
     public function test_get_issue_by_key()
     {
-        $issue1 = new Issue('00000000-0000-0000-0000-000000000000', 'issue-type-1');
-        $issue2 = new Issue('00000000-0000-0000-0000-000000000001', 'issue-type-2');
+        $issue1 = new Issue('CTX-0123', 'issue-type-1');
+        $issue2 = new Issue('CTX-0124', 'issue-type-2');
 
-        $collection = new IssueCollection([$issue1, $issue2]);
+        $collection = new IssueCollection(
+            ['00000000-0000-0000-0000-000000000000' => $issue1, '00000000-0000-0000-0000-000000000001' => $issue2]
+        );
 
-        $this->assertEquals($issue1, $collection->getIssueByKey('00000000-0000-0000-0000-000000000000'));
-        $this->assertEquals($issue2, $collection->getIssueByKey('00000000-0000-0000-0000-000000000001'));
-        $this->assertNull($collection->getIssueByKey('99999999-9999-9999-9999-999999999999'));
+        $this->assertEquals($issue1, $collection->getIssueById('00000000-0000-0000-0000-000000000000'));
+        $this->assertEquals($issue2, $collection->getIssueById('00000000-0000-0000-0000-000000000001'));
+        $this->assertNull($collection->getIssueById('99999999-9999-9999-9999-999999999999'));
     }
 
     public function test_count()
@@ -46,7 +48,14 @@ class IssueCollectionTest extends TestCase
         $issue5 = new Issue('00000000-0000-0000-0000-000000000003', 'issue-type-4');
         $issue6 = new Issue('00000000-0000-0000-0000-000000000003', 'issue-type-4');
 
-        $collection = new IssueCollection([$issue1, $issue2, $issue3, $issue4, $issue5, $issue6]);
+        $collection = new IssueCollection([
+            $issue1->getKey() => $issue1,
+            $issue2->getKey() => $issue2,
+            $issue3->getKey() => $issue3,
+            $issue4->getKey() => $issue4,
+            $issue5->getKey() => $issue5,
+            $issue6->getKey() => $issue6
+        ]);
 
         $this->assertCount(4, $collection);
     }

--- a/tests/unit/Infrastructure/DashboardBundle/Jira/Repository/IssueRepositoryTest.php
+++ b/tests/unit/Infrastructure/DashboardBundle/Jira/Repository/IssueRepositoryTest.php
@@ -90,10 +90,10 @@ class IssueRepositoryTest extends PHPUnit_Framework_TestCase
         $this->assertCount(2, $results);
 
         // assert the two issues
-        $issue = $results->getIssueByKey('manageId-4');
+        $issue = $results->getIssueById('manageId-4');
         $this->assertSame('manageId-4', $issue->getKey());
         $this->assertSame('test', $issue->getIssueType());
-        $issue = $results->getIssueByKey('manageId-5');
+        $issue = $results->getIssueById('manageId-5');
         $this->assertSame('manageId-5', $issue->getKey());
         $this->assertSame('test2', $issue->getIssueType());
 


### PR DESCRIPTION
Instead of indexing the Jira issues on the corresponding manage id, they were indexed on Jira key. This caused the status not being updated.

This is hard to test in a development environment, as we use a tests stand in for Jira interaction. And the issue did not surface in that solution.