### PR TITLE
Enable an additional grant type

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
@@ -23,6 +23,7 @@ use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints as SpDashboardAssert;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -104,9 +105,11 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
     private $isPublicClient;
 
     /**
-     * @var array
+     * @var OidcGrantType
+     *
+     * @Assert\NotBlank()
      */
-    private $grants = ['authorization_code'];
+    private $grantType;
 
     /**
      * @var int
@@ -394,6 +397,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
         $command->entityId = $entity->getEntityId();
         $command->secret = $entity->getClientSecret();
         $command->redirectUrls = $entity->getRedirectUris();
+        $command->grantType = $entity->getGrantType()->getGrantType();
         $command->logoUrl = $entity->getLogoUrl();
         $command->nameNl = $entity->getNameNl();
         $command->nameEn = $entity->getNameEn();
@@ -559,14 +563,6 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
     public function setRedirectUrls($redirectUrls)
     {
         $this->redirectUrls = $redirectUrls;
-    }
-
-    /**
-     * @return array
-     */
-    public function getGrants()
-    {
-        return $this->grants;
     }
 
     /**
@@ -1190,5 +1186,21 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
     public function setEnablePlayground($enablePlayground)
     {
         $this->enablePlayground = $enablePlayground;
+    }
+
+    /**
+     * @return OidcGrantType
+     */
+    public function getGrantType()
+    {
+        return $this->grantType;
+    }
+
+    /**
+     * @param OidcGrantType $grantType
+     */
+    public function setGrantType($grantType)
+    {
+        $this->grantType = $grantType;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandler.php
@@ -96,9 +96,8 @@ class SaveOidcngEntityCommandHandler implements CommandHandler
         $entity->setAccessTokenValidity($command->getAccessTokenValidity());
         $entity->setIsPublicClient($command->isPublicClient());
         $entity->setEnablePlayground($command->isEnablePlayground());
-        // Only one grant type is supported yet, use that one to create the OidcGrantType.
-        $grantTypes =  $command->getGrants();
-        $entity->setGrantType(new OidcGrantType(reset($grantTypes)));
+        $grantType =  $command->getGrantType();
+        $entity->setGrantType(new OidcGrantType($grantType));
         $entity->setLogoUrl($command->getLogoUrl());
         $entity->setNameNl($command->getNameNl());
         $entity->setNameEn($command->getNameEn());

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
@@ -19,8 +19,10 @@
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity;
 
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngEntityCommand;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -130,6 +132,21 @@ class OidcngEntityType extends AbstractType
                         'required' => false,
                         'data-help' => 'entity.edit.information.isPublicClient',
                     ]
+                ]
+            )
+            ->add(
+                'grantType',
+                ChoiceType::class,
+                [
+                    'expanded' => true,
+                    'multiple' => false,
+                    'choices'  => [
+                        'entity.edit.label.authorization_code' => OidcGrantType::GRANT_TYPE_AUTHORIZATION_CODE,
+                        'entity.edit.label.implicit' => OidcGrantType::GRANT_TYPE_IMPLICIT,
+                    ],
+                    'attr' => [
+                        'data-help' => 'entity.edit.information.grantType',
+                    ],
                 ]
             )
             ->add(

--- a/tests/webtests/EntityCreateOidcngTest.php
+++ b/tests/webtests/EntityCreateOidcngTest.php
@@ -252,6 +252,7 @@ class EntityCreateOidcngTest extends WebTestCase
                     'nameNl' => 'The A Team',
                     'clientId' => 'https://entity-id',
                     'isPublicClient' => true,
+                    'grantType' => 'implicit',
                     'accessTokenValidity' => 3600,
                     'logoUrl' => 'https://logo-url',
                 ],


### PR DESCRIPTION
Previously all oidcng entities would be set with grant type `authorization_code`. Now the user can choose between the `authorization_code` and implicit. The oidcng behaviour for the grant types is now aligned with that of the oidc type.

https://www.pivotaltracker.com/story/show/167511241