### PR TITLE
Set a hard default value on access token validity

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
@@ -119,7 +119,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      * @Assert\LessThanOrEqual(86400)
      * @Assert\GreaterThanOrEqual(3600)
      */
-    private $accessTokenValidity;
+    private $accessTokenValidity = 3600;
 
     /**
      * @var string

--- a/tests/integration/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandlerTest.php
@@ -93,6 +93,9 @@ class SaveOidcngEntityCommandHandlerTest extends MockeryTestCase
                         $epti = $entity->getEduPersonTargetedIDAttribute();
                         $this->assertNull($epti);
                         $this->assertEquals('Test Entity', $entity->getNameEn());
+                        // Without setting it explicitly 3600 is used as the default value
+                        // See: https://www.pivotaltracker.com/story/show/167510474
+                        $this->assertEquals(3600, $entity->getAccessTokenValidity());
                         return true;
                     }
                 )


### PR DESCRIPTION
Previously only the placeholder value was shown on the field. This is
still in place and is displayed when the default of 3600 is removed
manually.

https://www.pivotaltracker.com/story/show/167510474