### PR TITLE
Escape the wysiwyg translations

### DIFF
--- a/app/Resources/views/Translation/layout.html.twig
+++ b/app/Resources/views/Translation/layout.html.twig
@@ -5,7 +5,7 @@
 
     {% block lexik_stylesheets %}
         <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
-            <link rel="stylesheet" href="{{ asset('bundles/lexiktranslation/ng-table/ng-table.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('bundles/lexiktranslation/ng-table/ng-table.min.css') }}">
     {% endblock %}
     {% block lexik_flash_message %}
         <div class="container">

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -60,7 +60,8 @@ nelmio_security:
             - '%saml_remote_idp_host%'
     csp:
         report_logger_service: monolog.logger.security
-        hosts: []
+        hosts:
+            - 'ajax.googleapis.com'
         content_types: []
         enforce:
             report-uri: [/csp/report]

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "symfony/polyfill-apcu": "^1.0",
         "symfony/swiftmailer-bundle": "^2.3.10",
         "symfony/symfony": "3.4.*",
-        "twig/twig": "^1.34.4"
+        "twig/twig": "^1.34.4",
+        "xemlock/htmlpurifier-html5": "^0.1.10"
     },
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "873855d1c8c3948b33fea7d7c0a4d9aa",
+    "content-hash": "8af1a2fc9629a9bd78abb392a4b4ff9d",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -1016,6 +1016,53 @@
                 "orm"
             ],
             "time": "2017-12-17T02:57:51+00:00"
+        },
+        {
+            "name": "ezyang/htmlpurifier",
+            "version": "v4.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ezyang/htmlpurifier.git",
+                "reference": "d85d39da4576a6934b72480be6978fb10c860021"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/d85d39da4576a6934b72480be6978fb10c860021",
+                "reference": "d85d39da4576a6934b72480be6978fb10c860021",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "require-dev": {
+                "simpletest/simpletest": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "HTMLPurifier": "library/"
+                },
+                "files": [
+                    "library/HTMLPurifier.composer.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL"
+            ],
+            "authors": [
+                {
+                    "name": "Edward Z. Yang",
+                    "email": "admin@htmlpurifier.org",
+                    "homepage": "http://ezyang.com"
+                }
+            ],
+            "description": "Standards compliant HTML filter written in PHP",
+            "homepage": "http://htmlpurifier.org/",
+            "keywords": [
+                "html"
+            ],
+            "time": "2018-02-23T01:58:20+00:00"
         },
         {
             "name": "fig/link-util",
@@ -3858,6 +3905,55 @@
                 "validate"
             ],
             "time": "2018-01-29T19:49:41+00:00"
+        },
+        {
+            "name": "xemlock/htmlpurifier-html5",
+            "version": "v0.1.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/xemlock/htmlpurifier-html5.git",
+                "reference": "32cef47500fb77c2be0f160372095bec15bf0052"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/xemlock/htmlpurifier-html5/zipball/32cef47500fb77c2be0f160372095bec15bf0052",
+                "reference": "32cef47500fb77c2be0f160372095bec15bf0052",
+                "shasum": ""
+            },
+            "require": {
+                "ezyang/htmlpurifier": "^4.7",
+                "php": ">=5.2"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^1.1|^2.1",
+                "phpunit/phpunit": ">=4.7 <8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "library/HTMLPurifier/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "xemlock",
+                    "email": "xemlock@gmail.com"
+                }
+            ],
+            "description": "HTML Purifier definitions for HTML5 elements",
+            "keywords": [
+                "HTML5",
+                "Purifier",
+                "html",
+                "htmlpurifier",
+                "security",
+                "xss"
+            ],
+            "time": "2019-04-26T08:53:59+00:00"
         },
         {
             "name": "zendframework/zend-code",

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -12,5 +12,5 @@ To import the default translations into the lexik database, run the
 deployment.
 
 Translation tokens ending with `.html` will be loaded in a WYSIWYG editor in the translation interface. These
-translations are also to be outputted unescaped in the template. To do so in twig use the raw filter. For example:
-`{{ 'service.edit.comments.html'|trans|raw }}` 
+translations are stored without input validation or sanitization. Therefore we need to strip the allowed tags in the
+template. To do so in twig use the wysiwyg filter. For example: `{{ 'service.edit.comments.html'|trans|wysiwyg }}` 

--- a/src/Surfnet/ServiceProviderDashboard/Application/Assembler/ServiceStatusAssembler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Assembler/ServiceStatusAssembler.php
@@ -19,7 +19,7 @@ namespace Surfnet\ServiceProviderDashboard\Application\Assembler;
 
 use Surfnet\ServiceProviderDashboard\Application\Dto\ServiceStatusDto;
 use Surfnet\ServiceProviderDashboard\Application\Service\ServiceStatusService;
-use Surfnet\ServiceProviderDashboard\Application\ViewObject\EntityList;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Twig\WysiwygExtension;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Symfony\Component\Translation\TranslatorInterface;
 
@@ -226,7 +226,7 @@ class ServiceStatusAssembler
     {
         $labels = [];
         foreach (self::states() as $state) {
-            $labels[$state] = $this->translator->trans('service.overview.progress.label.' . $state);
+            $labels[$state] = $this->getSanitizedHtmlTranslation('service.overview.progress.label.' . $state);
         }
         return $labels;
     }
@@ -235,7 +235,7 @@ class ServiceStatusAssembler
     {
         $tooltips = [];
         foreach ($mappedStates as $state => $status) {
-            $tooltips[$state] = $this->translator->trans('service.overview.progress.tooltip.' . $state . '.' . $status . '.html');
+            $tooltips[$state] = $this->getSanitizedHtmlTranslation('service.overview.progress.tooltip.' . $state . '.' . $status . '.html');
         }
         return $tooltips;
     }
@@ -251,5 +251,12 @@ class ServiceStatusAssembler
             $total++;
         }
         return \round($done/$total*100);
+    }
+
+    private function getSanitizedHtmlTranslation($key)
+    {
+        $translated = $this->translator->trans($key);
+        $sanitized = WysiwygExtension::sanitizeWysiwyg($translated);
+        return $sanitized;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -218,6 +218,9 @@ services:
     Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Twig\IdentityExtension:
         tags: [twig.extension]
 
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Twig\WysiwygExtension:
+        tags: [twig.extension]
+
     Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\ValidEntityIdValidator:
         tags:
             - { name: validator.constraint_validator, alias: valid_entity_id }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityAcl/acl.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityAcl/acl.html.twig
@@ -22,7 +22,7 @@
         {{ form_errors(form) }}
 
         <h2>{{ ('entity.acl.info.title')|trans }}</h2>
-        <div class="wysiwyg">{{ ('entity.acl.info.html')|trans|raw }}</div>
+        <div class="wysiwyg">{{ ('entity.acl.info.html')|trans|wysiwyg }}</div>
     </div>
 
     <div class="fieldset card">

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detail.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detail.html.twig
@@ -10,12 +10,12 @@
     </div>
     <div class="fieldset card">
         <h2>{{ ('entity.detail.info.' ~ type ~ '.title')|trans }}</h2>
-        <div class="wysiwyg">{{ ('entity.detail.info.' ~ type ~ '.html')|trans|raw }}</div>
+        <div class="wysiwyg">{{ ('entity.detail.info.' ~ type ~ '.html')|trans|wysiwyg }}</div>
     </div>
 
     <div class="fieldset card">
         <h2>{{ ('entity.detail.metadata.' ~ type ~ '.title')|trans }}</h2>
-        <div class="wysiwyg">{{ ('entity.detail.metadata.' ~ type ~ '.html')|trans|raw }}</div>
+        <div class="wysiwyg">{{ ('entity.detail.metadata.' ~ type ~ '.html')|trans|wysiwyg }}</div>
 
         {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.metadata_url'|trans, value: entity.metadataUrl, informationPopup: 'entity.edit.information.metadataUrl'} %}
         {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.acs_location'|trans, value: entity.acsLocation, informationPopup: 'entity.edit.information.acsLocation'} %}
@@ -39,7 +39,7 @@
 
     <div class="fieldset card">
         <h2>{{ ('entity.detail.contact.' ~ type ~ '.title')|trans }}</h2>
-        <div class="wysiwyg">{{ ('entity.detail.contact.' ~ type ~ '.html')|trans|raw }}</div>
+        <div class="wysiwyg">{{ ('entity.detail.contact.' ~ type ~ '.html')|trans|wysiwyg }}</div>
 
         {% include '@Dashboard/EntityDetail/detailContactField.html.twig' with {label: 'entity.detail.contact.administrative'|trans, value: entity.administrativeContact, informationPopup: 'entity.edit.information.administrativeContact'} %}
         {% include '@Dashboard/EntityDetail/detailContactField.html.twig' with {label: 'entity.detail.contact.technical'|trans, value: entity.technicalContact, informationPopup: 'entity.edit.information.technicalContact'} %}
@@ -49,7 +49,7 @@
 
     <div class="fieldset card">
         <h2>{{ ('entity.detail.attribute.' ~ type ~ '.title')|trans }}</h2>
-        <div class="wysiwyg">{{ ('entity.detail.attribute.' ~ type ~ '.html')|trans|raw }}</div>
+        <div class="wysiwyg">{{ ('entity.detail.attribute.' ~ type ~ '.html')|trans|wysiwyg }}</div>
 
         {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.given_name')|trans, value: entity.givenNameAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.givenNameAttribute'} %}
         {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.surname')|trans, value: entity.surNameAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.surNameAttribute'} %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityEdit/edit.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityEdit/edit.html.twig
@@ -18,30 +18,30 @@
         {{ form_errors(form) }}
 
         <h2>{{ ('entity.edit.info.' ~ type ~ '.title')|trans }}</h2>
-        <div class="wysiwyg">{{ ('entity.edit.info.' ~ type ~ '.html')|trans|raw }}</div>
+        <div class="wysiwyg">{{ ('entity.edit.info.' ~ type ~ '.html')|trans|wysiwyg }}</div>
     </div>
 
     <div class="fieldset card">
         <h2>{{ ('entity.edit.metadata.' ~ type ~ '.title')|trans }}</h2>
-        <div class="wysiwyg">{{ ('entity.edit.metadata.' ~ type ~ '.html')|trans|raw }}</div>
+        <div class="wysiwyg">{{ ('entity.edit.metadata.' ~ type ~ '.html')|trans|wysiwyg }}</div>
         {{ form_widget(form.metadata) }}
     </div>
 
     <div class="fieldset card contact">
         <h2>{{ 'entity.edit.contact_information.title'|trans }}</h2>
-        <div class="wysiwyg">{{ 'entity.edit.contact_information.html'|trans|raw }}</div>
+        <div class="wysiwyg">{{ 'entity.edit.contact_information.html'|trans|wysiwyg }}</div>
         {{ form_widget(form.contactInformation) }}
     </div>
 
     <div class="fieldset card">
         <h2>{{ ('entity.edit.attributes.' ~ type ~ '.title')|trans }}</h2>
-        <div class="wysiwyg">{{ ('entity.edit.attributes.' ~ type ~ '.html')|trans|raw }}</div>
+        <div class="wysiwyg">{{ ('entity.edit.attributes.' ~ type ~ '.html')|trans|wysiwyg }}</div>
         {{ form_widget(form.attributes) }}
     </div>
 
     <div class="fieldset card">
         <h2>{{ 'entity.edit.comments.title'|trans }}</h2>
-        <div class="wysiwyg">{{ 'entity.edit.comments.html'|trans|raw }}</div>
+        <div class="wysiwyg">{{ 'entity.edit.comments.html'|trans|wysiwyg }}</div>
         {{ form_widget(form.comments) }}
     </div>
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityModal/secretResetModal.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityModal/secretResetModal.html.twig
@@ -3,8 +3,8 @@
 {% block page_heading %} {{ 'entity.actions.modal.oidc_client_reset.title'|trans }} {% endblock %}
 
 {% block body %}
-    <div class="warning"><i class="fa fa-exclamation-triangle"></i>{{ 'entity.actions.modal.oidc_client_reset.warning'|trans|raw }}</div>
-    <div class="wysiwyg">{{ 'entity.actions.modal.oidc_client_reset.info.html'|trans|raw }}</div>
+    <div class="warning"><i class="fa fa-exclamation-triangle"></i>{{ 'entity.actions.modal.oidc_client_reset.warning'|trans }}</div>
+    <div class="wysiwyg">{{ 'entity.actions.modal.oidc_client_reset.info.html'|trans|wysiwyg }}</div>
 
     <div class="row">
         <div class="button-row">

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/oidcConfirmationModal.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/oidcConfirmationModal.html.twig
@@ -3,8 +3,8 @@
 {% block page_heading %} {{ 'entity.list.modal.oidc_confirmation.title'|trans }} {% endblock %}
 
 {% block body %}
-    <div class="warning"><i class="fa fa-exclamation-triangle"></i>{{ 'entity.list.modal.oidc_confirmation.warning'|trans|raw }}</div>
-    <div class="wysiwyg">{{ 'entity.list.modal.oidc_confirmation.info.html'|trans|raw }}</div>
+    <div class="warning"><i class="fa fa-exclamation-triangle"></i>{{ 'entity.list.modal.oidc_confirmation.warning'|trans }}</div>
+    <div class="wysiwyg">{{ 'entity.list.modal.oidc_confirmation.info.html'|trans|wysiwyg }}</div>
 
     <div class="row oidc-confirmation">
         {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.list.modal.oidc_confirmation.client_secret.label'|trans, value: entity.clientSecret} %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/publishedProduction.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/publishedProduction.html.twig
@@ -3,6 +3,6 @@
 {% block page_heading %}{{ 'entity.published_production.title'|trans }}{%endblock%}
 {% block body %}
 
-    {{ 'entity.published_production.text.html'|trans({'%entityName%': entityName})|raw }}
+    {{ 'entity.published_production.text.html'|trans({'%entityName%': entityName})|wysiwyg }}
 
 {% endblock %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/publishedTest.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/publishedTest.html.twig
@@ -3,6 +3,6 @@
 {% block page_heading %}{{ 'entity.published_test.title'|trans }}{%endblock%}
 {% block body %}
 
-    {{ 'entity.published_test.text.html'|trans({'%entityName%': entityName})|raw }}
+    {{ 'entity.published_test.text.html'|trans({'%entityName%': entityName})|wysiwyg }}
 
 {% endblock %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityType/type.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityType/type.html.twig
@@ -6,7 +6,7 @@
 
 {% block body %}
 
-    <div class="wysiwyg">{{ 'entity.type.description.html'|trans|raw }}</div>
+    <div class="wysiwyg">{{ 'entity.type.description.html'|trans|wysiwyg }}</div>
 
     <div class="row entity-type">
         {{ form_start(form, {'action': path('entity_type', {'serviceId': serviceId, 'targetEnvironment': environment})}) }}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Privacy/form.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Privacy/form.html.twig
@@ -13,7 +13,7 @@
             </div>
         {% endfor %}
 
-        <div class="wysiwyg">{{ 'privacy.edit.introduction.html'|trans|raw }}</div>
+        <div class="wysiwyg">{{ 'privacy.edit.introduction.html'|trans|wysiwyg }}</div>
     </div>
 
     <div class="fieldset card">

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/admin_overview.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/admin_overview.html.twig
@@ -4,7 +4,7 @@
     <h1>{% block page_heading %}{{ 'service.admin_overview.title'|trans }}{%endblock%}</h1>
 
     <div class="fieldset card">
-        <div class="wysiwyg">{{ 'service.admin_overview.introduction.html'|trans|raw }}</div>
+        <div class="wysiwyg">{{ 'service.admin_overview.introduction.html'|trans|wysiwyg }}</div>
     </div>
 
 {% endblock %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Twig/WysiwygExtension.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Twig/WysiwygExtension.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Twig;
+
+use HTMLPurifier;
+use HTMLPurifier_HTML5Config;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class WysiwygExtension extends AbstractExtension
+{
+    /**
+     * @var HTMLPurifier
+     */
+    private static $purifier = null;
+
+    public function getFilters()
+    {
+        return [
+            new TwigFilter(
+                'wysiwyg',
+                [$this, 'sanitize'],
+                ['is_safe' => ['html']]
+            ),
+        ];
+    }
+
+    /**
+     * @param string $raw
+     * @return string
+     */
+    public function sanitize($raw)
+    {
+        return self::sanitizeWysiwyg($raw);
+    }
+
+    /**
+     * @param string $raw
+     * @return string
+     */
+    public static function sanitizeWysiwyg($raw)
+    {
+        self::initialise();
+        return self::$purifier->purify($raw);
+    }
+
+    private static function initialise()
+    {
+        if (!is_null(self::$purifier)) {
+            return;
+        }
+
+        $config = HTMLPurifier_HTML5Config::createDefault();
+
+        $config->set('HTML.Doctype', 'HTML5');
+        $config->set('Core.Encoding', 'UTF-8');
+        $config->set('HTML.AllowedElements', 'p,em,strong,span,h1,h2,h3,h4,h5,h6,ul,ol,li,a,sup,sub,code,blockquote,br');
+        $config->set('HTML.AllowedAttributes', 'a.target,a.href,p.style,span.style');
+        $config->set('CSS.AllowedProperties', 'text-decoration,text-align');
+        $config->set('Attr.AllowedFrameTargets', '_blank,_self,_parent,_top');
+
+        self::$purifier = new HTMLPurifier($config);
+    }
+}


### PR DESCRIPTION
The lexik translation bundle  doesn't input validate the wysiwyg
entries. Because it's third party software it's hard to get it into
the bundle. Therefore we decided to validate the output.

To do so a wysiwyg filter is introduced and the documentation is
updated accordingly.

Also the ServiceStatusAssembler needed to be updated in order to
escape the json returned to render the service status donut.

---
Boyscouted:
Add ajax.googleapis.com to CSP whitelist to load external assets
for the Lexik translation bundle.
