### PR TITLE
Refrain from sending a NULL secret to Manage

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
@@ -243,7 +243,10 @@ class OidcngJsonGenerator implements GeneratorInterface
      */
     private function generateOidcClient(Entity $entity)
     {
-        $metadata['secret'] = $entity->getClientSecret();
+        $secret = $entity->getClientSecret();
+        if ($secret) {
+            $metadata['secret'] = $secret;
+        }
         // Reset the redirect URI list in order to get a correct JSON formatting (See #163646662)
         $metadata['redirectUrls'] = $entity->getRedirectUris();
         $metadata['grants'] = [$entity->getGrantType()->getGrantType()];

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php
@@ -85,11 +85,13 @@ class PublishEntityClient implements PublishEntityRepositoryInterface
             } else {
                 $this->logger->info(sprintf('Updating existing \'%s\' entity in manage', $entity->getEntityId()));
 
+                $data = json_encode($this->generator->generateForExistingEntity(
+                    $entity,
+                    $this->manageConfig->getPublicationStatus()->getStatus()
+                ));
+
                 $response = $this->client->put(
-                    json_encode($this->generator->generateForExistingEntity(
-                        $entity,
-                        $this->manageConfig->getPublicationStatus()->getStatus()
-                    )),
+                    $data,
                     '/manage/api/internal/merge'
                 );
             }


### PR DESCRIPTION
Sending the client secret a second time (null) will cause Manage to spit out a 500 error. Easily remedied by testing if the client secret is set. If it is not, we no longer pass it to Manage API.

https://www.pivotaltracker.com/story/show/168049212