### PR TITLE
Fix the translations acl

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -46,4 +46,5 @@ security:
     access_control:
         - { path: ^/saml, roles: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: https }
         - { path: ^/entity/metadata, roles: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: https }
+        - { path: ^/translations, roles: ROLE_ADMINISTRATOR, requires_channel: https }
         - { path: ^/, roles: IS_AUTHENTICATED_FULLY, requires_channel: https }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Security/Voter/ManageEntityAccessGrantedVoter.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Security/Voter/ManageEntityAccessGrantedVoter.php
@@ -38,10 +38,15 @@ class ManageEntityAccessGrantedVoter extends Voter
 
     protected function supports($attribute, $subject)
     {
-        $supportedAttribute = $attribute === self::MANAGE_ENTITY_ACCESS;
-        $subjectFieldsPresent = isset($subject['manageId']) && isset($subject['environment']);
+        if ($attribute !== self::MANAGE_ENTITY_ACCESS) {
+            return false;
+        }
 
-        return $supportedAttribute && $subjectFieldsPresent;
+        if (!isset($subject['manageId']) || !isset($subject['environment'])) {
+            return false;
+        }
+
+        return true;
     }
 
     protected function voteOnAttribute($attribute, $subject, TokenInterface $token)


### PR DESCRIPTION
The translation endpoint could be reached if a user was logged in
and wasn't restricted to Administrators only.

The access_control is therefore changed and a change in a voter was
needed to allow validation of the endpoint.

https://www.pivotaltracker.com/story/show/167063760