### PR TITLE
Update Manage to a newer version and enable OIDC TNG

### DIFF
--- a/ansible/roles/manage-server-prod/defaults/main.yml
+++ b/ansible/roles/manage-server-prod/defaults/main.yml
@@ -9,3 +9,5 @@ manage_disclaimer_background_color: skyblue
 manage_disclaimer_content: OC
 manage_service_provider_feed_url: "http://mds.edugain.org/"
 manage_exclude_edugain_imports_in_push: true
+manage_show_oidc_rp_tab: false
+manage_exclude_oidc_rp_imports_in_push: false

--- a/ansible/roles/manage-server-prod/defaults/main.yml
+++ b/ansible/roles/manage-server-prod/defaults/main.yml
@@ -9,5 +9,5 @@ manage_disclaimer_background_color: skyblue
 manage_disclaimer_content: OC
 manage_service_provider_feed_url: "http://mds.edugain.org/"
 manage_exclude_edugain_imports_in_push: true
-manage_show_oidc_rp_tab: false
+manage_show_oidc_rp_tab: true
 manage_exclude_oidc_rp_imports_in_push: false

--- a/ansible/roles/manage-server-prod/files/metadata_configuration/oidc10_rp.schema.json
+++ b/ansible/roles/manage-server-prod/files/metadata_configuration/oidc10_rp.schema.json
@@ -1,22 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "single_tenant_template",
-  "order": 4,
+  "title": "oidc10_rp",
+  "order": 3,
   "definitions": {
-    "AssertionConsumerServiceBinding": {
-      "type": "string",
-      "enum": [
-        "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
-        "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-        "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign",
-        "urn:oasis:names:tc:SAML:2.0:bindings:SOAP",
-        "urn:oasis:names:tc:SAML:2.0:bindings:PAOS",
-        "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact",
-        "urn:oasis:names:tc:SAML:2.0:bindings:URI"
-      ],
-      "default": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-      "info": "Select the binding the SP claims support for. A binding specifies the technical method of a connection."
-    },
     "NameIDFormat": {
       "type": "string",
       "enum": [
@@ -51,12 +37,13 @@
       "type": "number"
     },
     "entityid": {
-      "type": "string"
+      "type": "string",
+      "format": "basic-authentication-user"
     },
     "type": {
       "type": "string",
       "enum": [
-        "single-tenant-template"
+        "oidc10-rp"
       ]
     },
     "revisionid": {
@@ -69,11 +56,12 @@
         "testaccepted"
       ]
     },
-    "metadataurl": {
+    "discoveryurl": {
       "type": [
         "string",
         "null"
-      ]
+      ],
+      "format": "url"
     },
     "allowedall": {
       "type": "boolean"
@@ -82,9 +70,6 @@
       "type": "string"
     },
     "created": {
-      "type": "string"
-    },
-    "ip": {
       "type": "string"
     },
     "revisionnote": {
@@ -104,6 +89,17 @@
         }
       }
     },
+    "allowedResourceServers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "arp": {
       "type": "object",
       "sources": [
@@ -112,7 +108,6 @@
         "sab",
         "voot",
         "pseudo_email",
-        "sbs",
         "surfmarket_entitlements"
       ],
       "properties": {
@@ -233,28 +228,19 @@
         "NameIDFormat": {
           "$ref": "#/definitions/NameIDFormat"
         },
-        "SingleLogoutService_Binding": {
-          "type": "string",
-          "enum": [
-            "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
-            "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-            "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign",
-            "urn:oasis:names:tc:SAML:2.0:bindings:SOAP",
-            "urn:oasis:names:tc:SAML:2.0:bindings:PAOS",
-            "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact",
-            "urn:oasis:names:tc:SAML:2.0:bindings:URI"
-          ],
-          "default": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
-          "info": "SingleLogoutService is not supported by the Engine Block. Selects the SingleLogoutService binding an SP claims support for. A binding specifies the protocol to access the service."
-        },
-        "SingleLogoutService_Location": {
-          "type": "string",
-          "format": "url",
-          "info": "SingleLogoutService is not supported by the Engine Block. If the connected SP supports SAML 2.0 Single Logout, this will specify the endpoint element as a URL."
-        },
         "mdrpi:RegistrationInfo": {
           "type": "string",
           "info": "The name of the authority that can register a service provider or identity provider."
+        },
+        "oidc:signingCertificateUrl": {
+          "type": "string",
+          "format": "url",
+          "info": "Enter the URL that provides to the public key to verify the signature of the client JWT."
+        },
+        "oidc:signingCertificate": {
+          "type": "string",
+          "format": "certificate",
+          "info": "The public JWT signing certificate of the service. This must be a PEM encoded certificate. DER, CRT or CER are not supported."
         },
         "logo:0:url": {
           "type": "string",
@@ -269,27 +255,15 @@
           "type": "number",
           "info": "The height of the logo found at logo:0:url in pixels."
         },
-        "redirect.sign": {
-          "type": "boolean",
-          "info": "Whether authentication request, logout requests and logout responses should be signed. The default is FALSE. This is generally set for trusted proxies like OpenID Connect Gateway."
-        },
-        "coin:publish_in_edugain": {
+        "coin:push_enabled": {
           "type": "boolean",
           "default": false,
-          "info": "Set this for service providers published in eduGAIN."
+          "info": "Must be set for this Service Provider to be included in the EB push despite being imported from eduGAIN."
         },
-        "coin:publish_in_edugain_date": {
-          "type": "string",
-          "format": "date-time",
-          "info": "When to add metadata to the eduGAIN feed. Usually the current time."
-        },
-        "coin:interfed_source": {
-          "type": "string",
-          "enum": [
-            "Entree",
-            "eduGAIN"
-          ],
-          "info": "Must be set if the federation source is either eduGAIN or Entree."
+        "coin:exclude_from_push": {
+          "type": "boolean",
+          "default": false,
+          "info": "Must be set for this Service Provider to be excluded in the EB push."
         },
         "coin:additional_logging": {
           "type": "boolean",
@@ -297,21 +271,17 @@
         },
         "coin:institution_id": {
           "type": "string",
-          "info": "The defined client code."
+          "info": "The defined client code. Generally an abbreviation of the name of the client."
         },
         "coin:institution_guid": {
           "type": "string",
           "format": "uuid",
           "info": "This is a 128 bit number also known as a globally unique identifier (GUID or UUID) for this service."
         },
-        "coin:trusted_proxy": {
-          "type": "boolean",
-          "default": false,
-          "info": "Set if the service provider can act on behalf of connected services to this service."
-        },
         "coin:no_consent_required": {
           "type": "boolean",
-          "info": "Select this option to skip the consent for a user."
+          "info": "Select this option to skip the consent for a user.",
+          "default": true
         },
         "coin:eula": {
           "type": "string",
@@ -326,18 +296,22 @@
           "type": "boolean",
           "info": "Set to indicate the service in the dashboard for institutions is marked as to have disagreed to sign the aansluitovereenkomst."
         },
+        "coin:ss:hidden": {
+          "type": "boolean",
+          "info": "Set to make invisible in the dashboard for identity providers."
+        },
         "coin:application_url": {
           "type": "string",
           "format": "url",
           "info": "The URL of the service used to log on."
         },
+        "coin:supports_idp_init_login": {
+          "type": "boolean",
+          "info": "The service provider supports IDP initiated login."
+        },
         "coin:transparant_issuer": {
           "type": "boolean",
           "info": "Set this to let the Engineblock use the EntityID of the IdP in stead of the EntityID of the Engineblock."
-        },
-        "coin:do_not_add_attribute_aliases": {
-          "type": "boolean",
-          "info": "Only send the SAML 2.0 name scheme. "
         },
         "coin:display_unconnected_idps_wayf": {
           "type": "boolean",
@@ -350,11 +324,6 @@
         "coin:attribute_aggregation_required": {
           "type": "boolean",
           "info": "Set to activate attribute aggregation for this service."
-        },
-        "coin:original_metadata_url": {
-          "type": "string",
-          "format": "url",
-          "info": "The provided URL to the metadata of the service."
         },
         "coin:service_team_id": {
           "type": "string",
@@ -396,11 +365,11 @@
         },
         "coin:privacy:surfmarket_dpa_agreement": {
           "type": "boolean",
-          "info": "Is the SURFmarket model Data Processing Agreement (DPA) signed by the service provider?"
+          "info": "Has the service provider agreed a Data Processing Agreement (DPA) with SURFmarket?"
         },
         "coin:privacy:surfnet_dpa_agreement": {
           "type": "boolean",
-          "info": "Is the SURFnet model Data Processing Agreement (DPA) signed by the service provider?"
+          "info": "Is the service provider willing to sign the SURF model Data Processing Agreement (DPA)?"
         },
         "coin:privacy:sn_dpa_why_not": {
           "type": "string",
@@ -419,16 +388,6 @@
           "type": "string",
           "info": "Other data privacy and security information that helps the institution decide whether it is OK to connect the service."
         },
-        "coin:signature_method": {
-          "type": "string",
-          "format": "url",
-          "enum": [
-            "http://www.w3.org/2000/09/xmldsig#rsa-sha1",
-            "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
-          ],
-          "default": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
-          "info": "Select the Secure Hash Algorithm (SHA) as used by the service provider."
-        },
         "coin:ss:supports_strong_authentication": {
           "type": "boolean",
           "info": "Set if StepUp is supported."
@@ -446,14 +405,79 @@
           ],
           "default": "license_required_by_service_provider",
           "info": "Set the applicable license for this service as provisioned by the SP Dashboard."
+        },
+        "secret": {
+          "type": "string",
+          "format": "password",
+          "info": "The secret of this Relying Party for authentication purposes."
+        },
+        "redirectUrls": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "url"
+          },
+          "info": "The redirect URLS of this Relying Party."
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "openid",
+              "members",
+              "groups",
+              "actions",
+              "cross-idp-services",
+              "stats",
+              "pdp",
+              "test",
+              "email",
+              "profile"
+            ]
+          },
+          "info": "The allowed scopes for this Relying Party."
+        },
+        "grants": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "authorization_code",
+              "implicit",
+              "refresh_token",
+              "client_credentials"
+            ]
+          },
+          "info": "The authorisation grant type's of this Relying Party."
+        },
+        "isResourceServer": {
+          "type": "boolean",
+          "default": false,
+          "info": "Must be set for this Relying Party to be marked as a Resource Server to explicitly grant access to the Introspect endpoint."
+        },
+        "isPublicClient": {
+          "type": "boolean",
+          "default": false,
+          "info": "Must be set for this Relying Party to be marked as a Public Client to explicitly allow the Proof Key for Code Exchange (PKCE) flow."
+        },
+        "accessTokenValidity": {
+          "type": "number",
+          "default": 3600,
+          "info": "The number of seconds that a new access token is valid for this Relying Party."
+        },
+        "refreshTokenValidity": {
+          "type": "number",
+          "default": 3600,
+          "info": "The number of seconds that a new refresh token is valid for this Relying Party."
         }
       },
       "patternProperties": {
-        "^name:(en|nl)$": {
+        "^name:(en|nl|pt)$": {
           "type": "string",
           "info": "Set the name of the service. Format: 'Service Name | Supplier'"
         },
-        "^displayName:(en|nl)$": {
+        "^displayName:(en|nl|pt)$": {
           "type": "string",
           "info": "Name as displayed in applications."
         },
@@ -462,7 +486,7 @@
           "format": "url",
           "info": "Add the URL to the SURF wiki for additional information of this service."
         },
-        "^description:(en|nl)$": {
+        "^description:(en|nl|pt)$": {
           "type": "string",
           "info": "The description of the service."
         },
@@ -470,26 +494,10 @@
           "type": "string",
           "info": "The type of service used in the facet search in dashboard."
         },
-        "^AssertionConsumerService:([0-9]{1}):Binding$": {
-          "$ref": "#/definitions/AssertionConsumerServiceBinding",
-          "multiplicity": 10,
-          "info": "An Assertion Consumer Service (or ACS) the location at a ServiceProvider that accepts <samlp:Response> messages. The type of binding for this location can be selected from the pull-down."
-        },
-        "^AssertionConsumerService:([0-9]{1}):Location$": {
-          "type": "string",
-          "format": "url",
-          "multiplicity": 10,
-          "info": "An Assertion Consumer Service (or ACS) is the location at a ServiceProvider that accepts <samlp:Response> messages. A typical ACS location for an SP might look like this: https://data.example-service.nl/saml/saml2_acs/"
-        },
-        "^AssertionConsumerService:([0-9]{1}):index$": {
-          "type": "number",
-          "multiplicity": 10,
-          "info": "An Assertion Consumer Service (or ACS) is the location at a ServiceProvider that accepts <samlp:Response> messages. With the index you can include additional <md:AssertionConsumerService> elements in the SAML 2.0 SP metadata with the same binding, each with its own unique index."
-        },
         "^NameIDFormats:([0-2]{1})$": {
           "$ref": "#/definitions/NameIDFormat",
           "multiplicity": 3,
-          "info": "The format in which the service expects the response. This can be transient, transparant or unspecified."
+          "info": "The NameIDFormat(s) this service provider supports. This can be transient, transparant or unspecified."
         },
         "^contacts:([0-3]{1}):surName$": {
           "type": "string",
@@ -535,20 +543,20 @@
           "sibblingIndependent": true,
           "info": "From the pull down, select the type of contact."
         },
-        "^OrganizationName:(en|nl)$": {
+        "^OrganizationName:(en|nl|pt)$": {
           "type": "string",
           "info": "The formal name of the organization. e.g. Service by University of Harderwijk."
         },
-        "^OrganizationDisplayName:(en|nl)$": {
+        "^OrganizationDisplayName:(en|nl|pt)$": {
           "type": "string",
           "info": "The friendly name of the organization. e.g. University of Harderwijk."
         },
-        "^OrganizationURL:(en|nl)$": {
+        "^OrganizationURL:(en|nl|pt)$": {
           "type": "string",
           "format": "url",
           "info": "The URL to the website of the service e.g. http://www.example-service.nl/en/."
         },
-        "^url:(en|nl)$": {
+        "^url:(en|nl|pt)$": {
           "type": "string",
           "format": "url",
           "info": "The URL to the support site of the service."
@@ -576,24 +584,20 @@
         }
       },
       "required": [
-        "name:en"
+        "name:en",
+        "secret",
+        "scopes",
+        "grants"
       ],
       "additionalProperties": false
     }
   },
   "required": [
+    "entityid",
     "state",
+    "allowedall",
     "metaDataFields"
   ],
   "additionalProperties": false,
-  "indexes": [
-    {
-      "name": "field_entityid",
-      "type": "field",
-      "fields": [
-        "entityid"
-      ],
-      "unique": false
-    }
-  ]
+  "indexes": []
 }

--- a/ansible/roles/manage-server-prod/files/metadata_configuration/saml20_idp.schema.json
+++ b/ansible/roles/manage-server-prod/files/metadata_configuration/saml20_idp.schema.json
@@ -3,7 +3,21 @@
   "title": "saml20_idp",
   "order": 2,
   "definitions": {
-    "SingleSignOnService": {
+    "SingleSignOnService_Binding": {
+      "type": "string",
+      "enum": [
+        "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+        "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+        "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign",
+        "urn:oasis:names:tc:SAML:2.0:bindings:SOAP",
+        "urn:oasis:names:tc:SAML:2.0:bindings:PAOS",
+        "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact",
+        "urn:oasis:names:tc:SAML:2.0:bindings:URI"
+      ],
+      "default": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+      "info": "Select the binding the IdP claims support for. A binding specifies the technical method of a connection."
+    },
+    "SingleLogoutService_Binding": {
       "type": "string",
       "enum": [
         "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
@@ -14,7 +28,7 @@
         "urn:oasis:names:tc:SAML:2.0:bindings:URI"
       ],
       "default": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
-      "info": "Select the binding the IdP claims support for. A binding specifies the technical method of a connection."
+      "info": "SingleLogoutService is not supported by the Engine Block. Select the SingleLogoutService binding an IdP claims support for. A binding specifies the protocol to access the service."
     },
     "NameIDFormat": {
       "type": "string",
@@ -167,16 +181,7 @@
           "info": "Up to three certificates per service can be defined. This is the third and last field for certificates you can enter. This must be a PEM encoded certificate. DER, CRT or CER are not supported."
         },
         "SingleLogoutService_Binding": {
-          "type": "string",
-          "enum": [
-            "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
-            "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-            "urn:oasis:names:tc:SAML:2.0:bindings:SOAP",
-            "urn:oasis:names:tc:SAML:2.0:bindings:PAOS",
-            "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact",
-            "urn:oasis:names:tc:SAML:2.0:bindings:URI"
-          ],
-          "default": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+          "$ref": "#/definitions/SingleLogoutService_Binding",
           "info": "SingleLogoutService is not supported by the Engine Block. Select the SingleLogoutService binding an IdP claims support for. A binding specifies the protocol to access the service."
         },
         "SingleLogoutService_Location": {
@@ -194,33 +199,28 @@
           "info": "Enter the URL to the logo used for this service. e.g. https://static.example-logo.nl/media/sp/logo.png."
         },
         "logo:0:width": {
-          "type": "string",
-          "format": "number",
+          "type": "number",
           "info": "The width of the logo found at logo:0:url in pixels."
         },
         "logo:0:height": {
-          "type": "string",
-          "format": "number",
+          "type": "number",
           "info": "The height of the logo found at logo:0:url in pixels."
         },
         "redirect.sign": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "info": "Whether authentication request, logout requests and logout responses should be signed. The default is FALSE. This is generally set for trusted proxies like OpenID Connect Gateway."
         },
         "coin:publish_in_edugain": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "info": "Set this for Identity Providers published in eduGAIN."
         },
         "coin:publish_in_edugain_date": {
           "type": "string",
           "format": "date-time",
-          "info": "When to add the metadata to the eduGAIN feed. Usually the current time."
+          "info": "When this entity first appeared in the eduGAIN feed. Usually the current time."
         },
         "coin:additional_logging": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "info": "Set to get an extended form of logging."
         },
         "coin:institution_id": {
@@ -255,14 +255,16 @@
           "info": "The format in which the service expects the response. This can be transient, transparent or unspecified."
         },
         "coin:disable_scoping": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "info": "Set to disable sending a scoping element in het authentication request to Active Directory Federation Services (ADFS) servers. Set for ADFS servers lower than 4.0."
         },
         "coin:hidden": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "info": "Set to make the IdP hidden in the dashboard when the IdP is not connected to a service."
+        },
+        "coin:ss:allow_scb_admin_rights":{
+          "type": "boolean",
+          "info": "Set to grant SAB SURFconext beheerders for this IdP the SURFconext verantwoordelijke rights."
         },
         "coin:signature_method": {
           "type": "string",
@@ -275,8 +277,7 @@
           "info": "Select the Secure Hash Algorithm (SHA) to use for signed authentication requests sent by Engineblock to this identity provider."
         },
         "coin:exclude_from_push": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "default": false,
           "info": "Must be set for this Identity Provider to be excluded in the EB push."
         }
@@ -320,8 +321,7 @@
           "info": "The telephoneNumber of the contact."
         },
         "^contacts:([0-3]{1}):isSirtfiSecurityContact$": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "multiplicity": 4,
           "sibblingIndependent": true,
           "info": "Set if the contact for this Identity Provider is responsible for security."
@@ -369,7 +369,7 @@
           "info": "Select one of the entity categories applicable to this service. Entity Categories group federation entities that share common criteria."
         },
         "^SingleSignOnService:([0-9]{1}):Binding$": {
-          "$ref": "#/definitions/SingleSignOnService",
+          "$ref": "#/definitions/SingleSignOnService_Binding",
           "multiplicity": 10,
           "info": "Select the binding the IdP claims support for. A binding specifies the technical method of a connection."
         },
@@ -389,8 +389,7 @@
           "info": "Select the allowed permissible attribute scope for the role. The scope is an attribute-specific concept used in Shibboleth to enhance the functionality of the attribute acceptance policy features."
         },
         "^shibmd:scope:([0-9]{1}):regexp$": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "multiplicity": 10,
           "info": "If not set or absent, the text content of the shibmd:Scope is interpreted as the literal scope value.  If not set the scope component of each scoped attribute value processed by the service provider MUST exactly match the value of <shibmd:Scope> element. If set, the text content of the shibmd:Scope is interpreted as specifying a regular expression.  If set, the scope component of each scoped attribute value processed by the service provider MUST match the regular expression."
         }

--- a/ansible/roles/manage-server-prod/files/metadata_configuration/saml20_sp.schema.json
+++ b/ansible/roles/manage-server-prod/files/metadata_configuration/saml20_sp.schema.json
@@ -3,11 +3,9 @@
   "title": "saml20_sp",
   "order": 1,
   "definitions": {
-    "AssertionConsumerServiceBinding": {
+    "AssertionConsumerService_Binding": {
       "type": "string",
       "enum": [
-        "urn:oasis:names:tc:SAML:1.0:profiles:browser-post",
-        "urn:oasis:names:tc:SAML:1.0:profiles:artifact-01",
         "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
         "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
         "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign",
@@ -18,6 +16,20 @@
       ],
       "default": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
       "info": "Select the binding the SP claims support for. A binding specifies the technical method of a connection."
+    },
+    "SingleLogoutService_Binding": {
+      "type": "string",
+      "enum": [
+        "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+        "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+        "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign",
+        "urn:oasis:names:tc:SAML:2.0:bindings:SOAP",
+        "urn:oasis:names:tc:SAML:2.0:bindings:PAOS",
+        "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact",
+        "urn:oasis:names:tc:SAML:2.0:bindings:URI"
+      ],
+      "default": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+      "info": "*** SingleLogoutService is not supported by the Engine Block. Import for future compatibility. *** Selects the SingleLogoutService binding an SP claims support for. A binding specifies the protocol to access the service."
     },
     "NameIDFormat": {
       "type": "string",
@@ -126,6 +138,7 @@
         "sab",
         "voot",
         "pseudo_email",
+        "sbs",
         "surfmarket_entitlements"
       ],
       "properties": {
@@ -262,17 +275,7 @@
           "info": "Up to three certificates per service can be defined. This is the third and last field for certificates you can enter. This must be a PEM encoded certificate. DER, CRT or CER are not supported."
         },
         "SingleLogoutService_Binding": {
-          "type": "string",
-          "enum": [
-            "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
-            "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-            "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign",
-            "urn:oasis:names:tc:SAML:2.0:bindings:SOAP",
-            "urn:oasis:names:tc:SAML:2.0:bindings:PAOS",
-            "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact",
-            "urn:oasis:names:tc:SAML:2.0:bindings:URI"
-          ],
-          "default": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+          "$ref": "#/definitions/SingleLogoutService_Binding",
           "info": "*** SingleLogoutService is not supported by the Engine Block. Import for future compatibility. *** Selects the SingleLogoutService binding an SP claims support for. A binding specifies the protocol to access the service."
         },
         "SingleLogoutService_Location": {
@@ -290,58 +293,53 @@
           "info": "Enter the URL to the logo used for this service. e.g. https://static.example-logo.nl/media/sp/logo.png."
         },
         "logo:0:width": {
-          "type": "string",
-          "format": "number",
+          "type": "number",
           "info": "The width of the logo found at logo:0:url in pixels."
         },
         "logo:0:height": {
-          "type": "string",
-          "format": "number",
+          "type": "number",
           "info": "The height of the logo found at logo:0:url in pixels."
         },
         "redirect.sign": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "info": "Whether authentication request, logout requests and logout responses should be signed. The default is FALSE. This is generally set for trusted proxies like OpenID Connect Gateway or Stepup authentication gateway."
         },
         "coin:sp_specific_metadata": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "default": false,
           "info": "Publish SP-specific metadata containing only whitelisted IdPs."
         },
         "coin:publish_in_edugain": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "default": false,
-          "info": "Set this for service providers published in eduGAIN."
+          "info": "Set this for service providers that we publish in eduGAIN. When set, this entity also needs to have a value for coin:publish_in_edugain_date."
         },
         "coin:publish_in_edugain_date": {
           "type": "string",
           "format": "date-time",
-          "info": "When to add metadata to the eduGAIN feed. Usually the current time."
+          "info": "When this entity first appeared in the eduGAIN feed. Usually the current time."
+        },
+        "coin:publish_in_edugain_allow_rns": {
+          "type": "boolean",
+          "info": "Whether we have approved that this SP may use the Research & Scholarship entity category."
         },
         "coin:imported_from_edugain": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "default": false,
           "info": "This is automatically set for service providers imported from eduGAIN. Unset it to prevent re-import."
         },
         "coin:push_enabled": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "default": false,
           "info": "Must be set for this Service Provider to be included in the EB push despite being imported from eduGAIN."
         },
         "coin:exclude_from_push": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "default": false,
           "info": "Must be set for this Service Provider to be excluded in the EB push."
         },
         "coin:oidc_client": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "default": false,
           "info": "Set for those Service Providers that are OpenIDConnect clients."
         },
@@ -354,8 +352,7 @@
           "info": "Must be set if the federation source is either eduGAIN or Entree."
         },
         "coin:additional_logging": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "info": "Set to get an extended form of logging."
         },
         "coin:institution_id": {
@@ -368,15 +365,14 @@
           "info": "This is a 128 bit number also known as a globally unique identifier (GUID or UUID) for this service."
         },
         "coin:trusted_proxy": {
-          "type": "string",
-          "format": "boolean",
-          "default": "false",
+          "type": "boolean",
+          "default": false,
           "info": "Set if the service provider can act on behalf of connected services to this service."
         },
         "coin:no_consent_required": {
-          "type": "string",
-          "format": "boolean",
-          "info": "Select this option to skip the consent for a user."
+          "type": "boolean",
+          "info": "Select this option to skip the consent for a user.",
+          "default": true
         },
         "coin:eula": {
           "type": "string",
@@ -384,18 +380,15 @@
           "info": "The URL to the end-user license agreement (EULA) of the service provider."
         },
         "coin:ss:idp_visible_only": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "info": "Set to make invisible in the dashboard for institutions that are not connected to this service."
         },
         "coin:ss:aansluitovereenkomst_refused": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "info": "Set to indicate the service in the dashboard for institutions is marked as to have disagreed to sign the aansluitovereenkomst."
         },
-        "coin:ss:hidden":{
-          "type": "string",
-          "format": "boolean",
+        "coin:ss:hidden": {
+          "type": "boolean",
           "info": "Set to make invisible in the dashboard for identity providers."
         },
         "coin:application_url": {
@@ -404,33 +397,27 @@
           "info": "The URL of the service used to log on."
         },
         "coin:supports_idp_init_login": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "info": "The service provider supports IDP initiated login."
         },
         "coin:transparant_issuer": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "info": "Set this to let the Engineblock use the EntityID of the IdP in stead of the EntityID of the Engineblock."
         },
         "coin:do_not_add_attribute_aliases": {
-          "type": "string",
-          "format": "boolean",
-          "info": "Only send the SAML 2.0 name scheme. "
+          "type": "boolean",
+          "info": "Only send the SAML 2.0 name scheme."
         },
         "coin:display_unconnected_idps_wayf": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "info": "Display unconnected IdPs in the WAYF."
         },
         "coin:policy_enforcement_decision_required": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "info": "Set to activate the user policy engine (PDP)."
         },
         "coin:attribute_aggregation_required": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "info": "Set to activate attribute aggregation for this service."
         },
         "coin:original_metadata_url": {
@@ -464,8 +451,7 @@
           "info": "Explains what security measures are taken to protect data. You can also link to a page describing this."
         },
         "coin:privacy:certification": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "info": "Can a Third Party Memorandum (TPM) be supplied? e.g. ISO27001/2, ISAE3402, etc."
         },
         "coin:privacy:certification_location": {
@@ -483,13 +469,11 @@
           "info": "The date until the Third Party Memorandum (TPM) is valid."
         },
         "coin:privacy:surfmarket_dpa_agreement": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "info": "Has the service provider agreed a Data Processing Agreement (DPA) with SURFmarket?"
         },
         "coin:privacy:surfnet_dpa_agreement": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "info": "Is the service provider willing to sign the SURF model Data Processing Agreement (DPA)?"
         },
         "coin:privacy:sn_dpa_why_not": {
@@ -497,8 +481,7 @@
           "info": "Explains why the SP answered no on the subject of the SURFmarket DPA."
         },
         "coin:privacy:privacy_policy": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "info": "Does the SP publish an applicable privacy policy on a web page?"
         },
         "coin:privacy:privacy_policy_url": {
@@ -520,14 +503,16 @@
           "default": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
           "info": "Select the Secure Hash Algorithm (SHA) to use for assertions sent by Engineblock to this service provider."
         },
+        "coin:sign_response": {
+          "type": "boolean",
+          "info": "Set to also directly sign the SAML Response element, in addition to the Assertion element that will always be signed."
+        },
         "coin:ss:supports_strong_authentication": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "info": "Set if StepUp is supported."
         },
         "coin:privacy:gdpr_is_in_wiki": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "info": "Set if the 'General Data Protection Regulation' (GDPR) is available on the SURF wiki. In Dutch known as 'Algemene Verordening Gegevensbescherming' (AVG). "
         },
         "coin:ss:license_status": {
@@ -542,11 +527,11 @@
         }
       },
       "patternProperties": {
-        "^name:(en|nl)$": {
+        "^name:(en|nl|pt)$": {
           "type": "string",
           "info": "Set the name of the service. Format: 'Service Name | Supplier'"
         },
-        "^displayName:(en|nl)$": {
+        "^displayName:(en|nl|pt)$": {
           "type": "string",
           "info": "Name as displayed in applications."
         },
@@ -563,21 +548,20 @@
           "type": "string",
           "info": "The type of service used in the facet search in dashboard."
         },
-        "^AssertionConsumerService:([0-9]{1}):Binding$": {
-          "$ref": "#/definitions/AssertionConsumerServiceBinding",
-          "multiplicity": 10,
+        "^AssertionConsumerService:([0-3]{0,1}[0-9]{1}):Binding$": {
+          "$ref": "#/definitions/AssertionConsumerService_Binding",
+          "multiplicity": 30,
           "info": "An Assertion Consumer Service (or ACS) the location at a ServiceProvider that accepts <samlp:Response> messages. The type of binding for this location can be selected from the pull-down."
         },
-        "^AssertionConsumerService:([0-9]{1}):Location$": {
+        "^AssertionConsumerService:([0-3]{0,1}[0-9]{1}):Location$": {
           "type": "string",
           "format": "url",
-          "multiplicity": 10,
+          "multiplicity": 30,
           "info": "An Assertion Consumer Service (or ACS) is the location at a ServiceProvider that accepts <samlp:Response> messages. A typical ACS location for an SP might look like this: https://data.example-service.nl/saml/saml2_acs/"
         },
-        "^AssertionConsumerService:([0-9]{1}):index$": {
-          "type": "string",
-          "format": "number",
-          "multiplicity": 10,
+        "^AssertionConsumerService:([0-3]{0,1}[0-9]{1}):index$": {
+          "type": "number",
+          "multiplicity": 30,
           "info": "An Assertion Consumer Service (or ACS) is the location at a ServiceProvider that accepts <samlp:Response> messages. With the index you can include additional <md:AssertionConsumerService> elements in the SAML 2.0 SP metadata with the same binding, each with its own unique index."
         },
         "^NameIDFormats:([0-2]{1})$": {
@@ -611,8 +595,7 @@
           "info": "The telephone number of the contact."
         },
         "^contacts:([0-3]{1}):isSirtfiSecurityContact$": {
-          "type": "string",
-          "format": "boolean",
+          "type": "boolean",
           "multiplicity": 4,
           "sibblingIndependent": true,
           "info": "Set the security contact for this service."

--- a/ansible/roles/manage-server-prod/files/metadata_export/saml20_sp.xml
+++ b/ansible/roles/manage-server-prod/files/metadata_export/saml20_sp.xml
@@ -3,234 +3,264 @@
                      xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
                      xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
                      entityID="{{entityid}}" validUntil="{{validUntil}}" cacheDuration="PT86400S">
-    <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
-        {{#UIInfoExtension}}
-        <md:Extensions>
-            <mdui:UIInfo>
-                {{#metaDataFields.name:en}}
-                <mdui:DisplayName xml:lang="en">{{metaDataFields.name:en}}</mdui:DisplayName>
-                {{/metaDataFields.name:en}}
-                {{#metaDataFields.name:nl}}
-                <mdui:DisplayName xml:lang="nl">{{metaDataFields.name:nl}}</mdui:DisplayName>
-                {{/metaDataFields.name:nl}}
-                {{#metaDataFields.description:en}}
-                <mdui:Description xml:lang="en">{{metaDataFields.description:en}}</mdui:Description>
-                {{/metaDataFields.description:en}}
-                {{#metaDataFields.description:nl}}
-                <mdui:Description xml:lang="nl">{{metaDataFields.description:nl}}</mdui:Description>
-                {{/metaDataFields.description:nl}}
-                {{#Logo}}
-                <mdui:Logo width="{{metaDataFields.logo:0:width}}" height="{{metaDataFields.logo:0:height}}" xml:lang="en">{{metaDataFields.logo:0:url}}</mdui:Logo>
-                {{/Logo}}
-            </mdui:UIInfo>
-        </md:Extensions>
-        {{/UIInfoExtension}}
-        {{#metaDataFields.certData}}
-        <md:KeyDescriptor use="signing">
-            <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-                <ds:X509Data>
-                    <ds:X509Certificate>{{metaDataFields.certData}}</ds:X509Certificate>
-                </ds:X509Data>
-            </ds:KeyInfo>
-        </md:KeyDescriptor>
-        <md:KeyDescriptor use="encryption">
-            <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-                <ds:X509Data>
-                    <ds:X509Certificate>{{metaDataFields.certData}}</ds:X509Certificate>
-                </ds:X509Data>
-            </ds:KeyInfo>
-        </md:KeyDescriptor>
-        {{/metaDataFields.certData}}
-        {{#metaDataFields.certData2}}
-        <md:KeyDescriptor use="signing">
-            <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-                <ds:X509Data>
-                    <ds:X509Certificate>{{metaDataFields.certData2}}</ds:X509Certificate>
-                </ds:X509Data>
-            </ds:KeyInfo>
-        </md:KeyDescriptor>
-        <md:KeyDescriptor use="encryption">
-            <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-                <ds:X509Data>
-                    <ds:X509Certificate>{{metaDataFields.certData2}}</ds:X509Certificate>
-                </ds:X509Data>
-            </ds:KeyInfo>
-        </md:KeyDescriptor>
-        {{/metaDataFields.certData2}}
-        {{#metaDataFields.certData3}}
-        <md:KeyDescriptor use="signing">
-            <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-                <ds:X509Data>
-                    <ds:X509Certificate>{{metaDataFields.certData3}}</ds:X509Certificate>
-                </ds:X509Data>
-            </ds:KeyInfo>
-        </md:KeyDescriptor>
-        <md:KeyDescriptor use="encryption">
-            <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-                <ds:X509Data>
-                    <ds:X509Certificate>{{metaDataFields.certData3}}</ds:X509Certificate>
-                </ds:X509Data>
-            </ds:KeyInfo>
-        </md:KeyDescriptor>
-        {{/metaDataFields.certData3}}
-        {{#metaDataFields.NameIDFormat}}
-        <md:NameIDFormat>{{metaDataFields.NameIDFormat}}</md:NameIDFormat>
-        {{/metaDataFields.NameIDFormat}}
-        {{#metaDataFields.AssertionConsumerService:0:Location}}
-        <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:0:Binding}}"
-                                     Location="{{metaDataFields.AssertionConsumerService:0:Location}}"
-                                     index="{{metaDataFields.AssertionConsumerService:0:index}}{{^metaDataFields.AssertionConsumerService:0:index}}0{{/metaDataFields.AssertionConsumerService:0:index}}"/>
-        {{/metaDataFields.AssertionConsumerService:0:Location}}
-        {{#metaDataFields.AssertionConsumerService:1:Location}}
-        <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:1:Binding}}"
-                                     Location="{{metaDataFields.AssertionConsumerService:1:Location}}"
-                                     index="{{metaDataFields.AssertionConsumerService:1:index}}{{^metaDataFields.AssertionConsumerService:1:index}}1{{/metaDataFields.AssertionConsumerService:1:index}}"/>
-        {{/metaDataFields.AssertionConsumerService:1:Location}}
-        {{#metaDataFields.AssertionConsumerService:2:Location}}
-        <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:2:Binding}}"
-                                     Location="{{metaDataFields.AssertionConsumerService:2:Location}}"
-                                     index="{{metaDataFields.AssertionConsumerService:2:index}}{{^metaDataFields.AssertionConsumerService:2:index}}2{{/metaDataFields.AssertionConsumerService:2:index}}"/>
-        {{/metaDataFields.AssertionConsumerService:2:Location}}
-        {{#metaDataFields.AssertionConsumerService:3:Location}}
-        <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:3:Binding}}"
-                                     Location="{{metaDataFields.AssertionConsumerService:3:Location}}"
-                                     index="{{metaDataFields.AssertionConsumerService:3:index}}{{^metaDataFields.AssertionConsumerService:3:index}}3{{/metaDataFields.AssertionConsumerService:3:index}}"/>
-        {{/metaDataFields.AssertionConsumerService:3:Location}}
-        {{#metaDataFields.AssertionConsumerService:4:Location}}
-        <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:4:Binding}}"
-                                     Location="{{metaDataFields.AssertionConsumerService:4:Location}}"
-                                     index="{{metaDataFields.AssertionConsumerService:4:index}}{{^metaDataFields.AssertionConsumerService:4:index}}4{{/metaDataFields.AssertionConsumerService:4:index}}"/>
-        {{/metaDataFields.AssertionConsumerService:4:Location}}
-        {{#metaDataFields.AssertionConsumerService:5:Location}}
-        <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:5:Binding}}"
-                                     Location="{{metaDataFields.AssertionConsumerService:5:Location}}"
-                                     index="{{metaDataFields.AssertionConsumerService:5:index}}{{^metaDataFields.AssertionConsumerService:5:index}}5{{/metaDataFields.AssertionConsumerService:5:index}}"/>
-        {{/metaDataFields.AssertionConsumerService:5:Location}}
-        {{#metaDataFields.AssertionConsumerService:6:Location}}
-        <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:6:Binding}}"
-                                     Location="{{metaDataFields.AssertionConsumerService:6:Location}}"
-                                     index="{{metaDataFields.AssertionConsumerService:6:index}}{{^metaDataFields.AssertionConsumerService:6:index}}6{{/metaDataFields.AssertionConsumerService:6:index}}"/>
-        {{/metaDataFields.AssertionConsumerService:6:Location}}
-        {{#metaDataFields.AssertionConsumerService:7:Location}}
-        <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:7:Binding}}"
-                                     Location="{{metaDataFields.AssertionConsumerService:7:Location}}"
-                                     index="{{metaDataFields.AssertionConsumerService:7:index}}{{^metaDataFields.AssertionConsumerService:7:index}}7{{/metaDataFields.AssertionConsumerService:7:index}}"/>
-        {{/metaDataFields.AssertionConsumerService:7:Location}}
-        {{#metaDataFields.AssertionConsumerService:8:Location}}
-        <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:8:Binding}}"
-                                     Location="{{metaDataFields.AssertionConsumerService:8:Location}}"
-                                     index="{{metaDataFields.AssertionConsumerService:8:index}}{{^metaDataFields.AssertionConsumerService:8:index}}8{{/metaDataFields.AssertionConsumerService:8:index}}"/>
-        {{/metaDataFields.AssertionConsumerService:8:Location}}
-        {{#metaDataFields.AssertionConsumerService:9:Location}}
-        <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:9:Binding}}"
-                                     Location="{{metaDataFields.AssertionConsumerService:9:Location}}"
-                                     index="{{metaDataFields.AssertionConsumerService:9:index}}{{^metaDataFields.AssertionConsumerService:9:index}}9{{/metaDataFields.AssertionConsumerService:9:index}}"/>
-        {{/metaDataFields.AssertionConsumerService:9:Location}}
-        {{#AttributeConsumingService}}
-        <md:AttributeConsumingService index="0">
-            {{#metaDataFields.name:en}}
-            <md:ServiceName xml:lang="en">{{metaDataFields.name:en}}</md:ServiceName>
-            {{/metaDataFields.name:en}}
-            {{#metaDataFields.name:nl}}
-            <md:ServiceName xml:lang="nl">{{metaDataFields.name:nl}}</md:ServiceName>
-            {{/metaDataFields.name:nl}}
-            {{#metaDataFields.description:en}}
-            <md:ServiceDescription xml:lang="en">{{metaDataFields.description:en}}</md:ServiceDescription>
-            {{/metaDataFields.description:en}}
-            {{#metaDataFields.description:nl}}
-            <md:ServiceDescription xml:lang="nl">{{metaDataFields.description:nl}}</md:ServiceDescription>
-            {{/metaDataFields.description:nl}}
-            {{#requestedAttributes}}
-            <md:RequestedAttribute Name="{{toString}}"/>
-            {{/requestedAttributes}}
-        </md:AttributeConsumingService>
-        {{/AttributeConsumingService}}
-    </md:SPSSODescriptor>
-    {{#metaDataFields.OrganizationInfo}}
-    <md:Organization>
-        {{#metaDataFields.OrganizationName:en}}
-        <md:OrganizationName xml:lang="en">{{metaDataFields.OrganizationName:en}}</md:OrganizationName>
-        {{/metaDataFields.OrganizationName:en}}
-        {{#metaDataFields.OrganizationName:nl}}
-        <md:OrganizationName xml:lang="nl">{{metaDataFields.OrganizationName:nl}}</md:OrganizationName>
-        {{/metaDataFields.OrganizationName:nl}}
-        {{#metaDataFields.OrganizationDisplayName:en}}
-        <md:OrganizationDisplayName xml:lang="en">{{metaDataFields.OrganizationDisplayName:en}}</md:OrganizationDisplayName>
-        {{/metaDataFields.OrganizationDisplayName:en}}
-        {{#metaDataFields.OrganizationDisplayName:nl}}
-        <md:OrganizationDisplayName xml:lang="nl">{{metaDataFields.OrganizationDisplayName:nl}}</md:OrganizationDisplayName>
-        {{/metaDataFields.OrganizationDisplayName:nl}}
-        {{#metaDataFields.OrganizationURL:en}}
-        <md:OrganizationURL xml:lang="en">{{metaDataFields.OrganizationURL:en}}</md:OrganizationURL>
-        {{/metaDataFields.OrganizationURL:en}}
-        {{#metaDataFields.OrganizationURL:nl}}
-        <md:OrganizationURL xml:lang="nl">{{metaDataFields.OrganizationURL:nl}}</md:OrganizationURL>
-        {{/metaDataFields.OrganizationURL:nl}}
-    </md:Organization>
-    {{/metaDataFields.OrganizationInfo}}
-    {{#metaDataFields.contacts:0:contactType}}
-    <md:ContactPerson contactType="{{metaDataFields.contacts:0:contactType}}">
-        {{#metaDataFields.contacts:0:givenName}}
-        <md:GivenName>{{metaDataFields.contacts:0:givenName}}</md:GivenName>
-        {{/metaDataFields.contacts:0:givenName}}
-        {{#metaDataFields.contacts:0:surName}}
-        <md:SurName>{{metaDataFields.contacts:0:surName}}</md:SurName>
-        {{/metaDataFields.contacts:0:surName}}
-        {{#metaDataFields.contacts:0:emailAddress}}
-        <md:EmailAddress>mailto:{{metaDataFields.contacts:0:emailAddress}}</md:EmailAddress>
-        {{/metaDataFields.contacts:0:emailAddress}}
-        {{#metaDataFields.contacts:0:telephoneNumber}}
-        <md:TelephoneNumber>{{metaDataFields.contacts:0:telephoneNumber}}</md:TelephoneNumber>
-        {{/metaDataFields.contacts:0:telephoneNumber}}
-    </md:ContactPerson>
-    {{/metaDataFields.contacts:0:contactType}}
-    {{#metaDataFields.contacts:1:contactType}}
-    <md:ContactPerson contactType="{{metaDataFields.contacts:1:contactType}}">
-        {{#metaDataFields.contacts:1:givenName}}
-        <md:GivenName>{{metaDataFields.contacts:1:givenName}}</md:GivenName>
-        {{/metaDataFields.contacts:1:givenName}}
-        {{#metaDataFields.contacts:1:surName}}
-        <md:SurName>{{metaDataFields.contacts:1:surName}}</md:SurName>
-        {{/metaDataFields.contacts:1:surName}}
-        {{#metaDataFields.contacts:1:emailAddress}}
-        <md:EmailAddress>mailto:{{metaDataFields.contacts:1:emailAddress}}</md:EmailAddress>
-        {{/metaDataFields.contacts:1:emailAddress}}
-        {{#metaDataFields.contacts:1:telephoneNumber}}
-        <md:TelephoneNumber>{{metaDataFields.contacts:1:telephoneNumber}}</md:TelephoneNumber>
-        {{/metaDataFields.contacts:1:telephoneNumber}}
-    </md:ContactPerson>
-    {{/metaDataFields.contacts:1:contactType}}
-    {{#metaDataFields.contacts:2:contactType}}
-    <md:ContactPerson contactType="{{metaDataFields.contacts:2:contactType}}">
-        {{#metaDataFields.contacts:2:givenName}}
-        <md:GivenName>{{metaDataFields.contacts:2:givenName}}</md:GivenName>
-        {{/metaDataFields.contacts:2:givenName}}
-        {{#metaDataFields.contacts:2:surName}}
-        <md:SurName>{{metaDataFields.contacts:2:surName}}</md:SurName>
-        {{/metaDataFields.contacts:2:surName}}
-        {{#metaDataFields.contacts:2:emailAddress}}
-        <md:EmailAddress>mailto:{{metaDataFields.contacts:2:emailAddress}}</md:EmailAddress>
-        {{/metaDataFields.contacts:2:emailAddress}}
-        {{#metaDataFields.contacts:2:telephoneNumber}}
-        <md:TelephoneNumber>{{metaDataFields.contacts:2:telephoneNumber}}</md:TelephoneNumber>
-        {{/metaDataFields.contacts:2:telephoneNumber}}
-    </md:ContactPerson>
-    {{/metaDataFields.contacts:2:contactType}}
-    {{#metaDataFields.contacts:3:contactType}}
-    <md:ContactPerson contactType="{{metaDataFields.contacts:3:contactType}}">
-        {{#metaDataFields.contacts:3:givenName}}
-        <md:GivenName>{{metaDataFields.contacts:3:givenName}}</md:GivenName>
-        {{/metaDataFields.contacts:3:givenName}}
-        {{#metaDataFields.contacts:3:surName}}
-        <md:SurName>{{metaDataFields.contacts:3:surName}}</md:SurName>
-        {{/metaDataFields.contacts:3:surName}}
-        {{#metaDataFields.contacts:3:emailAddress}}
-        <md:EmailAddress>mailto:{{metaDataFields.contacts:3:emailAddress}}</md:EmailAddress>
-        {{/metaDataFields.contacts:3:emailAddress}}
-        {{#metaDataFields.contacts:3:telephoneNumber}}
-        <md:TelephoneNumber>{{metaDataFields.contacts:3:telephoneNumber}}</md:TelephoneNumber>
-        {{/metaDataFields.contacts:3:telephoneNumber}}
-    </md:ContactPerson>
-    {{/metaDataFields.contacts:3:contactType}}
+  <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    {{#UIInfoExtension}}
+    <md:Extensions>
+      <mdui:UIInfo>
+        {{#metaDataFields.name:en}}
+        <mdui:DisplayName xml:lang="en">{{metaDataFields.name:en}}</mdui:DisplayName>
+        {{/metaDataFields.name:en}}
+        {{#metaDataFields.name:nl}}
+        <mdui:DisplayName xml:lang="nl">{{metaDataFields.name:nl}}</mdui:DisplayName>
+        {{/metaDataFields.name:nl}}
+        {{#metaDataFields.description:en}}
+        <mdui:Description xml:lang="en">{{metaDataFields.description:en}}</mdui:Description>
+        {{/metaDataFields.description:en}}
+        {{#metaDataFields.description:nl}}
+        <mdui:Description xml:lang="nl">{{metaDataFields.description:nl}}</mdui:Description>
+        {{/metaDataFields.description:nl}}
+        {{#Logo}}
+        <mdui:Logo width="{{metaDataFields.logo:0:width}}" height="{{metaDataFields.logo:0:height}}" xml:lang="en">{{metaDataFields.logo:0:url}}</mdui:Logo>
+        {{/Logo}}
+      </mdui:UIInfo>
+    </md:Extensions>
+    {{/UIInfoExtension}}
+    {{#metaDataFields.certData}}
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>{{metaDataFields.certData}}</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:KeyDescriptor use="encryption">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>{{metaDataFields.certData}}</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    {{/metaDataFields.certData}}
+    {{#metaDataFields.certData2}}
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>{{metaDataFields.certData2}}</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:KeyDescriptor use="encryption">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>{{metaDataFields.certData2}}</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    {{/metaDataFields.certData2}}
+    {{#metaDataFields.certData3}}
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>{{metaDataFields.certData3}}</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:KeyDescriptor use="encryption">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>{{metaDataFields.certData3}}</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    {{/metaDataFields.certData3}}
+    {{#metaDataFields.NameIDFormat}}
+    <md:NameIDFormat>{{metaDataFields.NameIDFormat}}</md:NameIDFormat>
+    {{/metaDataFields.NameIDFormat}}
+    {{#metaDataFields.AssertionConsumerService:0:Location}}
+    <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:0:Binding}}"
+                                 Location="{{metaDataFields.AssertionConsumerService:0:Location}}"
+                                 index="{{metaDataFields.AssertionConsumerService:0:index}}{{^metaDataFields.AssertionConsumerService:0:index}}0{{/metaDataFields.AssertionConsumerService:0:index}}"/>
+    {{/metaDataFields.AssertionConsumerService:0:Location}}
+    {{#metaDataFields.AssertionConsumerService:1:Location}}
+    <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:1:Binding}}"
+                                 Location="{{metaDataFields.AssertionConsumerService:1:Location}}"
+                                 index="{{metaDataFields.AssertionConsumerService:1:index}}{{^metaDataFields.AssertionConsumerService:1:index}}1{{/metaDataFields.AssertionConsumerService:1:index}}"/>
+    {{/metaDataFields.AssertionConsumerService:1:Location}}
+    {{#metaDataFields.AssertionConsumerService:2:Location}}
+    <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:2:Binding}}"
+                                 Location="{{metaDataFields.AssertionConsumerService:2:Location}}"
+                                 index="{{metaDataFields.AssertionConsumerService:2:index}}{{^metaDataFields.AssertionConsumerService:2:index}}2{{/metaDataFields.AssertionConsumerService:2:index}}"/>
+    {{/metaDataFields.AssertionConsumerService:2:Location}}
+    {{#metaDataFields.AssertionConsumerService:3:Location}}
+    <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:3:Binding}}"
+                                 Location="{{metaDataFields.AssertionConsumerService:3:Location}}"
+                                 index="{{metaDataFields.AssertionConsumerService:3:index}}{{^metaDataFields.AssertionConsumerService:3:index}}3{{/metaDataFields.AssertionConsumerService:3:index}}"/>
+    {{/metaDataFields.AssertionConsumerService:3:Location}}
+    {{#metaDataFields.AssertionConsumerService:4:Location}}
+    <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:4:Binding}}"
+                                 Location="{{metaDataFields.AssertionConsumerService:4:Location}}"
+                                 index="{{metaDataFields.AssertionConsumerService:4:index}}{{^metaDataFields.AssertionConsumerService:4:index}}4{{/metaDataFields.AssertionConsumerService:4:index}}"/>
+    {{/metaDataFields.AssertionConsumerService:4:Location}}
+    {{#metaDataFields.AssertionConsumerService:5:Location}}
+    <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:5:Binding}}"
+                                 Location="{{metaDataFields.AssertionConsumerService:5:Location}}"
+                                 index="{{metaDataFields.AssertionConsumerService:5:index}}{{^metaDataFields.AssertionConsumerService:5:index}}5{{/metaDataFields.AssertionConsumerService:5:index}}"/>
+    {{/metaDataFields.AssertionConsumerService:5:Location}}
+    {{#metaDataFields.AssertionConsumerService:6:Location}}
+    <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:6:Binding}}"
+                                 Location="{{metaDataFields.AssertionConsumerService:6:Location}}"
+                                 index="{{metaDataFields.AssertionConsumerService:6:index}}{{^metaDataFields.AssertionConsumerService:6:index}}6{{/metaDataFields.AssertionConsumerService:6:index}}"/>
+    {{/metaDataFields.AssertionConsumerService:6:Location}}
+    {{#metaDataFields.AssertionConsumerService:7:Location}}
+    <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:7:Binding}}"
+                                 Location="{{metaDataFields.AssertionConsumerService:7:Location}}"
+                                 index="{{metaDataFields.AssertionConsumerService:7:index}}{{^metaDataFields.AssertionConsumerService:7:index}}7{{/metaDataFields.AssertionConsumerService:7:index}}"/>
+    {{/metaDataFields.AssertionConsumerService:7:Location}}
+    {{#metaDataFields.AssertionConsumerService:8:Location}}
+    <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:8:Binding}}"
+                                 Location="{{metaDataFields.AssertionConsumerService:8:Location}}"
+                                 index="{{metaDataFields.AssertionConsumerService:8:index}}{{^metaDataFields.AssertionConsumerService:8:index}}8{{/metaDataFields.AssertionConsumerService:8:index}}"/>
+    {{/metaDataFields.AssertionConsumerService:8:Location}}
+    {{#metaDataFields.AssertionConsumerService:9:Location}}
+    <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:9:Binding}}"
+                                 Location="{{metaDataFields.AssertionConsumerService:9:Location}}"
+                                 index="{{metaDataFields.AssertionConsumerService:9:index}}{{^metaDataFields.AssertionConsumerService:9:index}}9{{/metaDataFields.AssertionConsumerService:9:index}}"/>
+    {{/metaDataFields.AssertionConsumerService:9:Location}}
+    {{#metaDataFields.AssertionConsumerService:10:Location}}
+    <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:10:Binding}}"
+                                 Location="{{metaDataFields.AssertionConsumerService:10:Location}}"
+                                 index="{{metaDataFields.AssertionConsumerService:10:index}}{{^metaDataFields.AssertionConsumerService:10:index}}10{{/metaDataFields.AssertionConsumerService:10:index}}"/>
+    {{/metaDataFields.AssertionConsumerService:10:Location}}
+    {{#metaDataFields.AssertionConsumerService:11:Location}}
+    <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:11:Binding}}"
+                                 Location="{{metaDataFields.AssertionConsumerService:11:Location}}"
+                                 index="{{metaDataFields.AssertionConsumerService:11:index}}{{^metaDataFields.AssertionConsumerService:11:index}}11{{/metaDataFields.AssertionConsumerService:11:index}}"/>
+    {{/metaDataFields.AssertionConsumerService:11:Location}}
+    {{#metaDataFields.AssertionConsumerService:12:Location}}
+    <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:12:Binding}}"
+                                 Location="{{metaDataFields.AssertionConsumerService:12:Location}}"
+                                 index="{{metaDataFields.AssertionConsumerService:12:index}}{{^metaDataFields.AssertionConsumerService:12:index}}12{{/metaDataFields.AssertionConsumerService:12:index}}"/>
+    {{/metaDataFields.AssertionConsumerService:12:Location}}
+    {{#metaDataFields.AssertionConsumerService:13:Location}}
+    <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:13:Binding}}"
+                                 Location="{{metaDataFields.AssertionConsumerService:13:Location}}"
+                                 index="{{metaDataFields.AssertionConsumerService:13:index}}{{^metaDataFields.AssertionConsumerService:13:index}}13{{/metaDataFields.AssertionConsumerService:13:index}}"/>
+    {{/metaDataFields.AssertionConsumerService:13:Location}}
+    {{#metaDataFields.AssertionConsumerService:14:Location}}
+    <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:14:Binding}}"
+                                 Location="{{metaDataFields.AssertionConsumerService:14:Location}}"
+                                 index="{{metaDataFields.AssertionConsumerService:14:index}}{{^metaDataFields.AssertionConsumerService:14:index}}14{{/metaDataFields.AssertionConsumerService:14:index}}"/>
+    {{/metaDataFields.AssertionConsumerService:14:Location}}
+    {{#metaDataFields.AssertionConsumerService:15:Location}}
+    <md:AssertionConsumerService Binding="{{metaDataFields.AssertionConsumerService:15:Binding}}"
+                                 Location="{{metaDataFields.AssertionConsumerService:15:Location}}"
+                                 index="{{metaDataFields.AssertionConsumerService:15:index}}{{^metaDataFields.AssertionConsumerService:15:index}}15{{/metaDataFields.AssertionConsumerService:15:index}}"/>
+    {{/metaDataFields.AssertionConsumerService:15:Location}}
+    {{#AttributeConsumingService}}
+    <md:AttributeConsumingService index="0">
+      {{#metaDataFields.name:en}}
+      <md:ServiceName xml:lang="en">{{metaDataFields.name:en}}</md:ServiceName>
+      {{/metaDataFields.name:en}}
+      {{#metaDataFields.name:nl}}
+      <md:ServiceName xml:lang="nl">{{metaDataFields.name:nl}}</md:ServiceName>
+      {{/metaDataFields.name:nl}}
+      {{#metaDataFields.description:en}}
+      <md:ServiceDescription xml:lang="en">{{metaDataFields.description:en}}</md:ServiceDescription>
+      {{/metaDataFields.description:en}}
+      {{#metaDataFields.description:nl}}
+      <md:ServiceDescription xml:lang="nl">{{metaDataFields.description:nl}}</md:ServiceDescription>
+      {{/metaDataFields.description:nl}}
+      {{#requestedAttributes}}
+      <md:RequestedAttribute Name="{{toString}}"/>
+      {{/requestedAttributes}}
+    </md:AttributeConsumingService>
+    {{/AttributeConsumingService}}
+  </md:SPSSODescriptor>
+  {{#metaDataFields.OrganizationInfo}}
+  <md:Organization>
+    {{#metaDataFields.OrganizationName:en}}
+    <md:OrganizationName xml:lang="en">{{metaDataFields.OrganizationName:en}}</md:OrganizationName>
+    {{/metaDataFields.OrganizationName:en}}
+    {{#metaDataFields.OrganizationName:nl}}
+    <md:OrganizationName xml:lang="nl">{{metaDataFields.OrganizationName:nl}}</md:OrganizationName>
+    {{/metaDataFields.OrganizationName:nl}}
+    {{#metaDataFields.OrganizationDisplayName:en}}
+    <md:OrganizationDisplayName xml:lang="en">{{metaDataFields.OrganizationDisplayName:en}}</md:OrganizationDisplayName>
+    {{/metaDataFields.OrganizationDisplayName:en}}
+    {{#metaDataFields.OrganizationDisplayName:nl}}
+    <md:OrganizationDisplayName xml:lang="nl">{{metaDataFields.OrganizationDisplayName:nl}}</md:OrganizationDisplayName>
+    {{/metaDataFields.OrganizationDisplayName:nl}}
+    {{#metaDataFields.OrganizationURL:en}}
+    <md:OrganizationURL xml:lang="en">{{metaDataFields.OrganizationURL:en}}</md:OrganizationURL>
+    {{/metaDataFields.OrganizationURL:en}}
+    {{#metaDataFields.OrganizationURL:nl}}
+    <md:OrganizationURL xml:lang="nl">{{metaDataFields.OrganizationURL:nl}}</md:OrganizationURL>
+    {{/metaDataFields.OrganizationURL:nl}}
+  </md:Organization>
+  {{/metaDataFields.OrganizationInfo}}
+  {{#metaDataFields.contacts:0:contactType}}
+  <md:ContactPerson contactType="{{metaDataFields.contacts:0:contactType}}">
+    {{#metaDataFields.contacts:0:givenName}}
+    <md:GivenName>{{metaDataFields.contacts:0:givenName}}</md:GivenName>
+    {{/metaDataFields.contacts:0:givenName}}
+    {{#metaDataFields.contacts:0:surName}}
+    <md:SurName>{{metaDataFields.contacts:0:surName}}</md:SurName>
+    {{/metaDataFields.contacts:0:surName}}
+    {{#metaDataFields.contacts:0:emailAddress}}
+    <md:EmailAddress>mailto:{{metaDataFields.contacts:0:emailAddress}}</md:EmailAddress>
+    {{/metaDataFields.contacts:0:emailAddress}}
+    {{#metaDataFields.contacts:0:telephoneNumber}}
+    <md:TelephoneNumber>{{metaDataFields.contacts:0:telephoneNumber}}</md:TelephoneNumber>
+    {{/metaDataFields.contacts:0:telephoneNumber}}
+  </md:ContactPerson>
+  {{/metaDataFields.contacts:0:contactType}}
+  {{#metaDataFields.contacts:1:contactType}}
+  <md:ContactPerson contactType="{{metaDataFields.contacts:1:contactType}}">
+    {{#metaDataFields.contacts:1:givenName}}
+    <md:GivenName>{{metaDataFields.contacts:1:givenName}}</md:GivenName>
+    {{/metaDataFields.contacts:1:givenName}}
+    {{#metaDataFields.contacts:1:surName}}
+    <md:SurName>{{metaDataFields.contacts:1:surName}}</md:SurName>
+    {{/metaDataFields.contacts:1:surName}}
+    {{#metaDataFields.contacts:1:emailAddress}}
+    <md:EmailAddress>mailto:{{metaDataFields.contacts:1:emailAddress}}</md:EmailAddress>
+    {{/metaDataFields.contacts:1:emailAddress}}
+    {{#metaDataFields.contacts:1:telephoneNumber}}
+    <md:TelephoneNumber>{{metaDataFields.contacts:1:telephoneNumber}}</md:TelephoneNumber>
+    {{/metaDataFields.contacts:1:telephoneNumber}}
+  </md:ContactPerson>
+  {{/metaDataFields.contacts:1:contactType}}
+  {{#metaDataFields.contacts:2:contactType}}
+  <md:ContactPerson contactType="{{metaDataFields.contacts:2:contactType}}">
+    {{#metaDataFields.contacts:2:givenName}}
+    <md:GivenName>{{metaDataFields.contacts:2:givenName}}</md:GivenName>
+    {{/metaDataFields.contacts:2:givenName}}
+    {{#metaDataFields.contacts:2:surName}}
+    <md:SurName>{{metaDataFields.contacts:2:surName}}</md:SurName>
+    {{/metaDataFields.contacts:2:surName}}
+    {{#metaDataFields.contacts:2:emailAddress}}
+    <md:EmailAddress>mailto:{{metaDataFields.contacts:2:emailAddress}}</md:EmailAddress>
+    {{/metaDataFields.contacts:2:emailAddress}}
+    {{#metaDataFields.contacts:2:telephoneNumber}}
+    <md:TelephoneNumber>{{metaDataFields.contacts:2:telephoneNumber}}</md:TelephoneNumber>
+    {{/metaDataFields.contacts:2:telephoneNumber}}
+  </md:ContactPerson>
+  {{/metaDataFields.contacts:2:contactType}}
+  {{#metaDataFields.contacts:3:contactType}}
+  <md:ContactPerson contactType="{{metaDataFields.contacts:3:contactType}}">
+    {{#metaDataFields.contacts:3:givenName}}
+    <md:GivenName>{{metaDataFields.contacts:3:givenName}}</md:GivenName>
+    {{/metaDataFields.contacts:3:givenName}}
+    {{#metaDataFields.contacts:3:surName}}
+    <md:SurName>{{metaDataFields.contacts:3:surName}}</md:SurName>
+    {{/metaDataFields.contacts:3:surName}}
+    {{#metaDataFields.contacts:3:emailAddress}}
+    <md:EmailAddress>mailto:{{metaDataFields.contacts:3:emailAddress}}</md:EmailAddress>
+    {{/metaDataFields.contacts:3:emailAddress}}
+    {{#metaDataFields.contacts:3:telephoneNumber}}
+    <md:TelephoneNumber>{{metaDataFields.contacts:3:telephoneNumber}}</md:TelephoneNumber>
+    {{/metaDataFields.contacts:3:telephoneNumber}}
+  </md:ContactPerson>
+  {{/metaDataFields.contacts:3:contactType}}
 
 </md:EntityDescriptor>

--- a/ansible/roles/manage-server-prod/files/metadata_templates/oidc10_rp.template.json
+++ b/ansible/roles/manage-server-prod/files/metadata_templates/oidc10_rp.template.json
@@ -1,0 +1,20 @@
+{
+  "entityid": "",
+  "state": "testaccepted",
+  "allowedall": true,
+  "arp": {
+    "enabled": false,
+    "attributes": {}
+  },
+  "metaDataFields": {
+    "name:en": "",
+    "secret": "",
+    "redirectUrls": [],
+    "scopes": ["openid"],
+    "grants": ["authorization_code"],
+    "NameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+    "isResourceServer": false
+  },
+  "allowedEntities": [],
+  "allowedResourceServers": []
+}

--- a/ansible/roles/manage-server-prod/templates/application.yml.j2
+++ b/ansible/roles/manage-server-prod/templates/application.yml.j2
@@ -17,17 +17,26 @@ server:
 features: {{ manage.features }}
 
 push:
-  url: https://{{ engine_api_domain }}/api/connections
-  user: {{ engine_api_metadata_push_user }}
-  password: {{ engine_api_metadata_push_password }}
-  name: {{ instance_name }} EngineBlock
-  exclude_edugain_imports: {{ manage_exclude_edugain_imports_in_push }}
+  eb:
+    url: https://{{ engine_api_domain }}/api/connections
+    user: {{ engine_api_metadata_push_user }}
+    password: {{ engine_api_metadata_push_password }}
+    name: {{ instance_name }} EngineBlock
+    exclude_edugain_imports: {{ manage_exclude_edugain_imports_in_push }}
+    exclude_oidc_rp: {{ manage_exclude_oidc_rp_imports_in_push }}
+  oidc:
+    url: https://oidcng.{{ base_domain }}/manage/connections
+    user: manage
+    name: {{ manage.oidcng_name }}
+    password: {{ oidcng_api_metadata_push_password }}
+    enabled: {{ manage.oidc_push_enabled }}
 
 product:
   name: Manage
   organization: {{ instance_name }}
   service_provider_feed_url: {{ manage_service_provider_feed_url }}
-
+  supported_languages: {{ supported_language_codes }}
+  show_oidc_rp: {{ manage_show_oidc_rp_tab }}
 
 metadata_configuration_path: file://{{ manage_dir }}/metadata_configuration
 metadata_templates_path: file://{{ manage_dir }}/metadata_templates

--- a/ansible/roles/manage-server-prod/templates/application.yml.j2
+++ b/ansible/roles/manage-server-prod/templates/application.yml.j2
@@ -29,7 +29,7 @@ push:
     user: manage
     name: {{ manage.oidcng_name }}
     password: {{ oidcng_api_metadata_push_password }}
-    enabled: {{ manage.oidc_push_enabled }}
+    enabled: true
 
 product:
   name: Manage


### PR DESCRIPTION
The Ansible roles in this project contain a copy of the manage role in OpenConext-deploy. This is needed to create a second Manage instance on the development VM.  Some changes have been made in OpenConext-deploy to accommodate the provisioning of OIDCNG clients.  This PR merges the changes from OpenConext-deploy back to the Ansible role "manage-prod"