### PR TITLE
Allow selection of Subject Type (NameIdFormat)

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
@@ -141,7 +141,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      *     strict=true
      * )
      */
-    private $subjectType = Entity::NAME_ID_FORMAT_DEFAULT;
+    private $subjectType = Entity::NAME_ID_FORMAT_TRANSIENT;
 
     /**
      * @var string

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
@@ -129,6 +129,21 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
     private $logoUrl;
 
     /**
+     * The subject type is comparable to the SAML name id format, that is why the Entity::NAME_ID_FORMAT_DEFAULT
+     * (transient) is used to set the default value.
+     *
+     * @var string
+     * @Assert\Choice(
+     *     callback={
+     *         "Surfnet\ServiceProviderDashboard\Domain\Entity\Entity",
+     *         "getValidNameIdFormats"
+     *     },
+     *     strict=true
+     * )
+     */
+    private $subjectType = Entity::NAME_ID_FORMAT_DEFAULT;
+
+    /**
      * @var string
      * @Assert\NotBlank()
      */
@@ -401,6 +416,8 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
         $command->logoUrl = $entity->getLogoUrl();
         $command->nameNl = $entity->getNameNl();
         $command->nameEn = $entity->getNameEn();
+        // The SAML nameidformat is used as the OIDC subject type https://www.pivotaltracker.com/story/show/167511146
+        $command->subjectType = $entity->getNameIdFormat();
         $command->descriptionNl = $entity->getDescriptionNl();
         $command->descriptionEn = $entity->getDescriptionEn();
         $command->applicationUrl = $entity->getApplicationUrl();
@@ -982,14 +999,6 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
     }
 
     /**
-     * @return bool
-     */
-    public function hasNameIdFormat()
-    {
-        return !empty($this->nameIdFormat);
-    }
-
-    /**
      * @return string
      */
     public function getOrganizationNameNl()
@@ -1202,5 +1211,21 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
     public function setGrantType($grantType)
     {
         $this->grantType = $grantType;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSubjectType()
+    {
+        return $this->subjectType;
+    }
+
+    /**
+     * @param string $subjectType
+     */
+    public function setSubjectType($subjectType)
+    {
+        $this->subjectType = $subjectType;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveSamlEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveSamlEntityCommand.php
@@ -322,7 +322,7 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
      *     strict=true
      * )
      */
-    private $nameIdFormat = Entity::NAME_ID_FORMAT_DEFAULT;
+    private $nameIdFormat = Entity::NAME_ID_FORMAT_TRANSIENT;
 
     /**
      * @var string

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandler.php
@@ -98,6 +98,8 @@ class SaveOidcngEntityCommandHandler implements CommandHandler
         $entity->setEnablePlayground($command->isEnablePlayground());
         $grantType =  $command->getGrantType();
         $entity->setGrantType(new OidcGrantType($grantType));
+        // The OIDC subject type is analog to the SAML NameIdFormat: https://www.pivotaltracker.com/story/show/167511146
+        $entity->setNameIdFormat($command->getSubjectType());
         $entity->setLogoUrl($command->getLogoUrl());
         $entity->setNameNl($command->getNameNl());
         $entity->setNameEn($command->getNameEn());
@@ -124,9 +126,6 @@ class SaveOidcngEntityCommandHandler implements CommandHandler
         $entity->setScopedAffiliationAttribute($command->getScopedAffiliationAttribute());
         $entity->setEduPersonTargetedIDAttribute($command->getEduPersonTargetedIDAttribute());
         $entity->setComments($command->getComments());
-
-        // Set the name id format to unspecified.
-        $entity->setNameIdFormat(Entity::NAME_ID_FORMAT_UNSPECIFIED);
 
         $entity->setOrganizationNameNl($command->getOrganizationNameNl());
         $entity->setOrganizationNameEn($command->getOrganizationNameEn());

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveSamlEntityCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveSamlEntityCommandHandler.php
@@ -114,7 +114,7 @@ class SaveSamlEntityCommandHandler implements CommandHandler
         if ($command->hasNameIdFormat()) {
             $entity->setNameIdFormat($command->getNameIdFormat());
         } else {
-            $entity->setNameIdFormat(Entity::NAME_ID_FORMAT_DEFAULT);
+            $entity->setNameIdFormat(Entity::NAME_ID_FORMAT_TRANSIENT);
         }
 
         $entity->setOrganizationNameNl($command->getOrganizationNameNl());

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
@@ -43,7 +43,7 @@ class Entity
     const BINDING_HTTP_POST = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST';
 
     // When adding valid name id formats, don't forget to add them to self::getValidNameIdFormats()
-    const NAME_ID_FORMAT_DEFAULT = 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient';
+    const NAME_ID_FORMAT_TRANSIENT = 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient';
     const NAME_ID_FORMAT_PERSISTENT = 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent';
     const NAME_ID_FORMAT_UNSPECIFIED = 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified';
 
@@ -1488,7 +1488,7 @@ class Entity
     public static function getValidNameIdFormats()
     {
         return [
-            static::NAME_ID_FORMAT_DEFAULT,
+            static::NAME_ID_FORMAT_TRANSIENT,
             static::NAME_ID_FORMAT_PERSISTENT,
         ];
     }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
@@ -156,7 +156,7 @@ class OidcngEntityType extends AbstractType
                     'expanded' => true,
                     'multiple' => false,
                     'choices'  => [
-                        'entity.edit.label.transient' => Entity::NAME_ID_FORMAT_DEFAULT,
+                        'entity.edit.label.transient' => Entity::NAME_ID_FORMAT_TRANSIENT,
                         'entity.edit.label.persistent' => Entity::NAME_ID_FORMAT_PERSISTENT,
                     ],
                     'attr' => [

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
@@ -19,6 +19,7 @@
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity;
 
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngEntityCommand;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -27,7 +28,6 @@ use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
-use Symfony\Component\Form\Extension\Core\Type\RangeType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -146,6 +146,22 @@ class OidcngEntityType extends AbstractType
                     ],
                     'attr' => [
                         'data-help' => 'entity.edit.information.grantType',
+                    ],
+                ]
+            )
+            ->add(
+                'subjectType',
+                ChoiceType::class,
+                [
+                    'expanded' => true,
+                    'multiple' => false,
+                    'choices'  => [
+                        'entity.edit.label.transient' => Entity::NAME_ID_FORMAT_DEFAULT,
+                        'entity.edit.label.persistent' => Entity::NAME_ID_FORMAT_PERSISTENT,
+                    ],
+                    'attr' => [
+                        'class' => 'nameidformat-container',
+                        'data-help' => 'entity.edit.information.subjectType',
                     ],
                 ]
             )

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
@@ -129,7 +129,7 @@ class SamlEntityType extends AbstractType
                             'expanded' => true,
                             'multiple' => false,
                             'choices'  => [
-                                'entity.edit.label.transient' => Entity::NAME_ID_FORMAT_DEFAULT,
+                                'entity.edit.label.transient' => Entity::NAME_ID_FORMAT_TRANSIENT,
                                 'entity.edit.label.persistent' => Entity::NAME_ID_FORMAT_PERSISTENT,
                             ],
                             'attr' => [

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -38,6 +38,7 @@ entity:
       redirect_uris: Redirect URIs
       playground_enabled: Playground enabled?
       name_id_format: NameID format
+      subject_type: Subject type
       certificate: Certificate
       logo_url: Logo URL
       name_nl: Name NL
@@ -353,6 +354,7 @@ entity.edit.information.oidc.scopedAffiliationAttribute: Text should be set in w
 entity.edit.information.oidc.eduPersonTargetedIDAttribute: Text should be set in web translations
 entity.edit.information.comments: Text should be set in web translations
 entity.edit.information.nameIdFormat: Text should be set in web translations
+entity.edit.information.subjectType: Text should be set in web translations
 entity.edit.motivation.keep_talking: 'Please provide a more detailed motivation.'
 entity.edit.label.transient: Transient
 entity.edit.label.persistent: Persistent

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detail.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detail.html.twig
@@ -21,6 +21,10 @@
         {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.acs_location'|trans, value: entity.acsLocation, informationPopup: 'entity.edit.information.acsLocation'} %}
         {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.entity_id'|trans, value: entity.entityId, informationPopup: 'entity.edit.information.entityId'} %}
 
+        {% if entity.protocol == "saml" %}
+            {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.name_id_format'|trans, value: entity.nameIdFormat|replace({'urn:oasis:names:tc:SAML:2.0:nameid-format:': ''}), informationPopup: 'entity.edit.information.nameIdFormat'} %}
+        {% endif %}
+
         {% if entity.protocol == "oidc" %}
             {% include '@Dashboard/EntityDetail/detailListField.html.twig' with {label: 'entity.detail.metadata.redirect_uris'|trans, value: entity.redirectUris, informationPopup: 'entity.edit.information.redirectUris'} %}
             {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.grant_type'|trans, value: ('entity.edit.label.' ~ entity.grantType)|trans, informationPopup: 'entity.edit.information.grantType'} %}
@@ -30,12 +34,13 @@
         {% if entity.protocol == "oidcng" %}
             {% include '@Dashboard/EntityDetail/detailListField.html.twig' with {label: 'entity.detail.metadata.redirect_uris'|trans, value: entity.redirectUris, informationPopup: 'entity.edit.information.redirectUris'} %}
             {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.grant_type'|trans, value: ('entity.edit.label.' ~ entity.grantType)|trans, informationPopup: 'entity.edit.information.grantType'} %}
+            {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.subject_type'|trans, value: entity.nameIdFormat|replace({'urn:oasis:names:tc:SAML:2.0:nameid-format:': ''}), informationPopup: 'entity.edit.information.subjectType'} %}
             {% include '@Dashboard/EntityDetail/detailBooleanField.html.twig' with {label: 'entity.detail.metadata.playground_enabled'|trans, value: entity.playgroundEnabled, informationPopup: 'entity.edit.information.playgroundEnabled'} %}
             {% include '@Dashboard/EntityDetail/detailBooleanField.html.twig' with {label: 'entity.detail.metadata.is_public_client'|trans, value: entity.publicClient, informationPopup: 'entity.edit.information.isPublicClient'} %}
             {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.access_token_validity'|trans, value: entity.accessTokenValidity, informationPopup: 'entity.edit.information.accessTokenValidity'} %}
         {% endif %}
 
-        {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.name_id_format'|trans, value: entity.nameIdFormat, informationPopup: 'entity.edit.information.nameIdFormat'} %}
+
         {% include '@Dashboard/EntityDetail/detailFormattedField.html.twig' with {label: 'entity.detail.metadata.certificate'|trans, value: entity.certificate, informationPopup: 'entity.edit.information.certificate'} %}
         {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.logo_url'|trans, value: entity.logoUrl, informationPopup: 'entity.edit.information.logoUrl'} %}
         {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.name_nl'|trans, value: entity.nameNl, informationPopup: 'entity.edit.information.nameNl'} %}

--- a/tests/webtests/EntityCreateSamlTest.php
+++ b/tests/webtests/EntityCreateSamlTest.php
@@ -173,7 +173,7 @@ class EntitySamlCreateSamlTest extends WebTestCase
         $entities = $this->getEntityRepository()->findAll();
         /** @var Entity $entity */
         $entity = end($entities);
-        $this->assertEquals(Entity::NAME_ID_FORMAT_DEFAULT, $entity->getNameIdFormat());
+        $this->assertEquals(Entity::NAME_ID_FORMAT_TRANSIENT, $entity->getNameIdFormat());
     }
 
     public function test_it_can_publish_the_form()


### PR DESCRIPTION
The OIDCng contributing users are now able to specifiy the subject type of their entity. Which is analog to the SAML20 NameIdFormat.

More details in: https://www.pivotaltracker.com/story/show/167511146