### PR TITLE
Request EPTI by default for each OIDC TNG entity

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcEntityCommand.php
@@ -530,7 +530,7 @@ class SaveOidcEntityCommand implements SaveEntityCommandInterface
     }
 
     /**
-     * @param string $redirectUris
+     * @param string[] $redirectUris
      */
     public function setRedirectUris($redirectUris)
     {

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
@@ -370,7 +370,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
 
     /**
      * @param Service $service
-     * @return SaveOidcEntityCommand
+     * @return SaveOidcngEntityCommand
      */
     public static function forCreateAction(Service $service)
     {
@@ -383,7 +383,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
     /**
      * @param Entity $entity
      *
-     * @return SaveOidcEntityCommand
+     * @return SaveOidcngEntityCommand
      */
     public static function fromEntity(Entity $entity)
     {
@@ -558,7 +558,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
     }
 
     /**
-     * @param string $redirectUrls
+     * @param string[] $redirectUrls
      */
     public function setRedirectUrls($redirectUrls)
     {
@@ -955,14 +955,6 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
     public function getEduPersonTargetedIDAttribute()
     {
         return $this->eduPersonTargetedIDAttribute;
-    }
-
-    /**
-     * @param Attribute $eduPersonTargetedIDAttribute
-     */
-    public function setEduPersonTargetedIDAttribute($eduPersonTargetedIDAttribute)
-    {
-        $this->eduPersonTargetedIDAttribute = $eduPersonTargetedIDAttribute;
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandler.php
@@ -122,7 +122,6 @@ class SaveOidcngEntityCommandHandler implements CommandHandler
         $entity->setPreferredLanguageAttribute($command->getPreferredLanguageAttribute());
         $entity->setPersonalCodeAttribute($command->getPersonalCodeAttribute());
         $entity->setScopedAffiliationAttribute($command->getScopedAffiliationAttribute());
-        $entity->setEduPersonTargetedIDAttribute($command->getEduPersonTargetedIDAttribute());
         $entity->setComments($command->getComments());
 
         // Set the name id format to unspecified.

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
@@ -408,16 +408,6 @@ class OidcngEntityType extends AbstractType
                             'attr' => ['data-help' => 'entity.edit.information.oidc.scopedAffiliationAttribute'],
                         ]
                     )
-                    ->add(
-                        'eduPersonTargetedIDAttribute',
-                        AttributeType::class,
-                        [
-                            'label' => 'entity.edit.form.attributes.oidc.eduPersonTargetedIDAttribute',
-                            'by_reference' => false,
-                            'required' => false,
-                            'attr' => ['data-help' => 'entity.edit.information.oidc.eduPersonTargetedIDAttribute'],
-                        ]
-                    )
             )
             ->add(
                 $builder->create('comments', FormType::class, ['inherit_data' => true])

--- a/tests/integration/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandlerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Integration\Application\CommandHandler\Entity;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery\Mock;
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngEntityCommand;
+use Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\SaveOidcngEntityCommandHandler;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityRepository;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
+
+class SaveOidcngEntityCommandHandlerTest extends MockeryTestCase
+{
+
+    /**
+     * @var SaveOidcngEntityCommandHandler
+     */
+    private $commandHandler;
+
+    /**
+     * @var EntityRepository&Mock
+     */
+    private $repository;
+
+    public function setUp()
+    {
+        $this->repository = m::mock(EntityRepository::class);
+
+        $this->commandHandler = new SaveOidcngEntityCommandHandler(
+            $this->repository
+        );
+    }
+
+    public function test_it_can_delete_an_entity_from_production()
+    {
+        $service = m::mock(Service::class);
+
+        $command = SaveOidcngEntityCommand::forCreateAction($service);
+        $command->setEntityId('test_entity');
+        $command->setGrantType(OidcGrantType::GRANT_TYPE_IMPLICIT);
+        $command->setRedirectUrls(['https://test.example.com/redirect', 'https://test.example.com/section/31/redirect']);
+        $command->setNameEn('Test Entity');
+        $command->setSupportContact(m::mock(Contact::class));
+        $command->setAdministrativeContact(m::mock(Contact::class));
+        $command->setTechnicalContact(m::mock(Contact::class));
+
+        $command->setGivenNameAttribute(m::mock(Attribute::class));
+        $command->setSurNameAttribute(m::mock(Attribute::class));
+        $command->setCommonNameAttribute(m::mock(Attribute::class));
+        $command->setDisplayNameAttribute(m::mock(Attribute::class));
+        $command->setEmailAddressAttribute(m::mock(Attribute::class));
+        $command->setOrganizationAttribute(m::mock(Attribute::class));
+        $command->setOrganizationTypeAttribute(m::mock(Attribute::class));
+        $command->setAffiliationAttribute(m::mock(Attribute::class));
+        $command->setEntitlementAttribute(m::mock(Attribute::class));
+        $command->setPrincipleNameAttribute(m::mock(Attribute::class));
+        $command->setUidAttribute(m::mock(Attribute::class));
+        $command->setPreferredLanguageAttribute(m::mock(Attribute::class));
+        $command->setPersonalCodeAttribute(m::mock(Attribute::class));
+        $command->setScopedAffiliationAttribute(m::mock(Attribute::class));
+
+        $this->repository
+            ->shouldReceive('isUnique')
+            ->andReturn(true);
+
+        $this->repository
+            ->shouldReceive('save')
+            ->with(
+                m::on(
+                    function (Entity $entity) {
+                        // EPTI is not configurable on OIDC(ng) forms
+                        $epti = $entity->getEduPersonTargetedIDAttribute();
+                        $this->assertNull($epti);
+                        $this->assertEquals('Test Entity', $entity->getNameEn());
+                        return true;
+                    }
+                )
+            );
+
+        $this->commandHandler->handle($command);
+    }
+}

--- a/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
@@ -53,10 +53,6 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
         $this->privacyQuestionsMetadataGenerator = m::mock(PrivacyQuestionsMetadataGenerator::class);
         $this->spDashboardMetadataGenerator = m::mock(SpDashboardMetadataGenerator::class);
 
-        $this->arpMetadataGenerator
-            ->shouldReceive('build')
-            ->andReturn(['arp' => 'arp']);
-
         $this->privacyQuestionsMetadataGenerator
             ->shouldReceive('build')
             ->andReturn(['privacy' => 'privacy']);
@@ -75,6 +71,22 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
             'http://oidc.test.playground.example.com',
             'http://oidc.prod.playground.example.com'
         );
+
+        $this->arpMetadataGenerator
+            ->shouldReceive('build')
+            ->with(
+                m::on(
+                    function (Entity $entity) {
+                        $epti = $entity->getEduPersonTargetedIDAttribute();
+                        $this->assertTrue($epti->isRequested());
+                        $this->assertTrue($epti->hasMotivation());
+                        $this->assertEquals('OIDC requires EduPersonTargetedID by default', $epti->getMotivation());
+
+                        return true;
+                    }
+                )
+            )
+            ->andReturn(['arp' => 'arp']);
 
         $data = $generator->generateForNewEntity($this->createOidcngEntity(), 'testaccepted');
         $this->assertEquals(
@@ -128,6 +140,10 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
 
     public function test_it_can_build_oidcng_data_for_existing_entities()
     {
+        $this->arpMetadataGenerator
+            ->shouldReceive('build')
+            ->andReturn(['arp' => 'arp']);
+
         $generator = new OidcngJsonGenerator(
             $this->arpMetadataGenerator,
             $this->privacyQuestionsMetadataGenerator,
@@ -190,6 +206,9 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
 
     public function test_it_can_build_acl_whitelist_for_existing_entities_default_allow_all()
     {
+        $this->arpMetadataGenerator
+            ->shouldReceive('build')
+            ->andReturn(['arp' => 'arp']);
         $generator = new OidcngJsonGenerator(
             $this->arpMetadataGenerator,
             $this->privacyQuestionsMetadataGenerator,
@@ -211,6 +230,10 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
 
     public function test_it_can_build_acl_whitelist_for_existing_entities_allow_all()
     {
+        $this->arpMetadataGenerator
+            ->shouldReceive('build')
+            ->andReturn(['arp' => 'arp']);
+
         $generator = new OidcngJsonGenerator(
             $this->arpMetadataGenerator,
             $this->privacyQuestionsMetadataGenerator,
@@ -232,6 +255,10 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
 
     public function test_it_can_build_acl_whitelist_for_existing_entities_none()
     {
+        $this->arpMetadataGenerator
+            ->shouldReceive('build')
+            ->andReturn(['arp' => 'arp']);
+
         $generator = new OidcngJsonGenerator(
             $this->arpMetadataGenerator,
             $this->privacyQuestionsMetadataGenerator,
@@ -254,6 +281,10 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
 
     public function test_it_can_build_acl_whitelist_for_existing_entities_allow_single()
     {
+        $this->arpMetadataGenerator
+            ->shouldReceive('build')
+            ->andReturn(['arp' => 'arp']);
+
         $generator = new OidcngJsonGenerator(
             $this->arpMetadataGenerator,
             $this->privacyQuestionsMetadataGenerator,
@@ -282,6 +313,10 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
 
     public function test_it_can_build_acl_whitelist_for_existing_entities_allow_multiple()
     {
+        $this->arpMetadataGenerator
+            ->shouldReceive('build')
+            ->andReturn(['arp' => 'arp']);
+
         $generator = new OidcngJsonGenerator(
             $this->arpMetadataGenerator,
             $this->privacyQuestionsMetadataGenerator,

--- a/tests/webtests/EntityCreateOidcngTest.php
+++ b/tests/webtests/EntityCreateOidcngTest.php
@@ -19,6 +19,7 @@
 namespace Surfnet\ServiceProviderDashboard\Webtests;
 
 use GuzzleHttp\Psr7\Response;
+use InvalidArgumentException;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
@@ -49,6 +50,19 @@ class EntityCreateOidcngTest extends WebTestCase
             $nameEnfield->getValue(),
             'Expect the NameEN field to be empty'
         );
+    }
+
+    public function epti_attribute_is_not_on_the_form()
+    {
+        $crawler = $this->client->request('GET', "/entity/create/2/oidcng/test");
+        $form = $crawler->filter('.page-container')
+            ->selectButton('Save')
+            ->form();
+
+        // OIDC NG entities do not have the epti attribute as an ARP option. As it's enabled by default.
+        // See: https://www.pivotaltracker.com/story/show/167511328
+        $this->expectException(InvalidArgumentException::class);
+        $form->get('dashboard_bundle_entity_type[attributes][eduPersonTargetedIDAttribute][requested]');
     }
 
     public function test_it_can_cancel_out_of_the_form()


### PR DESCRIPTION
The EduPersonTargettedID attribute is always requested for oidcng
entities. The command tasked with saving the entities enables the epti
attribute by default.

See: https://www.pivotaltracker.com/story/show/167511328