### PR TITLE
Disable the htmlpurifier cache

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Twig/WysiwygExtension.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Twig/WysiwygExtension.php
@@ -73,6 +73,7 @@ class WysiwygExtension extends AbstractExtension
         $config->set('HTML.AllowedAttributes', 'a.target,a.href,p.style,span.style');
         $config->set('CSS.AllowedProperties', 'text-decoration,text-align');
         $config->set('Attr.AllowedFrameTargets', '_blank,_self,_parent,_top');
+        $config->set('Cache.DefinitionImpl', null);
 
         self::$purifier = new HTMLPurifier($config);
     }


### PR DESCRIPTION
This is done in order to prevent warning because it will try
to write to `/vendor/ezyang/htmlpurifier/library/HTMLPurifier/DefinitionCache/Serializer`
which will generate a warning on production.

https://www.pivotaltracker.com/story/show/167222617