### PR TITLE
Make Jira test mode configurable

### DIFF
--- a/ansible/roles/spdashboard/defaults/main.yml
+++ b/ansible/roles/spdashboard/defaults/main.yml
@@ -28,5 +28,7 @@ spdashboard_jira_entityid_fieldname: customfield_12914
 spdashboard_jira_manageid_fieldname: customfield_13401
 spdashboard_jira_manageid_field_label: "SURFconext Manage ID"
 spdashboard_jira_project_key: CXT
+spdashboard_test_mode_enabled: false
+spdashboard_test_mode_path: '../var/issues.json'
 playground_uri_test: https://authz-playground.dev.support.surfconext.nl
 playground_uri_prod: https://authz-playground.dev.support.surfconext.nl

--- a/ansible/roles/spdashboard/templates/parameters.yml.j2
+++ b/ansible/roles/spdashboard/templates/parameters.yml.j2
@@ -51,5 +51,7 @@ parameters:
     jira_issue_manageid_fieldname: {{ spdashboard_jira_manageid_fieldname }}
     jira_issue_manageid_field_label: {{ spdashboard_jira_manageid_field_label }}
     jira_issue_project_key: {{ spdashboard_jira_project_key }}
+    jira_enable_test_mode: {{ spdashboard_test_mode_enabled }}
+    jira_test_mode_storage_path: {{ spdashboard_test_mode_path }}
     playground_uri_test: {{ spdashboard_playground_uri_test }}
     playground_uri_prod: {{ spdashboard_playground_uri_prod }}

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -64,6 +64,11 @@ parameters:
     jira_username: sp-dashboard
     jira_password: secret
 
+    # By enabling 'jira_enable_test_mode', no real Jira backend is required to still simulate the Jira integration
+    jira_enable_test_mode: true
+    # When 'jira_enable_test_mode' is enabled, 'jira_test_mode_storage_path' must be configured with a filename in a directory that is writable for the user running the application.
+    jira_test_mode_storage_path: '../var/issues.json'
+
     # Jira default issue settings
     jira_issue_assignee: conext-beheer
     jira_issue_priority: Medium

--- a/docs/jira.md
+++ b/docs/jira.md
@@ -1,3 +1,12 @@
+# Use a Jira test stand in
+
+By default SP dashboard is configured to not use the test stand in option in dev or production modes. To enable this 
+feature. Simply configure the `jira_enable_test_mode: true` and `jira_test_mode_storage_path: '../var/issues.json'` to
+your liking. The values above are sensible defaults.
+
+The Jira interaction is now skipped, and all actions are handled in a happy flow manner. Resulting in a JSON file that
+is filled with ticket id's that are then used by the application to track the Jira workflow state.
+
 # Install local jira with Docker
 
 This how to is based on the ivantichy Jira Docker image [1]

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DashboardBundle.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DashboardBundle.php
@@ -18,8 +18,15 @@
 
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle;
 
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\DependencyInjection\Compiler\IssueRepositoryCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class DashboardBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new IssueRepositoryCompilerPass());
+        parent::build($container);
+    }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DependencyInjection/Compiler/IssueRepositoryCompilerPass.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DependencyInjection/Compiler/IssueRepositoryCompilerPass.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\DependencyInjection\Compiler;
+
+use Exception;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Factory\IssueFieldFactory;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Factory\JiraServiceFactory;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Repository\DevelopmentIssueRepository;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Repository\IssueRepository;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class IssueRepositoryCompilerPass implements CompilerPassInterface
+{
+    const ENABLE_TEST_MODE_FEATURE_FLAG = 'jira_enable_test_mode';
+    const JIRA_REPOSITORY_ISSUE_SERVICE = 'surfnet.dashboard.repository.issue';
+
+    /**
+     * Based on the jira_enable_test_mode feature flag, will load the regular or test stand in for the IssueRepository.
+     *
+     * @param ContainerBuilder $container
+     * @SuppressWarnings(PHPMD.ElseExpression)
+     * @throws Exception
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $hasParameter = $container->hasParameter(self::ENABLE_TEST_MODE_FEATURE_FLAG);
+        $hasDefinition = $container->hasDefinition(self::JIRA_REPOSITORY_ISSUE_SERVICE);
+        if (!$hasParameter || !$hasDefinition) {
+            return;
+        }
+
+        $isTestModeEnabled = (bool) $container->getParameter(self::ENABLE_TEST_MODE_FEATURE_FLAG);
+
+        $kernelEnv = $container->getParameter('kernel.environment');
+
+        // Web tests, ironically for now do not utilize the test stand-in.
+        if ($kernelEnv === 'test' && $isTestModeEnabled) {
+            $isTestModeEnabled = false;
+        }
+
+        if ($isTestModeEnabled) {
+            $this->configureServiceInTestMode($container);
+        } else {
+            $this->configureService($container);
+        }
+    }
+
+    /**
+     * Configure the 'real' Jira repository
+     * @param ContainerBuilder $container
+     */
+    private function configureService(ContainerBuilder $container)
+    {
+        $service = $container->getDefinition(self::JIRA_REPOSITORY_ISSUE_SERVICE);
+        $service->setClass(IssueRepository::class);
+        $service->setArguments([
+            $container->getDefinition(JiraServiceFactory::class),
+            $container->getDefinition(IssueFieldFactory::class),
+            $container->getParameter('jira_issue_project_key'),
+            $container->getParameter('jira_issue_type'),
+            $container->getParameter('jira_issue_manageid_fieldname'),
+            $container->getParameter('jira_issue_manageid_field_label'),
+        ]);
+    }
+
+    /**
+     * Configure the test stand-in Jira repository
+     * @param ContainerBuilder $container
+     */
+    private function configureServiceInTestMode(ContainerBuilder $container)
+    {
+        $service = $container->getDefinition(self::JIRA_REPOSITORY_ISSUE_SERVICE);
+        $service->setClass(DevelopmentIssueRepository::class);
+        $service->setArguments([
+            $container->getParameter('jira_test_mode_storage_path')
+        ]);
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DependencyInjection/DashboardExtension.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DependencyInjection/DashboardExtension.php
@@ -50,10 +50,6 @@ class DashboardExtension extends Extension
             $loader->load($rootDir.'/../tests/webtests/Resources/config/services.yml');
         }
 
-        if ($environment === 'dev') {
-            $loader->load('services_dev.yml');
-        }
-
         foreach ($config['manage'] as $environment => $manageConfig) {
             $this->parseManageConfiguration($environment, $manageConfig, $container);
         }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -262,14 +262,6 @@ services:
             - '@surfnet.dashboard.repository.issue'
 
     surfnet.dashboard.repository.issue:
-        class: 'Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Repository\IssueRepository'
-        arguments:
-            - '@Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Factory\JiraServiceFactory'
-            - '@Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Factory\IssueFieldFactory'
-            - '%jira_issue_project_key%'
-            - '%jira_issue_type%'
-            - '%jira_issue_manageid_fieldname%'
-            - '%jira_issue_manageid_field_label%'
 
     Surfnet\ServiceProviderDashboard\Application\Service\EntityService:
         arguments:

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services_dev.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services_dev.yml
@@ -1,5 +1,0 @@
-services:
-  surfnet.dashboard.repository.issue:
-    class: 'Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Repository\DevelopmentIssueRepository'
-    arguments:
-      - '../var/issues.json'


### PR DESCRIPTION
We sometimes do not have a working Jira configuration at the ready. In those cases the test stand-in is a useful fallback measure. Previously the test and development environment by default used this stand-in. This has now been changed to become a feature flag.

This flag can be set to true/false in the parameters.yml

The filePath of the test file has also been made into a configuration option while at it.

https://www.pivotaltracker.com/story/show/167315333