### PR TITLE
Fix the entity delete acl

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityDeleteController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityDeleteController.php
@@ -133,7 +133,7 @@ class EntityDeleteController extends Controller
      */
     public function deletePublishedAction(Request $request, $serviceId, $manageId, $environment)
     {
-        $this->isGranted("MANAGE_ENTITY_ACCESS", ['manageId' => $manageId, 'environment' => $environment]);
+        $this->denyAccessUnlessGranted("MANAGE_ENTITY_ACCESS", ['manageId' => $manageId, 'environment' => $environment]);
 
         $entity = $this->entityService->getManageEntityById($manageId, $environment);
         $nameEn = $entity->getMetaData()->getNameEn();
@@ -186,7 +186,7 @@ class EntityDeleteController extends Controller
      */
     public function deleteRequestAction(Request $request, $serviceId, $manageId, $environment)
     {
-        $this->isGranted("MANAGE_ENTITY_ACCESS", ['manageId' => $manageId, 'environment' => $environment]);
+        $this->denyAccessUnlessGranted("MANAGE_ENTITY_ACCESS", ['manageId' => $manageId, 'environment' => $environment]);
 
         $entity = $this->entityService->getManageEntityById($manageId, $environment);
         $nameEn = $entity->getMetaData()->getNameEn();

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Security/Voter/ManageEntityAccessGrantedVoter.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Security/Voter/ManageEntityAccessGrantedVoter.php
@@ -47,7 +47,7 @@ class ManageEntityAccessGrantedVoter extends Voter
     protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
     {
         // Administrator is always allowed to delete an entity
-        if (in_array("ROLE_ADMINISTRATOR", $token->getRoles())) {
+        if ($token->hasRole('ROLE_ADMINISTRATOR')) {
             return true;
         }
 

--- a/tests/unit/Infrastructure/DashboardBundle/Security/Voter/ManageEntityAccessGrantedVoterTest.php
+++ b/tests/unit/Infrastructure/DashboardBundle/Security/Voter/ManageEntityAccessGrantedVoterTest.php
@@ -151,8 +151,12 @@ class ManageEntityAccessGrantedVoterTest extends MockeryTestCase
             ->andReturn($user);
 
         $token
-            ->shouldReceive('getRoles')
-            ->andReturn($roles);
+            ->shouldReceive('hasRole')
+            ->andReturnUsing(
+                function ($role) use ($roles) {
+                    return in_array($role, $roles);
+                }
+            );
 
         $user->shouldReceive('isPartOfTeam')
             ->andReturn($isPartOfTeam);

--- a/tests/webtests/EntityDeleteTest.php
+++ b/tests/webtests/EntityDeleteTest.php
@@ -35,6 +35,19 @@ class EntityDeleteTest extends WebTestCase
         $this->getAuthorizationService()->setSelectedServiceId($this->service->getId());
     }
 
+    public function test_a_normal_user_can_not_delete_entities()
+    {
+        $this->logIn('ROLE_USER');
+
+        $entity = $this->service->getEntities()->first();
+
+        $this->client->request('GET', "/entity/delete/{$entity->getId()}");
+
+        $statusCode = $this->client->getResponse()->getStatusCode();
+
+        $this->assertSame(403, $statusCode);
+    }
+
     public function test_delete_returns_to_entity_list()
     {
         $entity = $this->service->getEntities()->first();
@@ -111,12 +124,9 @@ class EntityDeleteTest extends WebTestCase
             ],
         ]);
 
-        // Authz test (ManageEntityAccessGrantedVoter) (tested twice for both controller entries)
-        $this->testMockHandler->append(new Response(200, [], $queryResponse));
+        // Authz test (ManageEntityAccessGrantedVoter)
         $this->testMockHandler->append(new Response(200, [], $queryResponse));
         // Rendering the form requires retrieval of the manage entity
-        $this->testMockHandler->append(new Response(200, [], $queryResponse));
-        // Handling the form also requires retrieval of the manage entity
         $this->testMockHandler->append(new Response(200, [], $queryResponse));
         // Successfull deleting an entity from manage results in return type boolean : true
         $this->testMockHandler->append(new Response(200, [], json_encode(true)));
@@ -159,12 +169,10 @@ class EntityDeleteTest extends WebTestCase
 
         // Authz test (ManageEntityAccessGrantedVoter) (tested twice for both controller entries)
         $this->prodMockHandler->append(new Response(200, [], $queryResponse));
-        $this->prodMockHandler->append(new Response(200, [], $queryResponse));
 
         // Rendering the form requires retrieval of the manage entity
         $this->prodMockHandler->append(new Response(200, [], $queryResponse));
-        // Handling the form also requires retrieval of the manage entity
-        $this->prodMockHandler->append(new Response(200, [], $queryResponse));
+
         // Successfull deleting an entity from manage results in return type boolean : true
         $this->prodMockHandler->append(new Response(200, [], json_encode(true)));
 
@@ -211,15 +219,10 @@ class EntityDeleteTest extends WebTestCase
         // Handling the form also requires retrieval of the manage entity
         $this->prodMockHandler->append(new Response(200, [], $queryResponse));
         $this->prodMockHandler->append(new Response(200, [], $queryResponse));
-        $this->prodMockHandler->append(new Response(200, [], $queryResponse));
-        $this->prodMockHandler->append(new Response(200, [], $queryResponse));
-        // Successful deleting an entity from manage results in return type boolean : true
-        $this->prodMockHandler->append(new Response(200, [], json_encode(true)));
 
         // The entity list action
         $this->testMockHandler->append(new Response(200, [], '[]'));
         $this->testMockHandler->append(new Response(200, [], '[]'));
-        $this->prodMockHandler->append(new Response(200, [], '[]'));
         $this->prodMockHandler->append(new Response(200, [], '[]'));
 
         $crawler = $this->client->request('GET', "/entity/delete/request/1/a8e7cffd-0409-45c7-a37a-000000000000");
@@ -240,6 +243,7 @@ class EntityDeleteTest extends WebTestCase
         );
 
         $crawler = $this->client->followRedirect();
+
 
         $flashMessage = $crawler->filter('div.message.error');
 


### PR DESCRIPTION
The voter used on the entity delete endpoint didn't work as expected
for the administrator role because the role was validated against a
string and not a Role.

Also the endpoint didn't take the result into account from the isGranted
method and the isGranted method din't throw an exception either. Both
issues are now fixed.

https://www.pivotaltracker.com/story/show/167062944