### PR TITLE
Fix the statuscode for switch to nonexistent service

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Exception/ServiceNotFoundException.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Exception/ServiceNotFoundException.php
@@ -18,8 +18,8 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Exception;
 
-use Exception;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-class ServiceNotFoundException extends Exception
+class ServiceNotFoundException extends NotFoundHttpException
 {
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Command/Service/SelectServiceCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Command/Service/SelectServiceCommand.php
@@ -29,18 +29,18 @@ class SelectServiceCommand implements Command
     private $selectedServiceId;
 
     /**
-     * @param string $selectedServiceId ID of selected service
-     */
-    public function __construct($selectedServiceId)
-    {
-        $this->selectedServiceId = $selectedServiceId;
-    }
-
-    /**
      * @return string
      */
     public function getSelectedServiceId()
     {
         return $this->selectedServiceId;
+    }
+
+    /**
+     * @param string $selectedServiceId
+     */
+    public function setSelectedServiceId($selectedServiceId)
+    {
+        $this->selectedServiceId = $selectedServiceId;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/CommandHandler/Service/ResetServiceCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/CommandHandler/Service/ResetServiceCommandHandler.php
@@ -40,6 +40,6 @@ class ResetServiceCommandHandler implements CommandHandler
      */
     public function handle(ResetServiceCommand $command)
     {
-        $this->service->setSelectedServiceId(null);
+        $this->service->resetService();
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/CommandHandler/Service/SelectServiceCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/CommandHandler/Service/SelectServiceCommandHandler.php
@@ -19,8 +19,10 @@
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\CommandHandler\Service;
 
 use Surfnet\ServiceProviderDashboard\Application\CommandHandler\CommandHandler;
+use Surfnet\ServiceProviderDashboard\Application\Exception\ServiceNotFoundException;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Command\Service\SelectServiceCommand;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AuthorizationService;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class SelectServiceCommandHandler implements CommandHandler
 {
@@ -39,6 +41,10 @@ class SelectServiceCommandHandler implements CommandHandler
      */
     public function handle(SelectServiceCommand $command)
     {
-        $this->service->setSelectedServiceId($command->getSelectedServiceId());
+        try {
+            $this->service->changeActiveService($command->getSelectedServiceId());
+        } catch (ServiceNotFoundException $exception) {
+            throw new NotFoundHttpException($exception->getMessage());
+        }
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/CommandHandler/Service/SelectServiceCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/CommandHandler/Service/SelectServiceCommandHandler.php
@@ -41,10 +41,6 @@ class SelectServiceCommandHandler implements CommandHandler
      */
     public function handle(SelectServiceCommand $command)
     {
-        try {
-            $this->service->changeActiveService($command->getSelectedServiceId());
-        } catch (ServiceNotFoundException $exception) {
-            throw new NotFoundHttpException($exception->getMessage());
-        }
+        $this->service->changeActiveService($command->getSelectedServiceId());
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityAclController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityAclController.php
@@ -81,7 +81,7 @@ class EntityAclController extends Controller
      */
     public function aclAction(Request $request, $serviceId, $id)
     {
-        $service = $this->authorizationService->getServiceById($serviceId);
+        $service = $this->authorizationService->changeActiveService($serviceId);
         $entity = $this->entityService->getEntityByIdAndTarget($id, Entity::ENVIRONMENT_TEST, $service);
 
         $selectedIdps = $this->entityAclService->getAllowedIdpsFromEntity($entity);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
@@ -62,7 +62,7 @@ class EntityCreateController extends Controller
         $command = new ChooseEntityTypeCommand();
         $form = $this->createForm(ChooseEntityTypeType::class, $command);
 
-        $service = $this->authorizationService->getServiceById($serviceId);
+        $service = $this->authorizationService->changeActiveService($serviceId);
 
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
@@ -101,7 +101,7 @@ class EntityCreateController extends Controller
         $flashBag = $this->get('session')->getFlashBag();
         $flashBag->clear();
 
-        $service = $this->authorizationService->getServiceById($serviceId);
+        $service = $this->authorizationService->changeActiveService($serviceId);
 
         if (!$service->isProductionEntitiesEnabled() &&
             $targetEnvironment !== Entity::ENVIRONMENT_TEST
@@ -196,7 +196,7 @@ class EntityCreateController extends Controller
         $flashBag = $this->get('session')->getFlashBag();
         $flashBag->clear();
 
-        $service = $this->authorizationService->getServiceById($serviceId);
+        $service = $this->authorizationService->changeActiveService($serviceId);
 
         $entity = $this->loadEntityService->load(null, $manageId, $service, $sourceEnvironment, $targetEnvironment);
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityDeleteController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityDeleteController.php
@@ -151,7 +151,7 @@ class EntityDeleteController extends Controller
                 $this->commandBus->handle($command);
             }
 
-            $service = $this->authorizationService->getServiceById($serviceId);
+            $service = $this->authorizationService->changeActiveService($serviceId);
             return $this->redirectToRoute('entity_list', ['serviceId' => $service->getId()]);
         }
 
@@ -206,7 +206,7 @@ class EntityDeleteController extends Controller
                     )
                 );
             }
-            $service = $this->authorizationService->getServiceById($serviceId);
+            $service = $this->authorizationService->changeActiveService($serviceId);
             return $this->redirectToRoute('entity_list', ['serviceId' => $service->getId()]);
         }
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityDetailController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityDetailController.php
@@ -57,7 +57,7 @@ class EntityDetailController extends Controller
      */
     public function detailAction($id, $serviceId, $manageTarget)
     {
-        $service = $this->authorizationService->getServiceById($serviceId);
+        $service = $this->authorizationService->changeActiveService($serviceId);
 
         // First try to read the entity from the local storage
         $entity = $this->entityService->getEntityById($id);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityListController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityListController.php
@@ -71,7 +71,7 @@ class EntityListController extends Controller
      */
     public function listAction($serviceId)
     {
-        $service = $this->authorizationService->getServiceById($serviceId);
+        $service = $this->authorizationService->changeActiveService($serviceId);
 
         $entityList = $this->entityService->getEntityListForService($service);
         $productionEntitiesEnabled = $service->isProductionEntitiesEnabled();

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/PrivacyQuestionsController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/PrivacyQuestionsController.php
@@ -68,7 +68,7 @@ class PrivacyQuestionsController extends Controller
      */
     public function privacyAction($serviceId)
     {
-        $service = $this->authorizationService->getServiceById($serviceId);
+        $service = $this->authorizationService->changeActiveService($serviceId);
 
         if (!$this->authorizationService->hasActivatedPrivacyQuestions()) {
             throw $this->createNotFoundException('Privacy questions are disabled');
@@ -92,7 +92,7 @@ class PrivacyQuestionsController extends Controller
      */
     public function createAction(Request $request, $serviceId)
     {
-        $service = $this->authorizationService->getServiceById($serviceId);
+        $service = $this->authorizationService->changeActiveService($serviceId);
 
         $command = PrivacyQuestionsCommand::fromService($service);
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -179,7 +179,7 @@ class ServiceController extends Controller
      */
     public function editAction(Request $request, $serviceId)
     {
-        $service = $this->authorizationService->getServiceById($serviceId);
+        $service = $this->authorizationService->changeActiveService($serviceId);
 
         $this->get('session')->getFlashBag()->clear();
         /** @var LoggerInterface $logger */
@@ -237,7 +237,7 @@ class ServiceController extends Controller
      */
     public function deleteAction(Request $request, $serviceId)
     {
-        $service = $this->authorizationService->getServiceById($serviceId);
+        $service = $this->authorizationService->changeActiveService($serviceId);
 
         $form = $this->createForm(DeleteServiceType::class);
         $form->handleRequest($request);
@@ -294,7 +294,7 @@ class ServiceController extends Controller
      */
     public function adminOverviewAction($serviceId)
     {
-        $service = $this->authorizationService->getServiceById($serviceId);
+        $service = $this->authorizationService->changeActiveService($serviceId);
         $entityList = $this->entityService->getEntityListForService($service);
         $serviceList = new ServiceList([Service::fromService($service, $entityList, $this->router)]);
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Service/ServiceSwitcherType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Service/ServiceSwitcherType.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service;
+
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Command\Service\SelectServiceCommand;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AuthorizationService;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ServiceSwitcherType extends AbstractType
+{
+    /**
+     * @var AuthorizationService
+     */
+    private $authorizationService;
+
+    public function __construct(AuthorizationService $authorizationService)
+    {
+        $this->authorizationService = $authorizationService;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $list = $this->authorizationService->getAllowedServiceNamesById();
+        if (count($list) <= 1) {
+            return '';
+        }
+
+        $selected = $this->authorizationService->getActiveServiceId();
+
+        $builder->add(
+            'selected_service_id',
+            ChoiceType::class,
+            [
+                'choices' => array_flip($list),
+                'expanded' => false,
+                'multiple' => false,
+                'data' => $selected,
+                'required' => false,
+            ]
+        );
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => SelectServiceCommand::class
+        ));
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -408,3 +408,8 @@ services:
         arguments:
             - '@Surfnet\ServiceProviderDashboard\Application\Service\EntityAclService'
         tags: ['form.type']
+
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service\ServiceSwitcherType:
+        arguments:
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AuthorizationService'
+        tags: ['form.type']

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/TwigExtension/service_switcher.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/TwigExtension/service_switcher.html.twig
@@ -1,11 +1,4 @@
-<form action="{{ path('select_service') }}" method="POST">
-    <select name="service" id="service-switcher">
-        <option value=""></option>
-    {% for service_id,service_name in services %}
-        <option value="{{ service_id }}"{{ service_id == selected_service ? ' selected' : '' }}>{{ service_name }}</option>
-    {% endfor %}
-    </select>
-    <noscript>
-        <input type="submit" value="Select" />
-    </noscript>
-</form>
+{{ form_start(form, {'attr': {'novalidate': 'novalidate', 'action': path('select_service') } }) }}
+{{ form_widget(form.selected_service_id, {'id': 'service-switcher'}) }}
+{{ form_rest(form) }}
+{{ form_end(form) }}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/AuthorizationService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/AuthorizationService.php
@@ -134,7 +134,7 @@ class AuthorizationService
      *
      * @return AuthorizationService
      */
-    public function setSelectedServiceId($serviceId)
+    private function setSelectedServiceId($serviceId)
     {
         $this->session->set('selected_service_id', $serviceId);
 
@@ -232,7 +232,7 @@ class AuthorizationService
      * @return \Surfnet\ServiceProviderDashboard\Domain\Entity\Service
      * @throws ServiceNotFoundException
      */
-    public function getServiceById($serviceId)
+    public function changeActiveService($serviceId)
     {
         $service = $this->serviceService->getServiceById($serviceId);
 
@@ -244,6 +244,12 @@ class AuthorizationService
 
         return $service;
     }
+
+    public function resetService()
+    {
+        $this->setSelectedServiceId(null);
+    }
+
 
     /**
      * @param string $serviceId

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Twig/ServiceSwitcherExtension.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Twig/ServiceSwitcherExtension.php
@@ -17,7 +17,9 @@
  */
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Twig;
 
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service\ServiceSwitcherType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AuthorizationService;
+use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Twig_Environment;
 use Twig_Extension;
@@ -34,11 +36,19 @@ class ServiceSwitcherExtension extends Twig_Extension
      * @var TokenStorageInterface
      */
     private $tokenStorage;
+    /**
+     * @var FormFactoryInterface
+     */
+    private $formFactory;
 
-    public function __construct(TokenStorageInterface $tokenStorage, AuthorizationService $authorizationService)
-    {
+    public function __construct(
+        TokenStorageInterface $tokenStorage,
+        AuthorizationService $authorizationService,
+        FormFactoryInterface $formFactory
+    ) {
         $this->tokenStorage = $tokenStorage;
         $this->authorizationService = $authorizationService;
+        $this->formFactory = $formFactory;
     }
 
     public function getFunctions()
@@ -62,16 +72,12 @@ class ServiceSwitcherExtension extends Twig_Extension
             return '';
         }
 
-        $allowedServices = $this->authorizationService->getAllowedServiceNamesById();
-        if (count($allowedServices) <= 1) {
-            return '';
-        }
+        $form = $this->formFactory->create(ServiceSwitcherType::class);
 
         return $environment->render(
             'DashboardBundle:TwigExtension:service_switcher.html.twig',
             [
-                'services' => $allowedServices,
-                'selected_service' => $this->authorizationService->getActiveServiceId(),
+                'form' => $form->createView(),
             ]
         );
     }

--- a/tests/unit/Infrastructure/DashboardBundle/CommandHandler/Service/ResetServiceCommandHandlerTest.php
+++ b/tests/unit/Infrastructure/DashboardBundle/CommandHandler/Service/ResetServiceCommandHandlerTest.php
@@ -47,7 +47,7 @@ class ResetServiceCommandHandlerTest extends MockeryTestCase
     {
         $command = new ResetServiceCommand();
 
-        $this->authService->shouldReceive('setSelectedServiceId')->with(null)->once();
+        $this->authService->shouldReceive('resetService')->withNoArgs()->once();
 
         $this->commandHandler->handle($command);
     }

--- a/tests/unit/Infrastructure/DashboardBundle/CommandHandler/Service/SelectServiceCommandHandlerTest.php
+++ b/tests/unit/Infrastructure/DashboardBundle/CommandHandler/Service/SelectServiceCommandHandlerTest.php
@@ -43,9 +43,10 @@ class SelectServiceCommandHandlerTest extends MockeryTestCase
      */
     public function test_handler_processes_command_and_selects_service()
     {
-        $command = new SelectServiceCommand('ibuildings');
+        $command = new SelectServiceCommand();
+        $command->setSelectedServiceId('ibuildings');
 
-        $this->authService->shouldReceive('setSelectedServiceId')->with('ibuildings')->once();
+        $this->authService->shouldReceive('changeActiveService')->with('ibuildings')->once();
 
         $this->commandHandler->handle($command);
     }

--- a/tests/unit/Infrastructure/DashboardBundle/Service/AuthorizationServiceTest.php
+++ b/tests/unit/Infrastructure/DashboardBundle/Service/AuthorizationServiceTest.php
@@ -21,6 +21,7 @@ namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\DashboardBu
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Surfnet\ServiceProviderDashboard\Application\Service\ServiceService;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AuthorizationService;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Authentication\Token\SamlToken;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -58,10 +59,25 @@ class AuthorizationServiceTest extends MockeryTestCase
      */
     public function test_service_writes_selected_service_to_session()
     {
+        $service = m::mock(Service::class);
+        $service->shouldReceive('getId')->andReturn(1);
+
+        $this->tokenStorage->shouldReceive('getToken')
+            ->andReturn(new SamlToken(['ROLE_ADMINISTRATOR']));
+
+        $this->serviceService->shouldReceive('getServiceById')->andReturn(
+            $service
+        );
+
+        $this->serviceService->shouldReceive('getServiceNamesById')
+            ->andReturn([
+                1 => 'SURFnet',
+            ]);
+
         $this->session->shouldReceive('set')
             ->with('selected_service_id', 1);
 
-        $this->service->setSelectedServiceId(1);
+        $this->service->changeActiveService(1);
     }
 
     /**

--- a/tests/webtests/EditServiceTest.php
+++ b/tests/webtests/EditServiceTest.php
@@ -30,7 +30,7 @@ class EditServiceTest extends WebTestCase
 
         $this->loadFixtures();
 
-        $this->getAuthorizationService()->setSelectedServiceId(
+        $this->getAuthorizationService()->changeActiveService(
             $this->getServiceRepository()->findByName('SURFnet')->getId()
         );
 

--- a/tests/webtests/EditServiceTest.php
+++ b/tests/webtests/EditServiceTest.php
@@ -30,10 +30,6 @@ class EditServiceTest extends WebTestCase
 
         $this->loadFixtures();
 
-        $this->getAuthorizationService()->changeActiveService(
-            $this->getServiceRepository()->findByName('SURFnet')->getId()
-        );
-
         $this->testMockHandler->append(new Response(200, [], '[]'));
         $this->prodMockHandler->append(new Response(200, [], '[]'));
     }
@@ -41,6 +37,7 @@ class EditServiceTest extends WebTestCase
     public function test_can_edit_existing_service()
     {
         $this->logIn('ROLE_ADMINISTRATOR');
+        $this->switchToService('SURFnet');
 
         $formData = [
             'dashboard_bundle_edit_service_type' => [
@@ -80,6 +77,7 @@ class EditServiceTest extends WebTestCase
         $serviceRepository = $this->getServiceRepository();
 
         $this->logIn('ROLE_ADMINISTRATOR');
+        $this->switchToService('SURFnet');
 
         // EntityService::getEntityListForService -> findByTeamName
         $this->testMockHandler->append(new Response(200, [], '[]'));

--- a/tests/webtests/EntityAclTest.php
+++ b/tests/webtests/EntityAclTest.php
@@ -35,8 +35,7 @@ class EntityAclTest extends WebTestCase
         $this->logIn('ROLE_ADMINISTRATOR');
 
         $service = $this->getServiceRepository()->findByName('SURFnet');
-
-        $this->getAuthorizationService()->changeActiveService($service->getId());
+        $this->switchToService('SURFnet');
 
         $entity = $service->getEntities()->first();
 

--- a/tests/webtests/EntityAclTest.php
+++ b/tests/webtests/EntityAclTest.php
@@ -36,7 +36,7 @@ class EntityAclTest extends WebTestCase
 
         $service = $this->getServiceRepository()->findByName('SURFnet');
 
-        $this->getAuthorizationService()->setSelectedServiceId($service->getId());
+        $this->getAuthorizationService()->changeActiveService($service->getId());
 
         $entity = $service->getEntities()->first();
 

--- a/tests/webtests/EntityCopyTest.php
+++ b/tests/webtests/EntityCopyTest.php
@@ -38,7 +38,7 @@ class EntityCopyTest extends WebTestCase
 
         $this->service = $this->getServiceRepository()->findByName('SURFnet');
 
-        $this->getAuthorizationService()->setSelectedServiceId($this->service->getId());
+        $this->getAuthorizationService()->changeActiveService($this->service->getId());
     }
 
     public function test_copy_does_not_create_new_entity()

--- a/tests/webtests/EntityCopyTest.php
+++ b/tests/webtests/EntityCopyTest.php
@@ -38,7 +38,7 @@ class EntityCopyTest extends WebTestCase
 
         $this->service = $this->getServiceRepository()->findByName('SURFnet');
 
-        $this->getAuthorizationService()->changeActiveService($this->service->getId());
+        $this->switchToService('SURFnet');
     }
 
     public function test_copy_does_not_create_new_entity()

--- a/tests/webtests/EntityCreateOidcTest.php
+++ b/tests/webtests/EntityCreateOidcTest.php
@@ -39,7 +39,7 @@ class EntityCreateOidcTest extends WebTestCase
 
         $this->service = $this->getServiceRepository()->findByName('Ibuildings B.V.');
 
-        $this->getAuthorizationService()->setSelectedServiceId(
+        $this->getAuthorizationService()->changeActiveService(
             $this->service->getId()
         );
 
@@ -207,7 +207,7 @@ class EntityCreateOidcTest extends WebTestCase
     public function test_creating_draft_for_production_is_not_allowed()
     {
         // SURFnet is not allowed to create production entities.
-        $this->getAuthorizationService()->setSelectedServiceId(
+        $this->getAuthorizationService()->changeActiveService(
             $this->getServiceRepository()->findByName('SURFnet')->getId()
         );
 

--- a/tests/webtests/EntityCreateOidcTest.php
+++ b/tests/webtests/EntityCreateOidcTest.php
@@ -39,9 +39,7 @@ class EntityCreateOidcTest extends WebTestCase
 
         $this->service = $this->getServiceRepository()->findByName('Ibuildings B.V.');
 
-        $this->getAuthorizationService()->changeActiveService(
-            $this->service->getId()
-        );
+        $this->switchToService('Ibuildings B.V.');
 
         $this->service = $this->getServiceRepository()->findByName('SURFnet');
     }

--- a/tests/webtests/EntityCreateSamlTest.php
+++ b/tests/webtests/EntityCreateSamlTest.php
@@ -33,9 +33,7 @@ class EntitySamlCreateSamlTest extends WebTestCase
 
         $this->logIn('ROLE_ADMINISTRATOR');
 
-        $this->getAuthorizationService()->changeActiveService(
-            $this->getServiceRepository()->findByName('Ibuildings B.V.')->getId()
-        );
+        $this->switchToService('Ibuildings B.V.');
     }
 
     public function test_it_renders_the_form()

--- a/tests/webtests/EntityCreateSamlTest.php
+++ b/tests/webtests/EntityCreateSamlTest.php
@@ -33,7 +33,7 @@ class EntitySamlCreateSamlTest extends WebTestCase
 
         $this->logIn('ROLE_ADMINISTRATOR');
 
-        $this->getAuthorizationService()->setSelectedServiceId(
+        $this->getAuthorizationService()->changeActiveService(
             $this->getServiceRepository()->findByName('Ibuildings B.V.')->getId()
         );
     }
@@ -297,7 +297,7 @@ class EntitySamlCreateSamlTest extends WebTestCase
     public function test_creating_draft_for_production_is_not_allowed()
     {
         // SURFnet is not allowed to create production entities.
-        $this->getAuthorizationService()->setSelectedServiceId(
+        $this->getAuthorizationService()->changeActiveService(
             $this->getServiceRepository()->findByName('SURFnet')->getId()
         );
 
@@ -309,7 +309,7 @@ class EntitySamlCreateSamlTest extends WebTestCase
     public function test_a_privileged_user_can_create_a_production_draft()
     {
         // Ibuildings is allowed to create production entities.
-        $this->getAuthorizationService()->setSelectedServiceId(
+        $this->getAuthorizationService()->changeActiveService(
             $this->getServiceRepository()->findByName('Ibuildings B.V.')->getId()
         );
 

--- a/tests/webtests/EntityDeleteTest.php
+++ b/tests/webtests/EntityDeleteTest.php
@@ -32,7 +32,7 @@ class EntityDeleteTest extends WebTestCase
 
         $this->service = $this->getServiceRepository()->findByName('SURFnet');
 
-        $this->getAuthorizationService()->setSelectedServiceId($this->service->getId());
+        $this->getAuthorizationService()->changeActiveService($this->service->getId());
     }
 
     public function test_a_normal_user_can_not_delete_entities()

--- a/tests/webtests/EntityDeleteTest.php
+++ b/tests/webtests/EntityDeleteTest.php
@@ -32,7 +32,7 @@ class EntityDeleteTest extends WebTestCase
 
         $this->service = $this->getServiceRepository()->findByName('SURFnet');
 
-        $this->getAuthorizationService()->changeActiveService($this->service->getId());
+        $this->switchToService('SURFnet');
     }
 
     public function test_a_normal_user_can_not_delete_entities()

--- a/tests/webtests/EntityDetailTest.php
+++ b/tests/webtests/EntityDetailTest.php
@@ -30,7 +30,7 @@ class EntityDetailTest extends WebTestCase
         $this->loadFixtures();
         $this->logIn('ROLE_ADMINISTRATOR');
 
-        $this->getAuthorizationService()->setSelectedServiceId(
+        $this->getAuthorizationService()->changeActiveService(
             $this->getServiceRepository()->findByName('SURFnet')->getId()
         );
 
@@ -56,7 +56,7 @@ class EntityDetailTest extends WebTestCase
         $this->loadFixtures();
         $this->logIn('ROLE_ADMINISTRATOR');
 
-        $this->getAuthorizationService()->setSelectedServiceId(
+        $this->getAuthorizationService()->changeActiveService(
             $this->getServiceRepository()->findByName('SURFnet')->getId()
         );
 
@@ -96,7 +96,7 @@ class EntityDetailTest extends WebTestCase
 
         $this->prodMockHandler->append(new Response(200, [], $sp3QueryResponse));
 
-        $this->getAuthorizationService()->setSelectedServiceId(
+        $this->getAuthorizationService()->changeActiveService(
             $this->getServiceRepository()->findByName('SURFnet')->getId()
         );
 
@@ -121,7 +121,7 @@ class EntityDetailTest extends WebTestCase
         $this->loadFixtures();
         $this->logIn('ROLE_ADMINISTRATOR');
 
-        $this->getAuthorizationService()->setSelectedServiceId(
+        $this->getAuthorizationService()->changeActiveService(
             $this->getServiceRepository()->findByName('SURFnet')->getId()
         );
 

--- a/tests/webtests/EntityDetailTest.php
+++ b/tests/webtests/EntityDetailTest.php
@@ -30,9 +30,7 @@ class EntityDetailTest extends WebTestCase
         $this->loadFixtures();
         $this->logIn('ROLE_ADMINISTRATOR');
 
-        $this->getAuthorizationService()->changeActiveService(
-            $this->getServiceRepository()->findByName('SURFnet')->getId()
-        );
+        $this->switchToService('SURFnet');
 
         $entity = reset($this->getEntityRepository()->findBy(['nameEn' => 'SP1']));
 
@@ -56,9 +54,7 @@ class EntityDetailTest extends WebTestCase
         $this->loadFixtures();
         $this->logIn('ROLE_ADMINISTRATOR');
 
-        $this->getAuthorizationService()->changeActiveService(
-            $this->getServiceRepository()->findByName('SURFnet')->getId()
-        );
+        $this->switchToService('SURFnet');
 
         /** @var Entity $entity */
         $entity = reset($this->getEntityRepository()->findBy(['nameEn' => 'SP1']));
@@ -96,9 +92,7 @@ class EntityDetailTest extends WebTestCase
 
         $this->prodMockHandler->append(new Response(200, [], $sp3QueryResponse));
 
-        $this->getAuthorizationService()->changeActiveService(
-            $this->getServiceRepository()->findByName('SURFnet')->getId()
-        );
+        $this->switchToService('SURFnet');
 
         $crawler = $this->client->request('GET', '/entity/detail/1/9729d851-cfdd-4283-a8f1-a29ba5036261/production');
 
@@ -121,9 +115,7 @@ class EntityDetailTest extends WebTestCase
         $this->loadFixtures();
         $this->logIn('ROLE_ADMINISTRATOR');
 
-        $this->getAuthorizationService()->changeActiveService(
-            $this->getServiceRepository()->findByName('SURFnet')->getId()
-        );
+        $this->switchToService('SURFnet');
 
         /** @var \Surfnet\ServiceProviderDashboard\Domain\Entity\Entity $entity */
         $entity = reset($this->getEntityRepository()->findBy(['nameEn' => 'SP1']));

--- a/tests/webtests/EntityEditTest.php
+++ b/tests/webtests/EntityEditTest.php
@@ -36,7 +36,7 @@ class EntityEditTest extends WebTestCase
 
         $service = $this->getServiceRepository()->findByName('SURFnet');
 
-        $this->getAuthorizationService()->setSelectedServiceId($service->getId());
+        $this->getAuthorizationService()->changeActiveService($service->getId());
 
         $this->entityId = $service->getEntities()
             ->first()

--- a/tests/webtests/EntityEditTest.php
+++ b/tests/webtests/EntityEditTest.php
@@ -36,7 +36,7 @@ class EntityEditTest extends WebTestCase
 
         $service = $this->getServiceRepository()->findByName('SURFnet');
 
-        $this->getAuthorizationService()->changeActiveService($service->getId());
+        $this->switchToService('SURFnet');
 
         $this->entityId = $service->getEntities()
             ->first()

--- a/tests/webtests/EntityListTest.php
+++ b/tests/webtests/EntityListTest.php
@@ -29,12 +29,10 @@ class EntityListTest extends WebTestCase
         $this->loadFixtures();
         $this->logIn('ROLE_ADMINISTRATOR');
 
+        $this->switchToService('SURFnet');
+
         $this->testMockHandler->append(new Response(200, [], '[]'));
         $this->prodMockHandler->append(new Response(200, [], '[]'));
-
-        $this->getAuthorizationService()->changeActiveService(
-            $this->getServiceRepository()->findByName('SURFnet')->getId()
-        );
 
         $crawler = $this->client->request('GET', '/entities/1');
 
@@ -93,13 +91,11 @@ class EntityListTest extends WebTestCase
             ],
         ]);
 
+        $this->switchToService('SURFnet');
+
         $this->testMockHandler->append(new Response(200, [], $searchResponse));
         $this->testMockHandler->append(new Response(200, [], $sp3QueryResponse));
         $this->prodMockHandler->append(new Response(200, [], '[]'));
-
-        $this->getAuthorizationService()->changeActiveService(
-            $this->getServiceRepository()->findByName('SURFnet')->getId()
-        );
 
         $crawler = $this->client->request('GET', '/entities/1');
 
@@ -153,10 +149,6 @@ class EntityListTest extends WebTestCase
         $this->testMockHandler->append(new Response(200, [], '[]'));
         $this->prodMockHandler->append(new Response(200, [], '[]'));
 
-        $this->getAuthorizationService()->changeActiveService(
-            $service->getId()
-        );
-
         $crawler = $this->client->request('GET', '/entities/1');
         $actions = $crawler->filter('a[href="#add-for-test"]');
 
@@ -174,10 +166,6 @@ class EntityListTest extends WebTestCase
 
         $this->testMockHandler->append(new Response(200, [], '[]'));
         $this->prodMockHandler->append(new Response(200, [], '[]'));
-
-        $this->getAuthorizationService()->changeActiveService(
-            $service->getId()
-        );
 
         $crawler = $this->client->request('GET', '/entities/2');
 
@@ -197,10 +185,6 @@ class EntityListTest extends WebTestCase
         $this->prodMockHandler->append(new Response(200, [], '[]'));
         $this->testMockHandler->append(new Response(200, [], '[]'));
         $this->prodMockHandler->append(new Response(200, [], '[]'));
-
-        $this->getAuthorizationService()->changeActiveService(
-            $service->getId()
-        );
 
         $crawler = $this->client->request('GET', '/entities/2');
 

--- a/tests/webtests/EntityListTest.php
+++ b/tests/webtests/EntityListTest.php
@@ -32,7 +32,7 @@ class EntityListTest extends WebTestCase
         $this->testMockHandler->append(new Response(200, [], '[]'));
         $this->prodMockHandler->append(new Response(200, [], '[]'));
 
-        $this->getAuthorizationService()->setSelectedServiceId(
+        $this->getAuthorizationService()->changeActiveService(
             $this->getServiceRepository()->findByName('SURFnet')->getId()
         );
 
@@ -97,7 +97,7 @@ class EntityListTest extends WebTestCase
         $this->testMockHandler->append(new Response(200, [], $sp3QueryResponse));
         $this->prodMockHandler->append(new Response(200, [], '[]'));
 
-        $this->getAuthorizationService()->setSelectedServiceId(
+        $this->getAuthorizationService()->changeActiveService(
             $this->getServiceRepository()->findByName('SURFnet')->getId()
         );
 
@@ -153,7 +153,7 @@ class EntityListTest extends WebTestCase
         $this->testMockHandler->append(new Response(200, [], '[]'));
         $this->prodMockHandler->append(new Response(200, [], '[]'));
 
-        $this->getAuthorizationService()->setSelectedServiceId(
+        $this->getAuthorizationService()->changeActiveService(
             $service->getId()
         );
 
@@ -175,7 +175,7 @@ class EntityListTest extends WebTestCase
         $this->testMockHandler->append(new Response(200, [], '[]'));
         $this->prodMockHandler->append(new Response(200, [], '[]'));
 
-        $this->getAuthorizationService()->setSelectedServiceId(
+        $this->getAuthorizationService()->changeActiveService(
             $service->getId()
         );
 
@@ -198,7 +198,7 @@ class EntityListTest extends WebTestCase
         $this->testMockHandler->append(new Response(200, [], '[]'));
         $this->prodMockHandler->append(new Response(200, [], '[]'));
 
-        $this->getAuthorizationService()->setSelectedServiceId(
+        $this->getAuthorizationService()->changeActiveService(
             $service->getId()
         );
 

--- a/tests/webtests/EntityPublishToProductionTest.php
+++ b/tests/webtests/EntityPublishToProductionTest.php
@@ -47,10 +47,6 @@ class EntityPublishToProductionTest extends WebTestCase
                 $surfNet,
             ]
         );
-
-        $this->getAuthorizationService()->changeActiveService(
-            $surfNet->getId()
-        );
     }
 
     private function buildEntityWithAttribute(Service $service)

--- a/tests/webtests/EntityPublishToProductionTest.php
+++ b/tests/webtests/EntityPublishToProductionTest.php
@@ -48,7 +48,7 @@ class EntityPublishToProductionTest extends WebTestCase
             ]
         );
 
-        $this->getAuthorizationService()->setSelectedServiceId(
+        $this->getAuthorizationService()->changeActiveService(
             $surfNet->getId()
         );
     }

--- a/tests/webtests/EntityPublishToTestTest.php
+++ b/tests/webtests/EntityPublishToTestTest.php
@@ -45,10 +45,6 @@ class EntityPublishToTestTest extends WebTestCase
                 $surfNet,
             ]
         );
-
-        $this->getAuthorizationService()->changeActiveService(
-            $surfNet->getId()
-        );
     }
 
     private function buildEntityWithAttribute(Service $service)

--- a/tests/webtests/EntityPublishToTestTest.php
+++ b/tests/webtests/EntityPublishToTestTest.php
@@ -46,7 +46,7 @@ class EntityPublishToTestTest extends WebTestCase
             ]
         );
 
-        $this->getAuthorizationService()->setSelectedServiceId(
+        $this->getAuthorizationService()->changeActiveService(
             $surfNet->getId()
         );
     }

--- a/tests/webtests/ServiceAdminOverviewTest.php
+++ b/tests/webtests/ServiceAdminOverviewTest.php
@@ -31,7 +31,7 @@ class ServiceAdminOverviewTest extends WebTestCase
 
         $this->loadFixtures();
 
-        $this->getAuthorizationService()->setSelectedServiceId(
+        $this->getAuthorizationService()->changeActiveService(
             $this->getServiceRepository()->findByName('SURFnet')->getId()
         );
     }

--- a/tests/webtests/ServiceAdminOverviewTest.php
+++ b/tests/webtests/ServiceAdminOverviewTest.php
@@ -30,10 +30,6 @@ class ServiceAdminOverviewTest extends WebTestCase
         parent::setUp();
 
         $this->loadFixtures();
-
-        $this->getAuthorizationService()->changeActiveService(
-            $this->getServiceRepository()->findByName('SURFnet')->getId()
-        );
     }
 
     /**

--- a/tests/webtests/ServiceCreateTest.php
+++ b/tests/webtests/ServiceCreateTest.php
@@ -29,10 +29,6 @@ class ServiceCreateTest extends WebTestCase
         parent::setUp();
 
         $this->loadFixtures();
-
-        $this->getAuthorizationService()->changeActiveService(
-            $this->getServiceRepository()->findByName('SURFnet')->getId()
-        );
     }
 
     public function test_it_validates_the_form()

--- a/tests/webtests/ServiceCreateTest.php
+++ b/tests/webtests/ServiceCreateTest.php
@@ -30,7 +30,7 @@ class ServiceCreateTest extends WebTestCase
 
         $this->loadFixtures();
 
-        $this->getAuthorizationService()->setSelectedServiceId(
+        $this->getAuthorizationService()->changeActiveService(
             $this->getServiceRepository()->findByName('SURFnet')->getId()
         );
     }

--- a/tests/webtests/ServiceDeleteTest.php
+++ b/tests/webtests/ServiceDeleteTest.php
@@ -29,7 +29,7 @@ class ServiceDeleteTest extends WebTestCase
 
         $this->loadFixtures();
 
-        $this->getAuthorizationService()->setSelectedServiceId(
+        $this->getAuthorizationService()->changeActiveService(
             $this->getServiceRepository()->findByName('SURFnet')->getId()
         );
     }

--- a/tests/webtests/ServiceDeleteTest.php
+++ b/tests/webtests/ServiceDeleteTest.php
@@ -28,15 +28,12 @@ class ServiceDeleteTest extends WebTestCase
         parent::setUp();
 
         $this->loadFixtures();
-
-        $this->getAuthorizationService()->changeActiveService(
-            $this->getServiceRepository()->findByName('SURFnet')->getId()
-        );
     }
 
     public function test_removing_a_service_redirects_to_service_overview()
     {
         $this->logIn('ROLE_ADMINISTRATOR');
+        $this->switchToService('SURFnet');
 
         // EntityService::getEntityListForService -> findByTeamName (service/edit first request)
         $this->testMockHandler->append(new Response(200, [], '[]'));
@@ -119,6 +116,7 @@ class ServiceDeleteTest extends WebTestCase
     public function test_removing_a_service_with_privacy_questions_is_possible()
     {
         $this->logIn('ROLE_ADMINISTRATOR');
+        $this->switchToService('SURFnet');
 
         // EntityService::getEntityListForService -> findByTeamName (service/edit first request)
         $this->testMockHandler->append(new Response(200, [], '[]'));

--- a/tests/webtests/ServiceOverviewTest.php
+++ b/tests/webtests/ServiceOverviewTest.php
@@ -31,7 +31,7 @@ class ServiceOverviewTest extends WebTestCase
 
         $this->loadFixtures();
 
-        $this->getAuthorizationService()->setSelectedServiceId(
+        $this->getAuthorizationService()->changeActiveService(
             $this->getServiceRepository()->findByName('SURFnet')->getId()
         );
     }

--- a/tests/webtests/ServiceOverviewTest.php
+++ b/tests/webtests/ServiceOverviewTest.php
@@ -30,10 +30,6 @@ class ServiceOverviewTest extends WebTestCase
         parent::setUp();
 
         $this->loadFixtures();
-
-        $this->getAuthorizationService()->changeActiveService(
-            $this->getServiceRepository()->findByName('SURFnet')->getId()
-        );
     }
 
     /**
@@ -47,10 +43,10 @@ class ServiceOverviewTest extends WebTestCase
         $serviceRepository = $this->getServiceRepository();
         $surfNet = $serviceRepository->findByName('SURFnet');
 
+        $this->logIn('ROLE_USER', [$surfNet]);
+
         $this->testMockHandler->append(new Response(200, [], '[]'));
         $this->prodMockHandler->append(new Response(200, [], '[]'));
-
-        $this->logIn('ROLE_USER', [$surfNet]);
 
         $crawler = $this->client->request('GET', '/');
 
@@ -184,6 +180,7 @@ class ServiceOverviewTest extends WebTestCase
         $this->prodMockHandler->append(new Response(200, [], '[]'));
 
         $this->logIn('ROLE_USER', [$surfNet]);
+
         $crawler = $this->client->request('GET', '/');
 
         $link = $crawler->filter('.service-status-title > a:nth-child(1)');

--- a/tests/webtests/ServiceSwitcherTest.php
+++ b/tests/webtests/ServiceSwitcherTest.php
@@ -105,11 +105,10 @@ class ServiceSwitcherTest extends WebTestCase
         $this->loadFixtures();
 
         $crawler = $this->client->request('GET', '/service/create');
-        $form = $crawler->filter('.service-switcher')
-            ->selectButton('Select')
+        $form = $crawler->filter('.service-switcher form')
             ->form();
 
-        $form['service']->select(
+        $form['service_switcher[selected_service_id]']->select(
             $this->getServiceRepository()->findByName('SURFnet')->getId()
         );
 

--- a/tests/webtests/WebTestCase.php
+++ b/tests/webtests/WebTestCase.php
@@ -138,14 +138,12 @@ class WebTestCase extends SymfonyWebTestCase
      */
     protected function switchToService($serviceName)
     {
-        $crawler = $this->client->request('GET', '/service/create');
-        $form = $crawler->filter('.service-switcher')
-            ->selectButton('Select')
-            ->form();
+        $crawler = $this->client->request('GET', '/');
+        $form = $crawler->filter('.service-switcher form')->form();
 
-        $form['service']->select(
-            $this->getServiceRepository()->findByName($serviceName)->getId()
-        );
+        $service  = $this->getServiceRepository()->findByName($serviceName);
+
+        $form['service_switcher[selected_service_id]']->select($service->getId());
 
         $this->client->submit($form);
 


### PR DESCRIPTION
Change the thrown exception to be a 404 instead a 500. Also renamed
the getServiceId method to be more descriptive. Also added a dedicated
symfony form to switch services to have csrf support.