### PR TITLE
Prevent error when loading an empty issue mock file

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/DevelopmentIssueRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/DevelopmentIssueRepository.php
@@ -107,6 +107,9 @@ class DevelopmentIssueRepository implements TicketServiceInterface
             file_put_contents($this->filePath, '{}');
         }
         $rawData = json_decode(file_get_contents($this->filePath), true);
+        if (is_null($rawData)) {
+            $rawData = [];
+        }
         $this->data = $this->loadIssues($rawData);
     }
 

--- a/tests/unit/Infrastructure/DashboardBundle/Jira/Repository/IssueRepositoryTest.php
+++ b/tests/unit/Infrastructure/DashboardBundle/Jira/Repository/IssueRepositoryTest.php
@@ -109,6 +109,13 @@ class IssueRepositoryTest extends PHPUnit_Framework_TestCase
         $this->assertSame(4, $found);
     }
 
+    public function test_empty_file_should_not_throw_an_exception()
+    {
+        touch(self::CACHE_FILEPATH);
+        $result = $this->repository->findByManageId(1);
+        $this->assertNull($result);
+    }
+
     /**
      * @param $id
      * @param $issueType


### PR DESCRIPTION
When loading an empty issue mock file to get a working implementation without the use of a working Jira instance, a mock file was used.

If this file was empty an exception was thrown because the data was then not parsed to an empty array but to null which triggered input validation. This is now fixed.