### PR TITLE
Correctly display ClientID values

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcEntityCommand.php
@@ -19,6 +19,7 @@
 namespace Surfnet\ServiceProviderDashboard\Application\Command\Entity;
 
 use InvalidArgumentException;
+use Surfnet\ServiceProviderDashboard\Application\Parser\OidcClientIdParser;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute;
@@ -501,7 +502,7 @@ class SaveOidcEntityCommand implements SaveEntityCommandInterface
      */
     public function getClientId()
     {
-        return str_replace('://', '@//', $this->entityId);
+        return OidcClientIdParser::parse($this->entityId);
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
@@ -21,6 +21,7 @@ namespace Surfnet\ServiceProviderDashboard\Application\Metadata;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\ArpGenerator;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\PrivacyQuestionsMetadataGenerator;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\SpDashboardMetadataGenerator;
+use Surfnet\ServiceProviderDashboard\Application\Parser\OidcClientIdParser;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
 
@@ -278,7 +279,7 @@ class JsonGenerator implements GeneratorInterface
      */
     private function generateOidcClient(Entity $entity)
     {
-        $metadata['clientId'] = str_replace('://', '@//', $entity->getEntityId());
+        $metadata['clientId'] = OidcClientIdParser::parse($entity->getEntityId());
         $metadata['clientSecret'] = $entity->getClientSecret();
         // Reset the redirect URI list in order to get a correct JSON formatting (See #163646662)
         $metadata['redirectUris'] = $entity->getRedirectUris();

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
@@ -21,6 +21,7 @@ namespace Surfnet\ServiceProviderDashboard\Application\Metadata;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\ArpGenerator;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\PrivacyQuestionsMetadataGenerator;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\SpDashboardMetadataGenerator;
+use Surfnet\ServiceProviderDashboard\Application\Parser\OidcngClientIdParser;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
@@ -125,7 +126,7 @@ class OidcngJsonGenerator implements GeneratorInterface
         $metadata = [
             'arp' => $this->arpMetadataGenerator->build($entity),
             'type' => 'oidc10-rp',
-            'entityid' => $this->updateClientId($entity->getEntityId()),
+            'entityid' => OidcngClientIdParser::parse($entity->getEntityId()),
             'active' => true,
             'state' => $workflowState,
             'metaDataFields' => $this->generateMetadataFields($entity),
@@ -152,7 +153,7 @@ class OidcngJsonGenerator implements GeneratorInterface
         $this->addEpti($entity);
         $metadata = [
             'arp' => $this->arpMetadataGenerator->build($entity),
-            'entityid' => $this->updateClientId($entity->getEntityId()),
+            'entityid' => OidcngClientIdParser::parse($entity->getEntityId()),
             'state' => $workflowState,
         ];
 
@@ -399,29 +400,6 @@ class OidcngJsonGenerator implements GeneratorInterface
             'allowedEntities' => $providers,
             'allowedall' => false,
         ];
-    }
-
-    /**
-     * Takes the entity id and removes the protocol as per:
-     *
-     * https://www.pivotaltracker.com/story/show/166702113/comments/204130376
-     *
-     * @param $entityId
-     * @return mixed
-     */
-    private function updateClientId($entityId)
-    {
-        $parts = parse_url($entityId);
-
-        // If no scheme is set, we are dealing with an entity that already had his scheme chopped off
-        if (!isset($parts['scheme'])) {
-            return $entityId;
-        }
-
-        // Remove the scheme (protocol) and the :// part
-        $clientId = str_replace($parts['scheme'].'://', '', $entityId);
-
-        return $clientId;
     }
 
     private function addEpti(Entity $entity)

--- a/src/Surfnet/ServiceProviderDashboard/Application/Parser/OidcClientIdParser.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Parser/OidcClientIdParser.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Parser;
+
+class OidcClientIdParser
+{
+
+    /**
+     * Takes the entity id and removes the protocol as per:
+     *
+     * https://www.pivotaltracker.com/story/show/166702113/comments/204130376
+     *
+     * @param $entityId
+     * @return mixed
+     */
+    public static function parse($entityId)
+    {
+        return str_replace('://', '@//', $entityId);
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/Parser/OidcClientIdParser.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Parser/OidcClientIdParser.php
@@ -18,16 +18,18 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Parser;
 
+/**
+ * A SAML Entity ID to OIDC ClientID parser
+ *
+ * Takes the entity id and removes the protocol as per:
+ *
+ * https://www.pivotaltracker.com/story/show/166702113/comments/204130376
+ */
 class OidcClientIdParser
 {
-
     /**
-     * Takes the entity id and removes the protocol as per:
-     *
-     * https://www.pivotaltracker.com/story/show/166702113/comments/204130376
-     *
-     * @param $entityId
-     * @return mixed
+     * @param string $entityId
+     * @return string
      */
     public static function parse($entityId)
     {

--- a/src/Surfnet/ServiceProviderDashboard/Application/Parser/OidcngClientIdParser.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Parser/OidcngClientIdParser.php
@@ -18,14 +18,18 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Parser;
 
+/**
+ * A SAML Entity ID to OIDC ClientID (TNG) parser
+ *
+ * Converts a entity id (which is a valid URL) to the proprietary SURFnet OpenID connect client id format.
+ *
+ * https://www.pivotaltracker.com/story/show/166702113/comments/204130376
+ */
 class OidcngClientIdParser
 {
-
     /**
-     * Converts a entity id (which is a valid URL) to the proprietary SURFnet OpenID connect client id format.
-     *
-     * @param $entityId
-     * @return mixed
+     * @param string $entityId
+     * @return string
      */
     public static function parse($entityId)
     {

--- a/src/Surfnet/ServiceProviderDashboard/Application/Parser/OidcngClientIdParser.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Parser/OidcngClientIdParser.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Parser;
+
+class OidcngClientIdParser
+{
+
+    /**
+     * Converts a entity id (which is a valid URL) to the proprietary SURFnet OpenID connect client id format.
+     *
+     * @param $entityId
+     * @return mixed
+     */
+    public static function parse($entityId)
+    {
+        $parts = parse_url($entityId);
+
+        // If no scheme is set, we are dealing with an entity that already had his scheme chopped off
+        if (!isset($parts['scheme'])) {
+            return $entityId;
+        }
+
+        // Remove the scheme (protocol) and the :// part
+        $clientId = str_replace($parts['scheme'].'://', '', $entityId);
+
+        return $clientId;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Entity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Entity.php
@@ -17,7 +17,7 @@
  */
 namespace Surfnet\ServiceProviderDashboard\Application\ViewObject;
 
-use Surfnet\ServiceProviderDashboard\Application\Parser\OidcClientIdParserTest;
+use Surfnet\ServiceProviderDashboard\Application\Parser\OidcClientIdParser;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity as DomainEntity;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact as Contact;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
@@ -232,7 +232,7 @@ class Entity
         if ($this->getProtocol() !== DomainEntity::TYPE_OPENID_CONNECT) {
             return $this->entityId;
         }
-        return OidcClientIdParserTest::parse($this->entityId);
+        return OidcClientIdParser::parse($this->entityId);
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Entity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Entity.php
@@ -17,6 +17,7 @@
  */
 namespace Surfnet\ServiceProviderDashboard\Application\ViewObject;
 
+use Surfnet\ServiceProviderDashboard\Application\Parser\OidcClientIdParserTest;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity as DomainEntity;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact as Contact;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
@@ -231,7 +232,7 @@ class Entity
         if ($this->getProtocol() !== DomainEntity::TYPE_OPENID_CONNECT) {
             return $this->entityId;
         }
-        return str_replace('://', '@//', $this->entityId);
+        return OidcClientIdParserTest::parse($this->entityId);
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityDetail.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityDetail.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\ViewObject;
 
-use Surfnet\ServiceProviderDashboard\Application\Parser\OidcClientIdParserTest;
+use Surfnet\ServiceProviderDashboard\Application\Parser\OidcClientIdParser;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity as DomainEntity;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
@@ -367,7 +367,7 @@ class EntityDetail
         if ($this->getProtocol() !== DomainEntity::TYPE_OPENID_CONNECT) {
             return $this->entityId;
         }
-        return OidcClientIdParserTest::parse($this->entityId);
+        return OidcClientIdParser::parse($this->entityId);
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityDetail.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityDetail.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\ViewObject;
 
+use Surfnet\ServiceProviderDashboard\Application\Parser\OidcClientIdParserTest;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity as DomainEntity;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
@@ -366,7 +367,7 @@ class EntityDetail
         if ($this->getProtocol() !== DomainEntity::TYPE_OPENID_CONNECT) {
             return $this->entityId;
         }
-        return str_replace('://', '@//', $this->entityId);
+        return OidcClientIdParserTest::parse($this->entityId);
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityOidcConfirmation.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityOidcConfirmation.php
@@ -17,6 +17,8 @@
  */
 namespace Surfnet\ServiceProviderDashboard\Application\ViewObject;
 
+use Surfnet\ServiceProviderDashboard\Application\Parser\OidcClientIdParser;
+use Surfnet\ServiceProviderDashboard\Application\Parser\OidcngClientIdParser;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity as DomainEntity;
 
 class EntityOidcConfirmation
@@ -32,22 +34,30 @@ class EntityOidcConfirmation
     private $clientSecret;
 
     /**
+     * @var string
+     */
+    private $protocol;
+
+    /**
      * @param string $entityId
      * @param string $clientSecret
      */
     public function __construct(
         $entityId,
-        $clientSecret
+        $clientSecret,
+        $protocol
     ) {
         $this->entityId = $entityId;
         $this->clientSecret = $clientSecret;
+        $this->protocol = $protocol;
     }
 
     public static function fromEntity(DomainEntity $entity)
     {
         return new self(
             $entity->getEntityId(),
-            $entity->getClientSecret()
+            $entity->getClientSecret(),
+            $entity->getProtocol()
         );
     }
 
@@ -56,7 +66,11 @@ class EntityOidcConfirmation
      */
     public function getEntityId()
     {
-        return str_replace('://', '@//', $this->entityId);
+        if ($this->protocol === DomainEntity::TYPE_OPENID_CONNECT_TNG) {
+            return OidcngClientIdParser::parse($this->entityId);
+        }
+
+        return OidcClientIdParser::parse($this->entityId);
     }
 
     /**

--- a/tests/unit/Application/Parser/OidcClientIdParserTest.php
+++ b/tests/unit/Application/Parser/OidcClientIdParserTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Application\Parser;
+
+use PHPUnit\Framework\TestCase;
+use Surfnet\ServiceProviderDashboard\Application\Parser\OidcClientIdParser;
+
+class OidcClientIdParserTest extends TestCase
+{
+    /**
+     * @param $url
+     * @param $expectation
+     * @param $message
+     *
+     * @dataProvider entityIdGenerator
+     */
+    public function test_expected_transformation($url, $expectation, $message)
+    {
+        $this->assertEquals($expectation, OidcClientIdParser::parse($url), $message);
+    }
+
+    public static function entityIdGenerator()
+    {
+        return [
+            ['https://www.google.com', 'https@//www.google.com', 'parses https'],
+            ['https://www.google.com/entityId', 'https@//www.google.com/entityId', 'parses https with path'],
+            ['http://www.google.com', 'http@//www.google.com', 'parses http'],
+            ['http://www.google.com/entityId', 'http@//www.google.com/entityId', 'parses https with path'],
+        ];
+    }
+}

--- a/tests/unit/Application/Parser/OidcngClientIdParserTest.php
+++ b/tests/unit/Application/Parser/OidcngClientIdParserTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Application\Parser;
+
+use PHPUnit\Framework\TestCase;
+use Surfnet\ServiceProviderDashboard\Application\Parser\OidcngClientIdParser;
+
+class OidcngClientIdParserTest extends TestCase
+{
+    /**
+     * @param $url
+     * @param $expectation
+     * @param $message
+     *
+     * @dataProvider entityIdGenerator
+     */
+    public function test_expected_transformation($url, $expectation, $message)
+    {
+        $this->assertEquals($expectation, OidcngClientIdParser::parse($url), $message);
+    }
+
+    public static function entityIdGenerator()
+    {
+        return [
+            ['https://www.google.com', 'www.google.com', 'parses https'],
+            ['https://www.google.com/entityId', 'www.google.com/entityId', 'parses https with path'],
+            ['http://www.google.com', 'www.google.com', 'parses http'],
+            ['http://www.google.com/entityId', 'www.google.com/entityId', 'parses https with path'],
+        ];
+    }
+}


### PR DESCRIPTION
The Oidc and Oidc TNG entities have different client id conventions. The parsers should ensure we always create the correct client id. Where currently the conversion logic is implemented in different classes, this solution enables the reuse of the conversion logic.

Both the Oidc and Oidc TNG classes, using or displaying the ClientID now use the correct parser to do so.

See: https://www.pivotaltracker.com/story/show/167510409