### PR TITLE
Implement OIDC TNG resource server support

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcEntityCommand.php
@@ -27,7 +27,6 @@ use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints as SpDashboardAssert;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
  * @SuppressWarnings(PHPMD.TooManyFields)

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
@@ -26,7 +26,6 @@ use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints as SpDashboardAssert;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
  * @SuppressWarnings(PHPMD.TooManyFields)
@@ -379,7 +378,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
     /**
      * @var string
      */
-    private $protocol;
+    private $protocol = Entity::TYPE_OPENID_CONNECT_TNG;
 
     private function __construct()
     {
@@ -389,13 +388,10 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      * @param Service $service
      * @return SaveOidcngEntityCommand
      */
-    public static function forCreateAction(Service $service, $protocol)
+    public static function forCreateAction(Service $service)
     {
         $command = new self();
         $command->service = $service;
-
-        $command->protocol = $protocol;
-
         return $command;
     }
 
@@ -416,9 +412,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
         $command->entityId = $entity->getEntityId();
         $command->secret = $entity->getClientSecret();
         $command->redirectUrls = $entity->getRedirectUris();
-        if ($entity->getProtocol() !== Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER) {
-            $command->grantType = $entity->getGrantType()->getGrantType();
-        }
+        $command->grantType = $entity->getGrantType()->getGrantType();
         $command->logoUrl = $entity->getLogoUrl();
         $command->nameNl = $entity->getNameNl();
         $command->nameEn = $entity->getNameEn();
@@ -456,8 +450,6 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
         $command->isPublicClient = $entity->isPublicClient();
         $command->accessTokenValidity = (int) $entity->getAccessTokenValidity();
         $command->enablePlayground = $entity->isEnablePlayground();
-
-        $command->protocol = $entity->getProtocol();
 
         return $command;
     }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
@@ -379,7 +379,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
     /**
      * @var string
      */
-    private $protocol = Entity::TYPE_OPENID_CONNECT_TNG;
+    private $protocol;
 
     private function __construct()
     {
@@ -389,10 +389,12 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      * @param Service $service
      * @return SaveOidcngEntityCommand
      */
-    public static function forCreateAction(Service $service)
+    public static function forCreateAction(Service $service, $protocol)
     {
         $command = new self();
         $command->service = $service;
+
+        $command->protocol = $protocol;
 
         return $command;
     }
@@ -402,7 +404,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      *
      * @return SaveOidcngEntityCommand
      */
-    public static function fromEntity(Entity $entity)
+    public static function fromEntity(Entity $entity, $protocol)
     {
         $command = new self();
         $command->id = $entity->getId();
@@ -452,6 +454,8 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
         $command->isPublicClient = $entity->isPublicClient();
         $command->accessTokenValidity = (int) $entity->getAccessTokenValidity();
         $command->enablePlayground = $entity->isEnablePlayground();
+
+        $command->protocol = $protocol;
 
         return $command;
     }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
@@ -404,7 +404,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      *
      * @return SaveOidcngEntityCommand
      */
-    public static function fromEntity(Entity $entity, $protocol)
+    public static function fromEntity(Entity $entity)
     {
         $command = new self();
         $command->id = $entity->getId();
@@ -416,7 +416,9 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
         $command->entityId = $entity->getEntityId();
         $command->secret = $entity->getClientSecret();
         $command->redirectUrls = $entity->getRedirectUris();
-        $command->grantType = $entity->getGrantType()->getGrantType();
+        if ($entity->getProtocol() !== Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER) {
+            $command->grantType = $entity->getGrantType()->getGrantType();
+        }
         $command->logoUrl = $entity->getLogoUrl();
         $command->nameNl = $entity->getNameNl();
         $command->nameEn = $entity->getNameEn();
@@ -455,7 +457,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
         $command->accessTokenValidity = (int) $entity->getAccessTokenValidity();
         $command->enablePlayground = $entity->isEnablePlayground();
 
-        $command->protocol = $protocol;
+        $command->protocol = $entity->getProtocol();
 
         return $command;
     }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngResourceServerEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngResourceServerEntityCommand.php
@@ -26,6 +26,12 @@ use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints as SpDashboardAssert;
 use Symfony\Component\Validator\Constraints as Assert;
 
+/**
+ * @SuppressWarnings(PHPMD.TooManyFields)
+ * @SuppressWarnings(PHPMD.ExcessiveClassLength)
+ * @SuppressWarnings(PHPMD.ExcessivePublicCount)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ */
 class SaveOidcngResourceServerEntityCommand implements SaveEntityCommandInterface
 {
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngResourceServerEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngResourceServerEntityCommand.php
@@ -77,13 +77,6 @@ class SaveOidcngResourceServerEntityCommand implements SaveEntityCommandInterfac
     private $scopes = ['openid'];
 
     /**
-     * @var OidcGrantType
-     *
-     * @Assert\NotBlank()
-     */
-    private $grantType;
-
-    /**
      * @var string
      * @Assert\NotBlank()
      */
@@ -212,11 +205,9 @@ class SaveOidcngResourceServerEntityCommand implements SaveEntityCommandInterfac
         $command->environment = $entity->getEnvironment();
         $command->entityId = $entity->getEntityId();
         $command->secret = $entity->getClientSecret();
-        if ($entity->getProtocol() !== Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER) {
-            $command->grantType = $entity->getGrantType()->getGrantType();
-        }
         $command->nameNl = $entity->getNameNl();
         $command->nameEn = $entity->getNameEn();
+        $command->comments = $entity->getComments();
         // The SAML nameidformat is used as the OIDC subject type https://www.pivotaltracker.com/story/show/167511146
         $command->descriptionNl = $entity->getDescriptionNl();
         $command->descriptionEn = $entity->getDescriptionEn();

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngResourceServerEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngResourceServerEntityCommand.php
@@ -1,0 +1,630 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Command\Entity;
+
+use InvalidArgumentException;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints as SpDashboardAssert;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class SaveOidcngResourceServerEntityCommand implements SaveEntityCommandInterface
+{
+    /**
+     * @var string
+     * @Assert\Uuid
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    private $status;
+
+    /**
+     * @var Service
+     */
+    private $service;
+
+    /**
+     * @var bool
+     */
+    private $archived = false;
+
+    /**
+     * @var string
+     *
+     * @Assert\NotBlank()
+     * @Assert\Choice(choices = {"production", "test"}, strict=true)
+     */
+    private $environment = Entity::ENVIRONMENT_TEST;
+
+    /**
+     * @var string
+     *
+     * @Assert\NotBlank()
+     * @SpDashboardAssert\ValidClientId()
+     * @SpDashboardAssert\UniqueEntityId()
+     */
+    private $entityId;
+
+    /**
+     * @var string
+     */
+    private $secret;
+
+    /**
+     * @var array
+     */
+    private $scopes = ['openid'];
+
+    /**
+     * @var OidcGrantType
+     *
+     * @Assert\NotBlank()
+     */
+    private $grantType;
+
+    /**
+     * @var string
+     * @Assert\NotBlank()
+     */
+    private $nameNl;
+
+    /**
+     * @var string
+     * @Assert\NotBlank()
+     */
+    private $nameEn;
+
+    /**
+     * @var string
+     *
+     * @Assert\NotBlank()
+     * @Assert\Length(max = 300)
+     */
+    private $descriptionNl;
+
+    /**
+     * @var string
+     *
+     * @Assert\NotBlank()
+     * @Assert\Length(max = 300)
+     */
+    private $descriptionEn;
+
+    /**
+     * @var Contact
+     *
+     * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact")
+     * @Assert\Valid(groups={"production"})
+     */
+    private $administrativeContact;
+
+    /**
+     * @var Contact
+     *
+     * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact")
+     * @Assert\Valid()
+     */
+    private $technicalContact;
+
+    /**
+     * @var Contact
+     *
+     * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact")
+     * @Assert\Valid(groups={"production"})
+     */
+    private $supportContact;
+
+    /**
+     * @var string
+     */
+    private $comments;
+
+    /**
+     * @var string
+     */
+    private $organizationNameNl;
+
+    /**
+     * @var string
+     */
+    private $organizationNameEn;
+
+    /**
+     * @var string
+     */
+    private $organizationDisplayNameNl;
+
+    /**
+     * @var string
+     */
+    private $organizationDisplayNameEn;
+
+    /**
+     * @var string
+     */
+    private $organizationUrlNl;
+
+    /**
+     * @var string
+     */
+    private $organizationUrlEn;
+
+    /**
+     * @var string
+     */
+    private $manageId;
+
+    /**
+     * @var string
+     */
+    private $protocol = Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER;
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param Service $service
+     * @return SaveOidcngResourceServerEntityCommand
+     */
+    public static function forCreateAction(Service $service)
+    {
+        $command = new self();
+        $command->service = $service;
+
+        return $command;
+    }
+
+    /**
+     * @param Entity $entity
+     *
+     * @return SaveOidcngResourceServerEntityCommand
+     */
+    public static function fromEntity(Entity $entity)
+    {
+        $command = new self();
+        $command->id = $entity->getId();
+        $command->status = $entity->getStatus();
+        $command->manageId = $entity->getManageId();
+        $command->service = $entity->getService();
+        $command->archived = $entity->isArchived();
+        $command->environment = $entity->getEnvironment();
+        $command->entityId = $entity->getEntityId();
+        $command->secret = $entity->getClientSecret();
+        if ($entity->getProtocol() !== Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER) {
+            $command->grantType = $entity->getGrantType()->getGrantType();
+        }
+        $command->nameNl = $entity->getNameNl();
+        $command->nameEn = $entity->getNameEn();
+        // The SAML nameidformat is used as the OIDC subject type https://www.pivotaltracker.com/story/show/167511146
+        $command->descriptionNl = $entity->getDescriptionNl();
+        $command->descriptionEn = $entity->getDescriptionEn();
+        $command->administrativeContact = $entity->getAdministrativeContact();
+        $command->technicalContact = $entity->getTechnicalContact();
+        $command->supportContact = $entity->getSupportContact();
+        $command->organizationNameNl = $entity->getOrganizationNameNl();
+        $command->organizationNameEn = $entity->getOrganizationNameEn();
+        $command->organizationDisplayNameNl = $entity->getOrganizationDisplayNameNl();
+        $command->organizationDisplayNameEn = $entity->getOrganizationDisplayNameEn();
+        $command->organizationUrlNl = $entity->getOrganizationUrlNl();
+        $command->organizationUrlEn = $entity->getOrganizationUrlEn();
+
+        return $command;
+    }
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    /**
+     * @return Service
+     */
+    public function getService()
+    {
+        return $this->service;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isArchived()
+    {
+        return $this->archived;
+    }
+
+    /**
+     * @param bool $archived
+     */
+    public function setArchived($archived)
+    {
+        $this->archived = $archived;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEnvironment()
+    {
+        return $this->environment;
+    }
+
+    /**
+     * @param string $environment
+     */
+    public function setEnvironment($environment)
+    {
+        if (!in_array(
+            $environment,
+            [
+                Entity::ENVIRONMENT_TEST,
+                Entity::ENVIRONMENT_PRODUCTION,
+            ]
+        )) {
+            throw new InvalidArgumentException(
+                "Unknown environment '{$environment}'"
+            );
+        }
+
+        $this->environment = $environment;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEntityId()
+    {
+        return $this->entityId;
+    }
+
+    /**
+     * @param string $entityId
+     */
+    public function setEntityId($entityId)
+    {
+        $this->entityId = $entityId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClientId()
+    {
+        return $this->entityId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSecret()
+    {
+        return $this->secret;
+    }
+
+    /**
+     * @param string $secret
+     */
+    public function setSecret($secret)
+    {
+        $this->secret = $secret;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameNl()
+    {
+        return $this->nameNl;
+    }
+
+    /**
+     * @param string $nameNl
+     */
+    public function setNameNl($nameNl)
+    {
+        $this->nameNl = $nameNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameEn()
+    {
+        return $this->nameEn;
+    }
+
+    /**
+     * @param string $nameEn
+     */
+    public function setNameEn($nameEn)
+    {
+        $this->nameEn = $nameEn;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescriptionNl()
+    {
+        return $this->descriptionNl;
+    }
+
+    /**
+     * @param string $descriptionNl
+     */
+    public function setDescriptionNl($descriptionNl)
+    {
+        $this->descriptionNl = $descriptionNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescriptionEn()
+    {
+        return $this->descriptionEn;
+    }
+
+    /**
+     * @param string $descriptionEn
+     */
+    public function setDescriptionEn($descriptionEn)
+    {
+        $this->descriptionEn = $descriptionEn;
+    }
+
+    /**
+     * @return Contact
+     */
+    public function getAdministrativeContact()
+    {
+        return $this->administrativeContact;
+    }
+
+    /**
+     * @param Contact $administrativeContact
+     */
+    public function setAdministrativeContact($administrativeContact)
+    {
+        $this->administrativeContact = $administrativeContact;
+    }
+
+    /**
+     * @return Contact
+     */
+    public function getTechnicalContact()
+    {
+        return $this->technicalContact;
+    }
+
+    /**
+     * @param Contact $technicalContact
+     */
+    public function setTechnicalContact($technicalContact)
+    {
+        $this->technicalContact = $technicalContact;
+    }
+
+    /**
+     * @return Contact
+     */
+    public function getSupportContact()
+    {
+        return $this->supportContact;
+    }
+
+    /**
+     * @param Contact $supportContact
+     */
+    public function setSupportContact($supportContact)
+    {
+        $this->supportContact = $supportContact;
+    }
+
+     /**
+     * @return string
+     */
+    public function getComments()
+    {
+        return $this->comments;
+    }
+
+    /**
+     * @param string $comments
+     */
+    public function setComments($comments)
+    {
+        $this->comments = $comments;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationNameNl()
+    {
+        return $this->organizationNameNl;
+    }
+
+    /**
+     * @param string $organizationNameNl
+     */
+    public function setOrganizationNameNl($organizationNameNl)
+    {
+        $this->organizationNameNl = $organizationNameNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationNameEn()
+    {
+        return $this->organizationNameEn;
+    }
+
+    /**
+     * @param string $organizationNameEn
+     */
+    public function setOrganizationNameEn($organizationNameEn)
+    {
+        $this->organizationNameEn = $organizationNameEn;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationDisplayNameNl()
+    {
+        return $this->organizationDisplayNameNl;
+    }
+
+    /**
+     * @param string $organizationDisplayNameNl
+     */
+    public function setOrganizationDisplayNameNl($organizationDisplayNameNl)
+    {
+        $this->organizationDisplayNameNl = $organizationDisplayNameNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationDisplayNameEn()
+    {
+        return $this->organizationDisplayNameEn;
+    }
+
+    /**
+     * @param string $organizationDisplayNameEn
+     */
+    public function setOrganizationDisplayNameEn($organizationDisplayNameEn)
+    {
+        $this->organizationDisplayNameEn = $organizationDisplayNameEn;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationUrlNl()
+    {
+        return $this->organizationUrlNl;
+    }
+
+    /**
+     * @param string $organizationUrlNl
+     */
+    public function setOrganizationUrlNl($organizationUrlNl)
+    {
+        $this->organizationUrlNl = $organizationUrlNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationUrlEn()
+    {
+        return $this->organizationUrlEn;
+    }
+
+    /**
+     * @param string $organizationUrlEn
+     */
+    public function setOrganizationUrlEn($organizationUrlEn)
+    {
+        $this->organizationUrlEn = $organizationUrlEn;
+    }
+
+    public function isForProduction()
+    {
+        return $this->environment === Entity::ENVIRONMENT_PRODUCTION;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function setStatus($status)
+    {
+        $this->status = $status;
+    }
+
+    /**
+     * @param Service $service
+     */
+    public function setService(Service $service)
+    {
+        $this->service = $service;
+    }
+
+    /**
+     * @return string
+     */
+    public function getManageId()
+    {
+        return $this->manageId;
+    }
+
+    /**
+     * @param string $manageId
+     */
+    public function setManageId($manageId)
+    {
+        $this->manageId = $manageId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProtocol()
+    {
+        return $this->protocol;
+    }
+
+    /**
+     * @return array
+     */
+    public function getScopes()
+    {
+        return $this->scopes;
+    }
+
+    /**
+     * @return OidcGrantType
+     */
+    public function getGrantType()
+    {
+        return $this->grantType;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/ResetOidcSecretCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/ResetOidcSecretCommandHandler.php
@@ -69,7 +69,10 @@ class ResetOidcSecretCommandHandler implements CommandHandler
         }
 
         $protocol = $entity->getProtocol();
-        if ($protocol !== Entity::TYPE_OPENID_CONNECT && $protocol !== Entity::TYPE_OPENID_CONNECT_TNG) {
+        if ($protocol !== Entity::TYPE_OPENID_CONNECT &&
+            $protocol !== Entity::TYPE_OPENID_CONNECT_TNG &&
+            $protocol !== Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER
+        ) {
             throw new EntityNotFoundException('The requested entity could be found, invalid protocol');
         }
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandler.php
@@ -78,7 +78,7 @@ class SaveOidcngEntityCommandHandler implements CommandHandler
         }
 
         if (is_null($entity)) {
-            throw new EntityNotFoundException('The requested Service cannot be found');
+            throw new EntityNotFoundException('The requested entity cannot be found');
         }
 
         if (!$command->getManageId()) {
@@ -116,26 +116,21 @@ class SaveOidcngEntityCommandHandler implements CommandHandler
         $entity->setAdministrativeContact($command->getAdministrativeContact());
         $entity->setTechnicalContact($command->getTechnicalContact());
         $entity->setSupportContact($command->getSupportContact());
-
-        // Resource servers have no ARP attributes, skip setting them.
-        if ($command->getProtocol() !== Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER) {
-            $entity->setGivenNameAttribute($command->getGivenNameAttribute());
-            $entity->setSurNameAttribute($command->getSurNameAttribute());
-            $entity->setCommonNameAttribute($command->getCommonNameAttribute());
-            $entity->setDisplayNameAttribute($command->getDisplayNameAttribute());
-            $entity->setEmailAddressAttribute($command->getEmailAddressAttribute());
-            $entity->setOrganizationAttribute($command->getOrganizationAttribute());
-            $entity->setOrganizationTypeAttribute($command->getOrganizationTypeAttribute());
-            $entity->setAffiliationAttribute($command->getAffiliationAttribute());
-            $entity->setEntitlementAttribute($command->getEntitlementAttribute());
-            $entity->setPrincipleNameAttribute($command->getPrincipleNameAttribute());
-            $entity->setUidAttribute($command->getUidAttribute());
-            $entity->setPreferredLanguageAttribute($command->getPreferredLanguageAttribute());
-            $entity->setPersonalCodeAttribute($command->getPersonalCodeAttribute());
-            $entity->setScopedAffiliationAttribute($command->getScopedAffiliationAttribute());
-            $entity->setComments($command->getComments());
-        }
-
+        $entity->setGivenNameAttribute($command->getGivenNameAttribute());
+        $entity->setSurNameAttribute($command->getSurNameAttribute());
+        $entity->setCommonNameAttribute($command->getCommonNameAttribute());
+        $entity->setDisplayNameAttribute($command->getDisplayNameAttribute());
+        $entity->setEmailAddressAttribute($command->getEmailAddressAttribute());
+        $entity->setOrganizationAttribute($command->getOrganizationAttribute());
+        $entity->setOrganizationTypeAttribute($command->getOrganizationTypeAttribute());
+        $entity->setAffiliationAttribute($command->getAffiliationAttribute());
+        $entity->setEntitlementAttribute($command->getEntitlementAttribute());
+        $entity->setPrincipleNameAttribute($command->getPrincipleNameAttribute());
+        $entity->setUidAttribute($command->getUidAttribute());
+        $entity->setPreferredLanguageAttribute($command->getPreferredLanguageAttribute());
+        $entity->setPersonalCodeAttribute($command->getPersonalCodeAttribute());
+        $entity->setScopedAffiliationAttribute($command->getScopedAffiliationAttribute());
+        $entity->setComments($command->getComments());
         $entity->setOrganizationNameNl($command->getOrganizationNameNl());
         $entity->setOrganizationNameEn($command->getOrganizationNameEn());
         $entity->setOrganizationDisplayNameNl($command->getOrganizationDisplayNameNl());

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandler.php
@@ -96,8 +96,13 @@ class SaveOidcngEntityCommandHandler implements CommandHandler
         $entity->setAccessTokenValidity($command->getAccessTokenValidity());
         $entity->setIsPublicClient($command->isPublicClient());
         $entity->setEnablePlayground($command->isEnablePlayground());
-        $grantType =  $command->getGrantType();
-        $entity->setGrantType(new OidcGrantType($grantType));
+        try {
+            $grantType =  $command->getGrantType();
+            $entity->setGrantType(new OidcGrantType($grantType));
+        } catch (\InvalidArgumentException $e) {
+            // Allow empty grant types
+        }
+
         // The OIDC subject type is analog to the SAML NameIdFormat: https://www.pivotaltracker.com/story/show/167511146
         $entity->setNameIdFormat($command->getSubjectType());
         $entity->setLogoUrl($command->getLogoUrl());
@@ -107,24 +112,29 @@ class SaveOidcngEntityCommandHandler implements CommandHandler
         $entity->setDescriptionEn($command->getDescriptionEn());
         $entity->setApplicationUrl($command->getApplicationUrl());
         $entity->setEulaUrl($command->getEulaUrl());
+
         $entity->setAdministrativeContact($command->getAdministrativeContact());
         $entity->setTechnicalContact($command->getTechnicalContact());
         $entity->setSupportContact($command->getSupportContact());
-        $entity->setGivenNameAttribute($command->getGivenNameAttribute());
-        $entity->setSurNameAttribute($command->getSurNameAttribute());
-        $entity->setCommonNameAttribute($command->getCommonNameAttribute());
-        $entity->setDisplayNameAttribute($command->getDisplayNameAttribute());
-        $entity->setEmailAddressAttribute($command->getEmailAddressAttribute());
-        $entity->setOrganizationAttribute($command->getOrganizationAttribute());
-        $entity->setOrganizationTypeAttribute($command->getOrganizationTypeAttribute());
-        $entity->setAffiliationAttribute($command->getAffiliationAttribute());
-        $entity->setEntitlementAttribute($command->getEntitlementAttribute());
-        $entity->setPrincipleNameAttribute($command->getPrincipleNameAttribute());
-        $entity->setUidAttribute($command->getUidAttribute());
-        $entity->setPreferredLanguageAttribute($command->getPreferredLanguageAttribute());
-        $entity->setPersonalCodeAttribute($command->getPersonalCodeAttribute());
-        $entity->setScopedAffiliationAttribute($command->getScopedAffiliationAttribute());
-        $entity->setComments($command->getComments());
+
+        // Resource servers have no ARP attributes, skip setting them.
+        if ($command->getProtocol() !== Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER) {
+            $entity->setGivenNameAttribute($command->getGivenNameAttribute());
+            $entity->setSurNameAttribute($command->getSurNameAttribute());
+            $entity->setCommonNameAttribute($command->getCommonNameAttribute());
+            $entity->setDisplayNameAttribute($command->getDisplayNameAttribute());
+            $entity->setEmailAddressAttribute($command->getEmailAddressAttribute());
+            $entity->setOrganizationAttribute($command->getOrganizationAttribute());
+            $entity->setOrganizationTypeAttribute($command->getOrganizationTypeAttribute());
+            $entity->setAffiliationAttribute($command->getAffiliationAttribute());
+            $entity->setEntitlementAttribute($command->getEntitlementAttribute());
+            $entity->setPrincipleNameAttribute($command->getPrincipleNameAttribute());
+            $entity->setUidAttribute($command->getUidAttribute());
+            $entity->setPreferredLanguageAttribute($command->getPreferredLanguageAttribute());
+            $entity->setPersonalCodeAttribute($command->getPersonalCodeAttribute());
+            $entity->setScopedAffiliationAttribute($command->getScopedAffiliationAttribute());
+            $entity->setComments($command->getComments());
+        }
 
         $entity->setOrganizationNameNl($command->getOrganizationNameNl());
         $entity->setOrganizationNameEn($command->getOrganizationNameEn());

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcngResourceServerEntityCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcngResourceServerEntityCommandHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2018 SURFnet B.V.
+ * Copyright 2019 SURFnet B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,20 +18,21 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity;
 
-use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcEntityCommand;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Ramsey\Uuid\Uuid;
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveEntityCommandInterface;
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngEntityCommand;
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngResourceServerEntityCommand;
 use Surfnet\ServiceProviderDashboard\Application\CommandHandler\CommandHandler;
 use Surfnet\ServiceProviderDashboard\Application\Exception\EntityNotFoundException;
 use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityRepository;
-use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Secret;
 
 /**
- * Saves oidc drafts
+ * Saves oidcng drafts
  */
-class SaveOidcEntityCommandHandler implements CommandHandler
+class SaveOidcngResourceServerEntityCommandHandler implements CommandHandler
 {
     /**
      * @var EntityRepository
@@ -47,13 +48,13 @@ class SaveOidcEntityCommandHandler implements CommandHandler
     }
 
     /**
-     * @param SaveOidcEntityCommand $command
+     * @param SaveOidcngResourceServerEntityCommand $command
      * @throws EntityNotFoundException
      * @throws InvalidArgumentException
      *
      * @SuppressWarnings(PHPMD.ElseExpression)
      */
-    public function handle(SaveOidcEntityCommand $command)
+    public function handle(SaveOidcngResourceServerEntityCommand $command)
     {
         // If the entity does not exist yet, create it on the fly
         if (is_null($command->getId())) {
@@ -91,39 +92,16 @@ class SaveOidcEntityCommandHandler implements CommandHandler
         $entity->setArchived($command->isArchived());
         $entity->setEnvironment($command->getEnvironment());
         $entity->setEntityId($command->getEntityId());
-        $entity->setProtocol(Entity::TYPE_OPENID_CONNECT);
-        $entity->setRedirectUris($command->getRedirectUris());
-        $entity->setGrantType(new OidcGrantType($command->getGrantType()));
-        $entity->setEnablePlayground($command->isEnablePlayground());
-        $entity->setLogoUrl($command->getLogoUrl());
+        $entity->setProtocol($command->getProtocol());
+        $entity->setNameIdFormat(Entity::NAME_ID_FORMAT_PERSISTENT);
         $entity->setNameNl($command->getNameNl());
         $entity->setNameEn($command->getNameEn());
         $entity->setDescriptionNl($command->getDescriptionNl());
         $entity->setDescriptionEn($command->getDescriptionEn());
-        $entity->setApplicationUrl($command->getApplicationUrl());
-        $entity->setEulaUrl($command->getEulaUrl());
+
         $entity->setAdministrativeContact($command->getAdministrativeContact());
         $entity->setTechnicalContact($command->getTechnicalContact());
         $entity->setSupportContact($command->getSupportContact());
-        $entity->setGivenNameAttribute($command->getGivenNameAttribute());
-        $entity->setSurNameAttribute($command->getSurNameAttribute());
-        $entity->setCommonNameAttribute($command->getCommonNameAttribute());
-        $entity->setDisplayNameAttribute($command->getDisplayNameAttribute());
-        $entity->setEmailAddressAttribute($command->getEmailAddressAttribute());
-        $entity->setOrganizationAttribute($command->getOrganizationAttribute());
-        $entity->setOrganizationTypeAttribute($command->getOrganizationTypeAttribute());
-        $entity->setAffiliationAttribute($command->getAffiliationAttribute());
-        $entity->setEntitlementAttribute($command->getEntitlementAttribute());
-        $entity->setPrincipleNameAttribute($command->getPrincipleNameAttribute());
-        $entity->setUidAttribute($command->getUidAttribute());
-        $entity->setPreferredLanguageAttribute($command->getPreferredLanguageAttribute());
-        $entity->setPersonalCodeAttribute($command->getPersonalCodeAttribute());
-        $entity->setScopedAffiliationAttribute($command->getScopedAffiliationAttribute());
-        $entity->setEduPersonTargetedIDAttribute($command->getEduPersonTargetedIDAttribute());
-        $entity->setComments($command->getComments());
-
-        // Set the name id format to unspecified.
-        $entity->setNameIdFormat(Entity::NAME_ID_FORMAT_UNSPECIFIED);
 
         $entity->setOrganizationNameNl($command->getOrganizationNameNl());
         $entity->setOrganizationNameEn($command->getOrganizationNameEn());

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcngResourceServerEntityCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcngResourceServerEntityCommandHandler.php
@@ -110,6 +110,8 @@ class SaveOidcngResourceServerEntityCommandHandler implements CommandHandler
         $entity->setOrganizationUrlNl($command->getOrganizationUrlNl());
         $entity->setOrganizationUrlEn($command->getOrganizationUrlEn());
 
+        $entity->setComments($command->getComments());
+
         $this->repository->save($entity);
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
@@ -1,0 +1,323 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Metadata;
+
+use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\PrivacyQuestionsMetadataGenerator;
+use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\SpDashboardMetadataGenerator;
+use Surfnet\ServiceProviderDashboard\Application\Parser\OidcngClientIdParser;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
+
+/**
+ * The OidcngResourceServerJsonGenerator generates oidc10_rp resource server entity json
+ *
+ * @SuppressWarnings(PHPMD.TooManyMethods)
+ * @SuppressWarnings(PHPMD.ElseExpression)
+ */
+class OidcngResourceServerJsonGenerator implements GeneratorInterface
+{
+    /**
+     * @var PrivacyQuestionsMetadataGenerator
+     */
+    private $privacyQuestionsMetadataGenerator;
+
+    /**
+     * @var SpDashboardMetadataGenerator
+     */
+    private $spDashboardMetadataGenerator;
+
+    /**
+     * @param PrivacyQuestionsMetadataGenerator $privacyQuestionsMetadataGenerator
+     * @param SpDashboardMetadataGenerator $spDashboardMetadataGenerator
+     */
+    public function __construct(
+        PrivacyQuestionsMetadataGenerator $privacyQuestionsMetadataGenerator,
+        SpDashboardMetadataGenerator $spDashboardMetadataGenerator
+    ) {
+        $this->privacyQuestionsMetadataGenerator = $privacyQuestionsMetadataGenerator;
+        $this->spDashboardMetadataGenerator = $spDashboardMetadataGenerator;
+    }
+
+    /**
+     * @param Entity $entity
+     * @param string $workflowState
+     * @return array
+     */
+    public function generateForNewEntity(Entity $entity, $workflowState)
+    {
+        // the type for entities is always saml because manage is using saml internally
+        return [
+            'data' => $this->generateDataForNewEntity($entity, $workflowState),
+            'type' => 'oidc10_rp',
+        ];
+    }
+
+    /**
+     * @param Entity $entity
+     * @param string $workflowState
+     * @return array
+     */
+    public function generateForExistingEntity(Entity $entity, $workflowState)
+    {
+        // the type for entities is always saml because manage is using saml internally
+        $data = [
+            'pathUpdates' => $this->generateDataForExistingEntity($entity, $workflowState),
+            'type' => 'oidc10_rp',
+            'id' => $entity->getManageId(),
+        ];
+
+        return $data;
+    }
+
+    /**
+     * @param Entity $entity
+     * @param string $workflowState
+     * @return array
+     */
+    private function generateDataForNewEntity(Entity $entity, $workflowState)
+    {
+        // the type for entities is always oidc10-rp because manage is using saml internally
+        $metadata = [
+            'type' => 'oidc10-rp',
+            'entityid' => OidcngClientIdParser::parse($entity->getEntityId()),
+            'active' => true,
+            'state' => $workflowState,
+            'metaDataFields' => $this->generateMetadataFields($entity),
+        ];
+
+        $metadata += $this->generateAclData($entity);
+
+        if ($entity->hasComments()) {
+            $metadata['revisionnote'] = $entity->getComments();
+        }
+
+        return $metadata;
+    }
+
+    /**
+     * @param Entity $entity
+     * @param string $workflowState
+     * @return array
+     */
+    private function generateDataForExistingEntity(Entity $entity, $workflowState)
+    {
+        $metadata = [
+            'entityid' => OidcngClientIdParser::parse($entity->getEntityId()),
+            'state' => $workflowState,
+        ];
+
+        $metadata += $this->generateAclData($entity);
+
+        $metadata += $this->flattenMetadataFields(
+            $this->generateMetadataFields($entity)
+        );
+
+        if ($entity->hasComments()) {
+            $metadata['revisionnote'] = $entity->getComments();
+        }
+
+        return $metadata;
+    }
+
+    /**
+     * Convert a list fields to a flat array expected by the merge-write API.
+     *
+     * Manage always returns metadata fields like this:
+     *
+     *     [ metaDataFields => [ description:en => ..., description:nl => ..., ...] ]
+     *
+     * But when using the merge-write API, sending a 'metaDataFields' property
+     * will overwrite all existing metadata fields. To prevent this, we only
+     * send the metadata fields we actually want to update by using the flat
+     * format:
+     *
+     *     [ metaDataFields.description:en => ..., metaDataFields.description:nl => ..., ...] ]
+     *
+     *
+     * @param array $fields
+     * @return array
+     */
+    private function flattenMetadataFields(array $fields)
+    {
+        $flatFields = [];
+
+        foreach ($fields as $name => $value) {
+            $flatFields['metaDataFields.'.$name] = $value;
+        }
+
+        return $flatFields;
+    }
+
+    /**
+     * @param Entity $entity
+     * @return array
+     */
+    private function generateMetadataFields(Entity $entity)
+    {
+        $metadata = array_merge(
+            [
+                'description:en' => $entity->getDescriptionEn(),
+                'description:nl' => $entity->getDescriptionNl(),
+                'name:en' => $entity->getNameEn(),
+                'name:nl' => $entity->getNameNl(),
+            ],
+            $this->generateAllContactsMetadata($entity),
+            $this->generateOrganizationMetadata($entity),
+            $this->privacyQuestionsMetadataGenerator->build($entity),
+            $this->spDashboardMetadataGenerator->build($entity)
+        );
+
+        $metadata['NameIDFormat'] = $entity->getNameIdFormat();
+
+        // Will become configurable some time in the future.
+        $metadata['scopes'] = ['openid'];
+
+        // When publishing to production, the coin:exclude_from_push must be present and set to '1'. This prevents the
+        // entity from being pushed to engineblock.
+        if ($entity->isProduction()) {
+            $metadata['coin:exclude_from_push'] = '1';
+        }
+
+        $metadata += $this->generateOidcClient($entity);
+
+        return $metadata;
+    }
+
+    /**
+     * @param Entity $entity
+     * @return array
+     */
+    private function generateOidcClient(Entity $entity)
+    {
+        $secret = $entity->getClientSecret();
+        if ($secret) {
+            $metadata['secret'] = $secret;
+        }
+        // Reset the redirect URI list in order to get a correct JSON formatting (See #163646662)
+        $metadata['grants'] = [OidcGrantType::GRANT_TYPE_CLIENT_CREDENTIALS];
+        $metadata['isResourceServer'] = true;
+
+        return $metadata;
+    }
+
+    /**
+     * @param Entity $entity
+     * @return array
+     */
+    private function generateAllContactsMetadata(Entity $entity)
+    {
+        $metadata = [];
+        $index = 0;
+
+        if ($entity->getSupportContact()) {
+            $metadata += $this->generateContactMetadata('support', $index++, $entity->getSupportContact());
+        }
+
+        if ($entity->getAdministrativeContact()) {
+            $metadata += $this->generateContactMetadata(
+                'administrative',
+                $index++,
+                $entity->getAdministrativeContact()
+            );
+        }
+
+        if ($entity->getTechnicalContact()) {
+            $metadata += $this->generateContactMetadata('technical', $index++, $entity->getTechnicalContact());
+        }
+
+        return $metadata;
+    }
+
+    /**
+     * @param Entity $entity
+     * @return array
+     */
+    private function generateOrganizationMetadata(Entity $entity)
+    {
+        $metadata = [
+            'OrganizationName:en' => $entity->getOrganizationNameEn(),
+            'OrganizationDisplayName:en' => $entity->getOrganizationDisplayNameEn(),
+            'OrganizationURL:en' => $entity->getOrganizationUrlEn(),
+            'OrganizationName:nl' => $entity->getOrganizationNameNl(),
+            'OrganizationDisplayName:nl' => $entity->getOrganizationDisplayNameNl(),
+            'OrganizationURL:nl' => $entity->getOrganizationUrlNl(),
+        ];
+
+        return array_filter($metadata);
+    }
+
+    /**
+     * @param string $contactType
+     * @param int $index
+     * @param Contact $contact
+     * @return array
+     */
+    private function generateContactMetadata($contactType, $index, Contact $contact)
+    {
+        $metadata = [
+            sprintf('contacts:%d:contactType', $index) => $contactType,
+        ];
+
+        if (!empty($contact->getFirstName())) {
+            $metadata[sprintf('contacts:%d:givenName', $index)] = $contact->getFirstName();
+        }
+
+        if (!empty($contact->getLastName())) {
+            $metadata[sprintf('contacts:%d:surName', $index)] = $contact->getLastName();
+        }
+
+        if (!empty($contact->getEmail())) {
+            $metadata[sprintf('contacts:%d:emailAddress', $index)] = $contact->getEmail();
+        }
+
+        if (!empty($contact->getPhone())) {
+            $metadata[sprintf('contacts:%d:telephoneNumber', $index)] = $contact->getPhone();
+        }
+
+        return $metadata;
+    }
+
+    /**
+     * @param Entity $entity
+     * @return array
+     */
+    private function generateAclData(Entity $entity)
+    {
+        if ($entity->isIdpAllowAll()) {
+            return [
+                'allowedEntities' => [],
+                'allowedall' => true,
+            ];
+        }
+
+        $providers = [];
+        foreach ($entity->getIdpWhitelist() as $entityId) {
+            $providers[] = [
+                'name' => $entityId,
+            ];
+        }
+
+        return [
+            'allowedEntities' => $providers,
+            'allowedall' => false,
+        ];
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityActions.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityActions.php
@@ -125,7 +125,9 @@ class EntityActions
      */
     public function allowAclAction()
     {
-        return $this->status == DomainEntity::STATE_PUBLISHED && $this->environment == DomainEntity::ENVIRONMENT_TEST;
+        return $this->status == DomainEntity::STATE_PUBLISHED &&
+            $this->environment == DomainEntity::ENVIRONMENT_TEST &&
+            $this->protocol !== DomainEntity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER;
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityActions.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityActions.php
@@ -137,8 +137,9 @@ class EntityActions
     {
         $protocol = $this->protocol;
         $status = $this->status;
-        return ($protocol == DomainEntity::TYPE_OPENID_CONNECT || $protocol == DomainEntity::TYPE_OPENID_CONNECT_TNG) &&
-            ($status == DomainEntity::STATE_PUBLISHED || $status == DomainEntity::STATE_PUBLICATION_REQUESTED);
+        $meetsProtocolRequirement = ($protocol == DomainEntity::TYPE_OPENID_CONNECT || $protocol == DomainEntity::TYPE_OPENID_CONNECT_TNG || $protocol == DomainEntity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER);
+        $meetsPublicationStatusRequirement = ($status == DomainEntity::STATE_PUBLISHED || $status == DomainEntity::STATE_PUBLICATION_REQUESTED);
+        return $meetsProtocolRequirement && $meetsPublicationStatusRequirement;
     }
 
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityActions.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityActions.php
@@ -137,7 +137,9 @@ class EntityActions
     {
         $protocol = $this->protocol;
         $status = $this->status;
-        $meetsProtocolRequirement = ($protocol == DomainEntity::TYPE_OPENID_CONNECT || $protocol == DomainEntity::TYPE_OPENID_CONNECT_TNG || $protocol == DomainEntity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER);
+        $meetsProtocolRequirement = $protocol == DomainEntity::TYPE_OPENID_CONNECT ||
+            $protocol == DomainEntity::TYPE_OPENID_CONNECT_TNG ||
+            $protocol == DomainEntity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER;
         $meetsPublicationStatusRequirement = ($status == DomainEntity::STATE_PUBLISHED || $status == DomainEntity::STATE_PUBLICATION_REQUESTED);
         return $meetsProtocolRequirement && $meetsPublicationStatusRequirement;
     }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
@@ -495,6 +495,13 @@ class Entity
                     $oidcngPlayGroundUriProd
                 );
                 break;
+            case (self::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER):
+                $oidcClient = $manageEntity->getOidcClient();
+                $entity->setClientSecret($oidcClient->getClientSecret());
+                $entity->setGrantType(new OidcGrantType($oidcClient->getGrantType()));
+                $entity->setProtocol(Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER);
+                $entity->setNameIdFormat($metaData->getNameIdFormat());
+                break;
             case (self::TYPE_SAML):
                 $entity->setProtocol(Entity::TYPE_SAML);
                 $entity->setImportUrl($metaData->getEntityId());

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
@@ -58,6 +58,7 @@ class Entity
     const TYPE_SAML = 'saml20';
     const TYPE_OPENID_CONNECT = 'oidc';
     const TYPE_OPENID_CONNECT_TNG = 'oidcng';
+    const TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER = 'oidcng_rs';
 
     const OIDC_SECRET_LENGTH = 20;
 

--- a/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/OidcGrantType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/OidcGrantType.php
@@ -21,10 +21,12 @@ class OidcGrantType
 {
     const GRANT_TYPE_AUTHORIZATION_CODE = 'authorization_code';
     const GRANT_TYPE_IMPLICIT = 'implicit';
+    const GRANT_TYPE_CLIENT_CREDENTIALS = 'client_credentials';
 
     private static $validGrantTypes = [
         self::GRANT_TYPE_AUTHORIZATION_CODE,
         self::GRANT_TYPE_IMPLICIT,
+        self::GRANT_TYPE_CLIENT_CREDENTIALS,
     ];
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityListController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityListController.php
@@ -99,7 +99,9 @@ class EntityListController extends Controller
             return false;
         }
         $protocol = $publishedEntity->getProtocol();
-        $isOidcProtocol = $protocol === Entity::TYPE_OPENID_CONNECT_TNG || $protocol === Entity::TYPE_OPENID_CONNECT;
+        $isOidcProtocol = $protocol === Entity::TYPE_OPENID_CONNECT_TNG ||
+            $protocol === Entity::TYPE_OPENID_CONNECT ||
+            $protocol === Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER;
 
         return $publishedEntity && $isOidcProtocol && $publishedEntity->getClientSecret();
     }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityPublishedController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityPublishedController.php
@@ -43,7 +43,10 @@ class EntityPublishedController extends Controller
         // Redirects OIDC (including TNG) published entity confirmations to the entity list page and shows a
         // confirmation dialog in a modal window that renders the oidcConfirmationModalAction
         $protocol = $entity->getProtocol();
-        if ($protocol === Entity::TYPE_OPENID_CONNECT || $protocol === Entity::TYPE_OPENID_CONNECT_TNG) {
+        if ($protocol === Entity::TYPE_OPENID_CONNECT ||
+            $protocol === Entity::TYPE_OPENID_CONNECT_TNG ||
+            $protocol === Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER
+        ) {
             return $this->redirectToRoute('entity_list', ['serviceId' => $entity->getService()->getId()]);
         }
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Factory/EntityTypeFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Factory/EntityTypeFactory.php
@@ -20,6 +20,7 @@ namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Factor
 use InvalidArgumentException;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcEntityCommand;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngEntityCommand;
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngResourceServerEntityCommand;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveSamlEntityCommand;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
@@ -67,16 +68,16 @@ class EntityTypeFactory
                 $command->setEnvironment($environment);
                 return $this->formFactory->create(SamlEntityType::class, $command, $this->buildOptions($environment));
             case ($type == Entity::TYPE_OPENID_CONNECT_TNG):
-                $command = SaveOidcngEntityCommand::forCreateAction($service, Entity::TYPE_OPENID_CONNECT_TNG);
+                $command = SaveOidcngEntityCommand::forCreateAction($service);
                 if ($entity) {
                     $command = SaveOidcngEntityCommand::fromEntity($entity);
                 }
                 $command->setEnvironment($environment);
                 return $this->formFactory->create(OidcngEntityType::class, $command, $this->buildOptions($environment));
             case ($type == Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER):
-                $command = SaveOidcngEntityCommand::forCreateAction($service, Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER);
+                $command = SaveOidcngResourceServerEntityCommand::forCreateAction($service);
                 if ($entity) {
-                    $command = SaveOidcngEntityCommand::fromEntity($entity);
+                    $command = SaveOidcngResourceServerEntityCommand::fromEntity($entity);
                 }
                 $command->setEnvironment($environment);
 
@@ -113,7 +114,7 @@ class EntityTypeFactory
                 $command->setEnvironment($entity->getEnvironment());
                 return $this->formFactory->create(OidcngEntityType::class, $command, $this->buildOptions($entity->getEnvironment()));
             case ($entity->getProtocol() == Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER):
-                $command = SaveOidcngEntityCommand::fromEntity($entity);
+                $command = SaveOidcngResourceServerEntityCommand::fromEntity($entity);
                 $command->setEnvironment($entity->getEnvironment());
                 return $this->formFactory->create(OidcngResourceServerEntityType::class, $command, $this->buildOptions($entity->getEnvironment()));
         }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Factory/EntityTypeFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Factory/EntityTypeFactory.php
@@ -69,14 +69,14 @@ class EntityTypeFactory
             case ($type == Entity::TYPE_OPENID_CONNECT_TNG):
                 $command = SaveOidcngEntityCommand::forCreateAction($service, Entity::TYPE_OPENID_CONNECT_TNG);
                 if ($entity) {
-                    $command = SaveOidcngEntityCommand::fromEntity($entity, Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER);
+                    $command = SaveOidcngEntityCommand::fromEntity($entity);
                 }
                 $command->setEnvironment($environment);
                 return $this->formFactory->create(OidcngEntityType::class, $command, $this->buildOptions($environment));
             case ($type == Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER):
                 $command = SaveOidcngEntityCommand::forCreateAction($service, Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER);
                 if ($entity) {
-                    $command = SaveOidcngEntityCommand::fromEntity($entity, Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER);
+                    $command = SaveOidcngEntityCommand::fromEntity($entity);
                 }
                 $command->setEnvironment($environment);
 
@@ -112,6 +112,10 @@ class EntityTypeFactory
                 $command = SaveOidcngEntityCommand::fromEntity($entity);
                 $command->setEnvironment($entity->getEnvironment());
                 return $this->formFactory->create(OidcngEntityType::class, $command, $this->buildOptions($entity->getEnvironment()));
+            case ($entity->getProtocol() == Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER):
+                $command = SaveOidcngEntityCommand::fromEntity($entity);
+                $command->setEnvironment($entity->getEnvironment());
+                return $this->formFactory->create(OidcngResourceServerEntityType::class, $command, $this->buildOptions($entity->getEnvironment()));
         }
 
         throw new InvalidArgumentException("invalid form type requested");

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Factory/EntityTypeFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Factory/EntityTypeFactory.php
@@ -67,16 +67,16 @@ class EntityTypeFactory
                 $command->setEnvironment($environment);
                 return $this->formFactory->create(SamlEntityType::class, $command, $this->buildOptions($environment));
             case ($type == Entity::TYPE_OPENID_CONNECT_TNG):
-                $command = SaveOidcngEntityCommand::forCreateAction($service);
+                $command = SaveOidcngEntityCommand::forCreateAction($service, Entity::TYPE_OPENID_CONNECT_TNG);
                 if ($entity) {
-                    $command = SaveOidcngEntityCommand::fromEntity($entity);
+                    $command = SaveOidcngEntityCommand::fromEntity($entity, Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER);
                 }
                 $command->setEnvironment($environment);
                 return $this->formFactory->create(OidcngEntityType::class, $command, $this->buildOptions($environment));
             case ($type == Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER):
-                $command = SaveOidcngEntityCommand::forCreateAction($service);
+                $command = SaveOidcngEntityCommand::forCreateAction($service, Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER);
                 if ($entity) {
-                    $command = SaveOidcngEntityCommand::fromEntity($entity);
+                    $command = SaveOidcngEntityCommand::fromEntity($entity, Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER);
                 }
                 $command->setEnvironment($environment);
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Factory/EntityTypeFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Factory/EntityTypeFactory.php
@@ -26,6 +26,7 @@ use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity\EntityTypeInterface;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity\OidcEntityType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity\OidcngEntityType;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity\OidcngResourceServerEntityType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity\SamlEntityType;
 use Symfony\Component\Form\FormFactory;
 
@@ -72,6 +73,18 @@ class EntityTypeFactory
                 }
                 $command->setEnvironment($environment);
                 return $this->formFactory->create(OidcngEntityType::class, $command, $this->buildOptions($environment));
+            case ($type == Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER):
+                $command = SaveOidcngEntityCommand::forCreateAction($service);
+                if ($entity) {
+                    $command = SaveOidcngEntityCommand::fromEntity($entity);
+                }
+                $command->setEnvironment($environment);
+
+                return $this->formFactory->create(
+                    OidcngResourceServerEntityType::class,
+                    $command,
+                    $this->buildOptions($environment)
+                );
         }
 
         throw new InvalidArgumentException("invalid form type requested: " . $type);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngResourceServerEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngResourceServerEntityType.php
@@ -18,7 +18,6 @@
 
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity;
 
-use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngEntityCommand;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngResourceServerEntityCommand;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
@@ -146,20 +145,25 @@ class OidcngResourceServerEntityType extends AbstractType
                         ]
                     )
             );
-
-            $builder->create('comments', FormType::class, ['inherit_data' => true])
-                ->add(
-                    'comments',
-                    TextareaType::class,
-                    [
-                        'required' => false,
-                        'attr' => [
-                            'data-help' => 'entity.edit.information.comments',
-                            'rows' => 10,
-                        ],
-                    ]
-                );
         $builder
+            ->add(
+                $builder->create(
+                    'comments',
+                    FormType::class,
+                    ['inherit_data' => true, 'attr' => ['class' => 'attributes']]
+                )
+                    ->add(
+                        'comments',
+                        TextareaType::class,
+                        [
+                            'required' => false,
+                            'attr' => [
+                                'data-help' => 'entity.edit.information.comments',
+                                'rows' => 10,
+                            ],
+                        ]
+                    )
+            )
             ->add('status', HiddenType::class)
             ->add('manageId', HiddenType::class)
             ->add('environment', HiddenType::class)

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngResourceServerEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngResourceServerEntityType.php
@@ -1,0 +1,196 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity;
+
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngEntityCommand;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class OidcngResourceServerEntityType extends AbstractType
+{
+
+    /**
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable) - for the nameIdFormat choice_attr callback parameters
+     *
+     * @param FormBuilderInterface $builder
+     * @param array $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $metadata = $builder->create('metadata', FormType::class, ['inherit_data' => true]);
+
+        $metadata
+            ->add(
+                'clientId',
+                TextType::class,
+                [
+                    'property_path' => 'entityId',
+                    'required' => false,
+                    'attr' => [
+                        'data-help' => 'entity.edit.information.clientId',
+                        'data-parsley-uri' => null,
+                        'data-parsley-trigger' => 'blur',
+                    ],
+                ]
+            );
+
+        $manageId = $options['data']->getManageId();
+        if (!empty($manageId)) {
+            $metadata->remove('clientId');
+            $metadata
+                ->add(
+                    'clientId',
+                    TextType::class,
+                    [
+                        'required' => false,
+                        'validation_groups' => false,
+                        'disabled' => true,
+                        'attr' => [
+                            'readonly' => 'readonly',
+                            'data-help' => 'entity.edit.information.clientId',
+                        ],
+                    ]
+                );
+        }
+        $metadata
+            ->add(
+                'nameNl',
+                TextType::class,
+                [
+                    'required' => false,
+                    'attr' => ['data-help' => 'entity.edit.information.nameNl'],
+                ]
+            )
+            ->add(
+                'descriptionNl',
+                TextareaType::class,
+                [
+                    'required' => false,
+                    'attr' => [
+                        'data-help' => 'entity.edit.information.descriptionNl',
+                        'rows' => 10,
+                    ],
+                ]
+            )
+            ->add(
+                'nameEn',
+                TextType::class,
+                [
+                    'required' => false,
+                    'attr' => ['data-help' => 'entity.edit.information.nameEn'],
+                ]
+            )
+            ->add(
+                'descriptionEn',
+                TextareaType::class,
+                [
+                    'required' => false,
+                    'attr' => [
+                        'data-help' => 'entity.edit.information.descriptionEn',
+                        'rows' => 10,
+                    ],
+                ]
+            );
+
+        $builder
+            ->add($metadata)
+            ->add(
+                $builder->create('contactInformation', FormType::class, ['inherit_data' => true])
+                    ->add(
+                        'administrativeContact',
+                        ContactType::class,
+                        [
+                            'by_reference' => false,
+                            'attr' => ['data-help' => 'entity.edit.information.administrativeContact'],
+                        ]
+                    )
+                    ->add(
+                        'technicalContact',
+                        ContactType::class,
+                        [
+                            'by_reference' => false,
+                            'attr' => ['data-help' => 'entity.edit.information.technicalContact'],
+                        ]
+                    )
+                    ->add(
+                        'supportContact',
+                        ContactType::class,
+                        [
+                            'by_reference' => false,
+                            'attr' => ['data-help' => 'entity.edit.information.supportContact'],
+                        ]
+                    )
+            );
+
+            $builder->create('comments', FormType::class, ['inherit_data' => true])
+                ->add(
+                    'comments',
+                    TextareaType::class,
+                    [
+                        'required' => false,
+                        'attr' => [
+                            'data-help' => 'entity.edit.information.comments',
+                            'rows' => 10,
+                        ],
+                    ]
+                );
+        $builder
+            ->add('status', HiddenType::class)
+            ->add('manageId', HiddenType::class)
+            ->add('environment', HiddenType::class)
+            ->add('organizationNameNl', HiddenType::class)
+            ->add('organizationNameEn', HiddenType::class)
+            ->add('organizationDisplayNameNl', HiddenType::class)
+            ->add('organizationDisplayNameEn', HiddenType::class)
+            ->add('organizationUrlNl', HiddenType::class)
+            ->add('organizationUrlEn', HiddenType::class)
+
+            ->add('save', SubmitType::class, ['attr' => ['class' => 'button']])
+            ->add('publishButton', SubmitType::class, ['label'=> 'Publish', 'attr' => ['class' => 'button']])
+            ->add('cancel', SubmitType::class, ['attr' => ['class' => 'button']]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => SaveOidcngEntityCommand::class
+        ));
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'dashboard_bundle_entity_type';
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngResourceServerEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngResourceServerEntityType.php
@@ -19,15 +19,9 @@
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity;
 
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngEntityCommand;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
-use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
-use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngResourceServerEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngResourceServerEntityType.php
@@ -19,6 +19,7 @@
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity;
 
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngEntityCommand;
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngResourceServerEntityCommand;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -54,8 +55,6 @@ class OidcngResourceServerEntityType extends AbstractType
                     'required' => false,
                     'attr' => [
                         'data-help' => 'entity.edit.information.clientId',
-                        'data-parsley-uri' => null,
-                        'data-parsley-trigger' => 'blur',
                     ],
                 ]
             );
@@ -179,7 +178,7 @@ class OidcngResourceServerEntityType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            'data_class' => SaveOidcngEntityCommand::class
+            'data_class' => SaveOidcngResourceServerEntityCommand::class
         ));
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/ProtocolChoiceFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/ProtocolChoiceFactory.php
@@ -43,7 +43,8 @@ class ProtocolChoiceFactory
     private $availableOptions = [
         Entity::TYPE_SAML => 'entity.type.saml20.title',
         Entity::TYPE_OPENID_CONNECT => 'entity.type.oidc.title',
-        Entity::TYPE_OPENID_CONNECT_TNG => 'entity.type.oidcng.title',
+        Entity::TYPE_OPENID_CONNECT_TNG => 'entity.type.oidcng.client.title',
+        Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER => 'entity.type.oidcng.resource_server.title',
     ];
 
     public function __construct(Config $manageConfigTest, Config $manageConfigProd)
@@ -72,6 +73,7 @@ class ProtocolChoiceFactory
         $options = $this->availableOptions;
         if (!$this->oidcngEnabledMarshaller->allowed($this->service, $manageConfig->getOidcngEnabled()->isEnabled())) {
             unset($options[Entity::TYPE_OPENID_CONNECT_TNG]);
+            unset($options[Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER]);
         }
         return array_flip($options);
     }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -73,6 +73,12 @@ services:
         tags:
             - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngEntityCommand }
 
+    surfnet.dashboard.command_handler.edit_oidcng_rs_entity:
+        class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\SaveOidcngResourceServerEntityCommandHandler
+        public: true
+        tags:
+            - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngResourceServerEntityCommand }
+
     surfnet.dashboard.command_handler.edit_service:
         class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Service\EditServiceCommandHandler
         public: true
@@ -200,6 +206,11 @@ services:
         arguments:
             $oidcPlaygroundUriTest: '%oidcng_playground_uri_test%'
             $oidcPlaygroundUriProd: '%oidcng_playground_uri_prod%'
+
+    Surfnet\ServiceProviderDashboard\Application\Metadata\OidcngResourceServerJsonGenerator:
+        class: Surfnet\ServiceProviderDashboard\Application\Metadata\OidcngResourceServerJsonGenerator
+        tags:
+            - { name: dashboard.json_generator, identifier: oidcng_rs }
 
     Surfnet\ServiceProviderDashboard\Legacy\Metadata\Parser:
         arguments:

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -389,6 +389,8 @@ entity.type.description.html: "<p><strong>Lorem ipsum dolor sit amet</strong> Co
 entity.type.saml20.title: SAML 2.0
 entity.type.oidc.title: OpenID Connect
 entity.type.oidcng.title: OpenID Connect - The Next Generation
+entity.type.oidcng.client.title: OpenID Connect client - The Next Generation
+entity.type.oidcng.resource_server.title: OpenID Connect resource server - The Next Generation
 privacy.edit.title: GDPR related questions
 privacy.edit.introduction.html: "<p><strong>Pellentesque habitant morbi tristique</strong> senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. <em>Aenean ultricies mi vitae est.</em> Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, <code>commodo vitae</code>, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. <a href=\"#\">Donec non enim</a> in turpis pulvinar facilisis. Ut felis.</p>"
 privacy.form.label.accessData.html: 2. Who can access the data?

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -28,6 +28,9 @@ entity:
       oidcng:
         title: Information
         html: <strong>information about this view</strong>
+      oidcng_rs:
+        title: Information
+        html: <strong>information about this view</strong>
     metadata:
       metadata_url: Metadata URL
       acs_location: ACS location
@@ -56,6 +59,9 @@ entity:
       oidcng:
         title: Metadata
         html: <strong>information about the metadata fields</strong>
+      oidcng_rs:
+        title: Metadata
+        html: <strong>information about the metadata fields</strong>
     contact:
       administrative: Administrative contact
       technical: Technical contact
@@ -71,6 +77,9 @@ entity:
         title: Contact information
         html: <strong>information about the contact information fields</strong>
       oidcng:
+        title: Contact information
+        html: <strong>information about the contact information fields</strong>
+      oidcng_rs:
         title: Contact information
         html: <strong>information about the contact information fields</strong>
     attribute:
@@ -246,18 +255,35 @@ should be present.</li>
 <li>A list of the attributes your Service Provider requires to operate.</li>
 </ul>
 "
+entity.edit.info.oidcng_rs.title: Info
+entity.edit.info.oidcng_rs.html: "
+<p>Documentation about this SP registration form can be found at:
+<a href=\"https://wiki.surfnet.nl/x/isZWAw\">https://wiki.surfnet.nl/x/isZWAw</a>.</p>
+
+<p>The registration of your Service Provider consists of two parts. A contractual and technical part. This form covers the technical part. The contractual part will be handled by SURFmarket.
+In the following pages we will ask you to submit the necessary information that allows us to create a test connection. With the following details ready we estimate this process will take around 20 minutes to complete. Information we need and collect through this form includes:</p>
+<ul>
+<li>Various contacts responsible for the entity. Support, administrative and technical
+should be present.</li>
+<li>Information about SAML 2.0 configuration.</li>
+<li>Metadata information including URL, certificate and logo of your entity.</li>
+<li>A list of the attributes your Service Provider requires to operate.</li>
+</ul>
+"
 entity.edit.general.title: General
 entity.edit.general.html: "<p>Enter/edit your contact information below. We will use this information in case we have additional questions.</p>"
 entity.edit.metadata.fetch.exception: "Unable to load the metadata from the provided import url."
 entity.edit.metadata.saml20.html: "Please provide the metadata URL of your entity. The URL will be validated and the fields below will be filled in automatically (when available in the metadata). <strong>If the input is not correct please change the settings in your SAML enabled software.</strong> Note that the fields with a * are required and need to be correctly configured. Check the following page for more information: <a href=\"https://wiki.surfnet.nl/x/vclWAw\">https://wiki.surfnet.nl/x/vclWAw</a>."
 entity.edit.metadata.oidc.html: "Please provide the metadata URL of your entity. The URL will be validated and the fields below will be filled in automatically (when available in the metadata). <strong>If the input is not correct please change the settings in your SAML enabled software.</strong> Note that the fields with a * are required and need to be correctly configured. Check the following page for more information: <a href=\"https://wiki.surfnet.nl/x/vclWAw\">https://wiki.surfnet.nl/x/vclWAw</a>."
 entity.edit.metadata.oidcng.html: "Please provide the metadata URL of your entity. The URL will be validated and the fields below will be filled in automatically (when available in the metadata). <strong>If the input is not correct please change the settings in your SAML enabled software.</strong> Note that the fields with a * are required and need to be correctly configured. Check the following page for more information: <a href=\"https://wiki.surfnet.nl/x/vclWAw\">https://wiki.surfnet.nl/x/vclWAw</a>."
+entity.edit.metadata.oidcng_rs.html: "Please provide the metadata URL of your entity. The URL will be validated and the fields below will be filled in automatically (when available in the metadata). <strong>If the input is not correct please change the settings in your SAML enabled software.</strong> Note that the fields with a * are required and need to be correctly configured. Check the following page for more information: <a href=\"https://wiki.surfnet.nl/x/vclWAw\">https://wiki.surfnet.nl/x/vclWAw</a>."
 entity.edit.metadata.invalid.exception: "An error occurred while importing the metadata."
 entity.edit.metadata.validation-failed: "Warning! Some entries are missing or incorrect. Please review and fix those entries below."
 entity.edit.metadata.unknown.exception: "An unknown error occurred while importing the metadata."
 entity.edit.metadata.saml20.title: Metadata
 entity.edit.metadata.oidc.title: Metadata
 entity.edit.metadata.oidcng.title: Metadata
+entity.edit.metadata.oidcng_rs.title: Metadata
 entity.edit.metadata.parse.exception: "The provided metadata is invalid."
 entity.edit.contact_information.title: Contact information
 entity.edit.contact_information.html: "
@@ -293,6 +319,14 @@ entity.edit.attributes.oidc.html: "
 "
 entity.edit.attributes.oidcng.title: Attributes
 entity.edit.attributes.oidcng.html: "
+<p>When an end-user logs in to your SP, SURFconext sends a SAML-assertion to the SP. The SAML-assertion contains statements about the user, including identity and possibly a number of other attributes (see list below). Select the attributes this service requires to operate. For each attribute you request a <strong>valid reason</strong> must be provided which will be reviewed. Note: <strong>every extra attribute you request could complicate the contractual phase</strong>: just one more reason to not select more attributes than you absolutely need. Also note that SURFconext operates with a minimal disclosure principle. This means that only the absolute necessary (personal) information is transferred to a entity. Check this page for more information: <a href=\"https://wiki.surfnet.nl/x/xcpWAw\">https://wiki.surfnet.nl/x/xcpWAw</a>.</p>
+
+<p>Possibly some boxes have already been checked. This information is reused from the metadata.</p>
+
+<p><i>Identity Providers will be informed about the attributes your service requests and must agree to the release of these attributes to your entity.</i></p>
+"
+entity.edit.attributes.oidcng_rs.title: Attributes
+entity.edit.attributes.oidcng_rs.html: "
 <p>When an end-user logs in to your SP, SURFconext sends a SAML-assertion to the SP. The SAML-assertion contains statements about the user, including identity and possibly a number of other attributes (see list below). Select the attributes this service requires to operate. For each attribute you request a <strong>valid reason</strong> must be provided which will be reviewed. Note: <strong>every extra attribute you request could complicate the contractual phase</strong>: just one more reason to not select more attributes than you absolutely need. Also note that SURFconext operates with a minimal disclosure principle. This means that only the absolute necessary (personal) information is transferred to a entity. Check this page for more information: <a href=\"https://wiki.surfnet.nl/x/xcpWAw\">https://wiki.surfnet.nl/x/xcpWAw</a>.</p>
 
 <p>Possibly some boxes have already been checked. This information is reused from the metadata.</p>

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detail.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detail.html.twig
@@ -62,6 +62,8 @@
 
     </div>
 
+    {% if entity.protocol != "oidcng_rs" %}
+
     <div class="fieldset card">
         <h2>{{ ('entity.detail.attribute.' ~ type ~ '.title')|trans }}</h2>
         <div class="wysiwyg">{{ ('entity.detail.attribute.' ~ type ~ '.html')|trans|wysiwyg }}</div>
@@ -83,6 +85,8 @@
         {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.edu_person_targetted_id')|trans, value: entity.eduPersonTargetedIDAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.eduPersonTargetedIDAttribute'} %}
 
     </div>
+
+    {% endif %}
 
     <div class="modal oidc-confirmation" id="reset-secret-confirmation">
         {% include "@Dashboard/EntityModal/secretResetModal.html.twig" %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityEdit/edit.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityEdit/edit.html.twig
@@ -43,15 +43,11 @@
 
     {% endif %}
 
-    {% if form.attributes is defined %}
-
     <div class="fieldset card">
         <h2>{{ 'entity.edit.comments.title'|trans }}</h2>
         <div class="wysiwyg">{{ 'entity.edit.comments.html'|trans|wysiwyg }}</div>
         {{ form_widget(form.comments) }}
     </div>
-
-    {% endif %}
 
     <div class="button-wrapper">
         {{ form_end(form) }}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityEdit/edit.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityEdit/edit.html.twig
@@ -33,17 +33,25 @@
         {{ form_widget(form.contactInformation) }}
     </div>
 
+    {% if form.attributes is defined %}
+
     <div class="fieldset card">
         <h2>{{ ('entity.edit.attributes.' ~ type ~ '.title')|trans }}</h2>
         <div class="wysiwyg">{{ ('entity.edit.attributes.' ~ type ~ '.html')|trans|wysiwyg }}</div>
         {{ form_widget(form.attributes) }}
     </div>
 
+    {% endif %}
+
+    {% if form.attributes is defined %}
+
     <div class="fieldset card">
         <h2>{{ 'entity.edit.comments.title'|trans }}</h2>
         <div class="wysiwyg">{{ 'entity.edit.comments.html'|trans|wysiwyg }}</div>
         {{ form_widget(form.comments) }}
     </div>
+
+    {% endif %}
 
     <div class="button-wrapper">
         {{ form_end(form) }}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/UniqueRedirectUrlsValidator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/UniqueRedirectUrlsValidator.php
@@ -42,6 +42,10 @@ class UniqueRedirectUrlsValidator extends ConstraintValidator
             throw new Exception('invalid validator command exception');
         }
 
+        if (is_null($value)) {
+            return;
+        }
+
         if (array_unique($value) !== $value) {
             $this->context->addViolation('validator.unique_redirect_urls.duplicate_found');
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/DeleteEntityClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/DeleteEntityClient.php
@@ -85,6 +85,7 @@ class DeleteEntityClient implements DeleteEntityRepositoryInterface
     private function getProtocol($dashboardProtocol)
     {
         $lookup = [
+            Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER => Protocol::OIDC10_RP,
             Entity::TYPE_OPENID_CONNECT_TNG => Protocol::OIDC10_RP,
             Entity::TYPE_OPENID_CONNECT => Protocol::SAML20_SP,
             Entity::TYPE_SAML => Protocol::SAML20_SP,

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Dto/ManageEntity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Dto/ManageEntity.php
@@ -61,7 +61,11 @@ class ManageEntity
         $attributeList = AttributeList::fromApiResponse($data);
         $metaData = MetaData::fromApiResponse($data);
         if ($manageProtocol === Protocol::OIDC10_RP) {
-            $oidcClient = OidcngClient::fromApiResponse($data, $manageProtocol);
+            if (isset($data['data']['metaDataFields']['isResourceServer']) && $data['data']['metaDataFields']['isResourceServer']){
+                $oidcClient = OidcngResourceServerClient::fromApiResponse($data, $manageProtocol);
+            } else {
+                $oidcClient = OidcngClient::fromApiResponse($data, $manageProtocol);
+            }
         } elseif ($manageProtocol === Protocol::SAML20_SP) {
             // Try to create an OidcClient, the first oidc implementation used SAML20_SP as entity type.
             $oidcClient = OidcClient::fromApiResponse($data, $manageProtocol);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Dto/ManageEntity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Dto/ManageEntity.php
@@ -54,6 +54,12 @@ class ManageEntity
      */
     private $allowedIdentityProviders;
 
+    /**
+     * @param $data
+     * @return ManageEntity
+     *
+     * @SuppressWarnings(PHPMD.ElseExpression)
+     */
     public static function fromApiResponse($data)
     {
         $manageProtocol = isset($data['type']) ? $data['type'] : '';
@@ -61,7 +67,9 @@ class ManageEntity
         $attributeList = AttributeList::fromApiResponse($data);
         $metaData = MetaData::fromApiResponse($data);
         if ($manageProtocol === Protocol::OIDC10_RP) {
-            if (isset($data['data']['metaDataFields']['isResourceServer']) && $data['data']['metaDataFields']['isResourceServer']){
+            if (isset($data['data']['metaDataFields']['isResourceServer']) &&
+                $data['data']['metaDataFields']['isResourceServer']
+            ) {
                 $oidcClient = OidcngResourceServerClient::fromApiResponse($data, $manageProtocol);
             } else {
                 $oidcClient = OidcngClient::fromApiResponse($data, $manageProtocol);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Dto/OidcngResourceServerClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Dto/OidcngResourceServerClient.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto;
+
+use Webmozart\Assert\Assert;
+
+class OidcngResourceServerClient implements OidcClientInterface
+{
+    /**
+     * @var string
+     */
+    private $clientId;
+    /**
+     * @var string
+     */
+    private $clientSecret;
+    /**
+     * @var string
+     */
+    private $grantType;
+    /**
+     * @var array
+     */
+    private $scope;
+    /**
+     * @param array $data
+     * @param string $manageProtocol
+     * @return OidcngClient
+     */
+    public static function fromApiResponse(array $data, $manageProtocol)
+    {
+        $clientId = isset($data['data']['entityid']) ? $data['data']['entityid'] : '';
+        $clientSecret = isset($data['data']['metaDataFields']['secret']) ? $data['data']['metaDataFields']['secret'] : '';
+        $grantType = isset($data['data']['metaDataFields']['grants'])
+            ? reset($data['data']['metaDataFields']['grants']) : '';
+        $scope = isset($data['data']['metaDataFields']['scopes']) ? $data['data']['metaDataFields']['scopes'] : '';
+
+        Assert::stringNotEmpty($clientId);
+        Assert::string($clientSecret);
+        Assert::string($grantType);
+        Assert::isArray($scope);
+
+        return new self(
+            $clientId,
+            $clientSecret,
+            $grantType,
+            $scope
+        );
+    }
+
+    /**
+     * @param string $clientId ,
+     * @param string $clientSecret
+     * @param string $grantType
+     * @param array $scope
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     */
+    private function __construct(
+        $clientId,
+        $clientSecret,
+        $grantType,
+        $scope
+    ) {
+        $this->clientId = $clientId;
+        $this->clientSecret = $clientSecret;
+        $this->grantType = $grantType;
+        $this->scope = $scope;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClientId()
+    {
+        return $this->clientId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClientSecret()
+    {
+        return $this->clientSecret;
+    }
+
+    /**
+     * @return string
+     */
+    public function getGrantType()
+    {
+        return $this->grantType;
+    }
+
+    /**
+     * @return array
+     */
+    public function getScope()
+    {
+        return $this->scope;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRedirectUris()
+    {
+        return [];
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPublicClient()
+    {
+        return false;
+    }
+
+    /**
+     * @return int
+     */
+    public function getAccessTokenValidity()
+    {
+        return 0;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Dto/Protocol.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Dto/Protocol.php
@@ -50,6 +50,11 @@ class Protocol
             $protocol = Entity::TYPE_OPENID_CONNECT;
         }
 
+        $isResourceServer = isset($data['data']['metaDataFields']['isResourceServer']) && $data['data']['metaDataFields']['isResourceServer'];
+        if ($protocol === Entity::TYPE_OPENID_CONNECT_TNG && $isResourceServer) {
+            $protocol = Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER;
+        }
+
         return new self($protocol);
     }
 

--- a/tests/integration/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandlerTest.php
@@ -52,11 +52,11 @@ class SaveOidcngEntityCommandHandlerTest extends MockeryTestCase
         );
     }
 
-    public function test_it_can_delete_an_entity_from_production()
+    public function test_it_can_handle_saving_of_a_save_command()
     {
         $service = m::mock(Service::class);
 
-        $command = SaveOidcngEntityCommand::forCreateAction($service, Entity::TYPE_OPENID_CONNECT_TNG);
+        $command = SaveOidcngEntityCommand::forCreateAction($service);
         $command->setEntityId('test_entity');
         $command->setGrantType(OidcGrantType::GRANT_TYPE_IMPLICIT);
         $command->setRedirectUrls(['https://test.example.com/redirect', 'https://test.example.com/section/31/redirect']);

--- a/tests/integration/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandlerTest.php
@@ -56,7 +56,7 @@ class SaveOidcngEntityCommandHandlerTest extends MockeryTestCase
     {
         $service = m::mock(Service::class);
 
-        $command = SaveOidcngEntityCommand::forCreateAction($service);
+        $command = SaveOidcngEntityCommand::forCreateAction($service, Entity::TYPE_OPENID_CONNECT_TNG);
         $command->setEntityId('test_entity');
         $command->setGrantType(OidcGrantType::GRANT_TYPE_IMPLICIT);
         $command->setRedirectUrls(['https://test.example.com/redirect', 'https://test.example.com/section/31/redirect']);

--- a/tests/integration/Application/CommandHandler/Entity/SaveOidcngResourceServerEntityCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/SaveOidcngResourceServerEntityCommandHandlerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Integration\Application\CommandHandler\Entity;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery\Mock;
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngResourceServerEntityCommand;
+use Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\SaveOidcngResourceServerEntityCommandHandler;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityRepository;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
+
+class SaveOidcngResourceServerEntityCommandHandlerTest extends MockeryTestCase
+{
+
+    /**
+     * @var SaveOidcngResourceServerEntityCommandHandler
+     */
+    private $commandHandler;
+
+    /**
+     * @var EntityRepository&Mock
+     */
+    private $repository;
+
+    public function setUp()
+    {
+        $this->repository = m::mock(EntityRepository::class);
+
+        $this->commandHandler = new SaveOidcngResourceServerEntityCommandHandler(
+            $this->repository
+        );
+    }
+
+    public function test_it_can_handle_saving_of_a_save_command()
+    {
+        $service = m::mock(Service::class);
+
+        $command = SaveOidcngResourceServerEntityCommand::forCreateAction($service);
+        $command->setEntityId('test_entity');
+        $command->setNameEn('Test Entity');
+        $command->setSupportContact(m::mock(Contact::class));
+        $command->setAdministrativeContact(m::mock(Contact::class));
+        $command->setTechnicalContact(m::mock(Contact::class));
+
+
+        $this->repository
+            ->shouldReceive('isUnique')
+            ->andReturn(true);
+
+        $this->repository
+            ->shouldReceive('save')
+            ->with(
+                m::on(
+                    function (Entity $entity) {
+                        $this->assertEquals('test_entity', $entity->getEntityId());
+                        $this->assertEquals('Test Entity', $entity->getNameEn());
+                        return true;
+                    }
+                )
+            );
+
+        $this->commandHandler->handle($command);
+    }
+}

--- a/tests/integration/Application/ViewObject/EntityActionsTest.php
+++ b/tests/integration/Application/ViewObject/EntityActionsTest.php
@@ -29,4 +29,37 @@ class EntityActionsTest extends TestCase
         $actions = new EntityActions('manage-id', 1, Entity::STATE_PUBLISHED, Entity::ENVIRONMENT_TEST, Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER);
         $this->assertFalse($actions->allowAclAction());
     }
+
+    /**
+     * @param bool $expectation
+     * @param string $protocol
+     * @param string $publicationStatus
+     * @param string $description
+     *
+     * @dataProvider resetClientOptions
+     */
+    public function test_oidc_entities_can_reset_client_secret($expectation, $protocol, $publicationStatus, $description)
+    {
+        $actions = new EntityActions('manage-id', 1, $publicationStatus, Entity::ENVIRONMENT_TEST, $protocol);
+
+        $this->assertEquals($expectation, $actions->allowSecretResetAction(), $description);
+    }
+
+    public static function resetClientOptions()
+    {
+        return [
+            [true, Entity::TYPE_OPENID_CONNECT, Entity::STATE_PUBLISHED, 'Published OIDC entity should have reset option'],
+            [true, Entity::TYPE_OPENID_CONNECT_TNG, Entity::STATE_PUBLISHED, 'Published OIDC TNG entity should have reset option'],
+            [true, Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER, Entity::STATE_PUBLISHED, 'Published OIDC Resource Server TNG entity should have reset option'],
+
+            [true, Entity::TYPE_OPENID_CONNECT, Entity::STATE_PUBLICATION_REQUESTED, 'Request for publication OIDC entity should have reset option'],
+            [true, Entity::TYPE_OPENID_CONNECT_TNG, Entity::STATE_PUBLICATION_REQUESTED, 'Request for publication OIDC TNG entity should have reset option'],
+            [true, Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER, Entity::STATE_PUBLISHED, 'Request for publication OIDC Resource Server TNG entity should have reset option'],
+
+            [false, Entity::TYPE_SAML, Entity::STATE_PUBLISHED, 'SAML entities do not perform client resets'],
+
+            [false, Entity::TYPE_OPENID_CONNECT, Entity::STATE_DRAFT, 'Draft OIDC entities do not perform client resets'],
+            [false, Entity::TYPE_OPENID_CONNECT, Entity::STATE_REMOVAL_REQUESTED, 'Removed (requested) entities do not perform client resets'],
+        ];
+    }
 }

--- a/tests/integration/Application/ViewObject/EntityActionsTest.php
+++ b/tests/integration/Application/ViewObject/EntityActionsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Integration\Application\ViewObject;
+
+use PHPUnit\Framework\TestCase;
+use Surfnet\ServiceProviderDashboard\Application\ViewObject\EntityActions;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+
+class EntityActionsTest extends TestCase
+{
+    public function test_it_hides_idp_whitlist_option_for_oidcng_resource_server()
+    {
+        $actions = new EntityActions('manage-id', 1, Entity::STATE_PUBLISHED, Entity::ENVIRONMENT_TEST, Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER);
+        $this->assertFalse($actions->allowAclAction());
+    }
+}

--- a/tests/unit/Application/Metadata/OidcngResourceServerJsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/OidcngResourceServerJsonGeneratorTest.php
@@ -1,0 +1,204 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Application\Factory;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\ArpGenerator;
+use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\PrivacyQuestionsMetadataGenerator;
+use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\SpDashboardMetadataGenerator;
+use Surfnet\ServiceProviderDashboard\Application\Metadata\OidcngResourceServerJsonGenerator;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
+
+class OidcngResourceServerJsonGeneratorTest extends MockeryTestCase
+{
+    /**
+     * @var ArpGenerator
+     */
+    private $arpMetadataGenerator;
+
+    /**
+     * @var PrivacyQuestionsMetadataGenerator
+     */
+    private $privacyQuestionsMetadataGenerator;
+
+    /**
+     * @var SpDashboardMetadataGenerator
+     */
+    private $spDashboardMetadataGenerator;
+
+    public function setUp()
+    {
+        $this->arpMetadataGenerator = m::mock(ArpGenerator::class);
+        $this->privacyQuestionsMetadataGenerator = m::mock(PrivacyQuestionsMetadataGenerator::class);
+        $this->spDashboardMetadataGenerator = m::mock(SpDashboardMetadataGenerator::class);
+
+        $this->privacyQuestionsMetadataGenerator
+            ->shouldReceive('build')
+            ->andReturn(['privacy' => 'privacy']);
+
+        $this->spDashboardMetadataGenerator
+            ->shouldReceive('build')
+            ->andReturn([]);
+    }
+
+    public function test_it_can_build_oidcng_entity_data_for_new_entities()
+    {
+        $generator = new OidcngResourceServerJsonGenerator(
+            $this->privacyQuestionsMetadataGenerator,
+            $this->spDashboardMetadataGenerator
+        );
+
+        $data = $generator->generateForNewEntity($this->createOidcngEntity(), 'testaccepted');
+        $this->assertEquals(
+            [
+                'data' => [
+                    'type' => 'oidc10-rp',
+                    'state' => 'testaccepted',
+                    'entityid' => 'entityid',
+                    'active' => true,
+                    'allowedEntities' => [],
+                    'allowedall' => true,
+                    'metaDataFields' => [
+                        'description:en' => 'description en',
+                        'description:nl' => 'description nl',
+                        'grants' => [
+                            'client_credentials',
+                        ],
+                        'isResourceServer' => true,
+                        'name:en' => 'name en',
+                        'name:nl' => 'name nl',
+                        'NameIDFormat' => 'nameidformat',
+                        'contacts:0:contactType' => 'support',
+                        'contacts:0:givenName' => 'givenname',
+                        'contacts:0:surName' => 'surname',
+                        'contacts:0:emailAddress' => 'emailaddress',
+                        'contacts:0:telephoneNumber' => 'telephonenumber',
+                        'OrganizationName:en' => 'orgen',
+                        'OrganizationDisplayName:en' => 'orgdisen',
+                        'OrganizationURL:en' => 'http://orgen',
+                        'OrganizationName:nl' => 'orgnl',
+                        'OrganizationDisplayName:nl' => 'orgdisnl',
+                        'OrganizationURL:nl' => 'http://orgnl',
+                        'scopes' => ['openid'],
+                        'privacy' => 'privacy',
+                        'secret' => 'test'
+                    ],
+                ],
+                'type' => 'oidc10_rp',
+            ],
+            $data
+        );
+    }
+
+    public function test_it_can_build_oidcng_data_for_existing_entities()
+    {
+        $generator = new OidcngResourceServerJsonGenerator(
+            $this->privacyQuestionsMetadataGenerator,
+            $this->spDashboardMetadataGenerator
+        );
+
+        $data = $generator->generateForExistingEntity($this->createOidcngEntity(), 'testaccepted');
+
+        $this->assertEquals(
+            array(
+                'pathUpdates' =>
+                    array(
+                        'entityid' => 'entityid',
+                        'metaDataFields.NameIDFormat' => 'nameidformat',
+                        'metaDataFields.description:en' => 'description en',
+                        'metaDataFields.description:nl' => 'description nl',
+                        'metaDataFields.name:en' => 'name en',
+                        'metaDataFields.name:nl' => 'name nl',
+                        'metaDataFields.contacts:0:contactType' => 'support',
+                        'metaDataFields.contacts:0:givenName' => 'givenname',
+                        'metaDataFields.contacts:0:surName' => 'surname',
+                        'metaDataFields.contacts:0:emailAddress' => 'emailaddress',
+                        'metaDataFields.contacts:0:telephoneNumber' => 'telephonenumber',
+                        'metaDataFields.OrganizationName:en' => 'orgen',
+                        'metaDataFields.OrganizationDisplayName:en' => 'orgdisen',
+                        'metaDataFields.OrganizationURL:en' => 'http://orgen',
+                        'metaDataFields.OrganizationName:nl' => 'orgnl',
+                        'metaDataFields.OrganizationDisplayName:nl' => 'orgdisnl',
+                        'metaDataFields.OrganizationURL:nl' => 'http://orgnl',
+                        'metaDataFields.scopes' => ['openid'],
+                        'metaDataFields.secret' => 'test',
+                        'metaDataFields.grants' => [
+                            'client_credentials',
+                        ],
+                        'metaDataFields.isResourceServer' => true,
+                        'state' => 'testaccepted',
+                        'allowedEntities' => [],
+                        'allowedall' => true,
+                        'metaDataFields.privacy' => 'privacy'
+                    ),
+                'type' => 'oidc10_rp',
+                'id' => 'manageId',
+            ),
+            $data
+        );
+    }
+
+    /**
+     * @return Entity
+     */
+    private function createOidcngEntity()
+    {
+        /** @var Entity $entity */
+        $entity = m::mock(Entity::class)->makePartial();
+
+        $entity->setProtocol('oidcng_rs');
+
+        $entity->setManageId('manageId');
+        $entity->setEntityId('http://entityid');
+        $entity->setNameEn('name en');
+        $entity->setNameNl('name nl');
+        $entity->setNameIdFormat('nameidformat');
+        $entity->setDescriptionEn('description en');
+        $entity->setDescriptionNl('description nl');
+        $entity->setCertificate(
+            <<<CERT
+-----BEGIN CERTIFICATE-----
+certdata
+-----END CERTIFICATE-----
+CERT
+        );
+
+        $entity->setOrganizationNameEn('orgen');
+        $entity->setOrganizationDisplayNameEn('orgdisen');
+        $entity->setOrganizationUrlEn('http://orgen');
+        $entity->setOrganizationNameNl('orgnl');
+        $entity->setOrganizationDisplayNameNl('orgdisnl');
+        $entity->setOrganizationUrlNl('http://orgnl');
+
+        $contact = new Contact();
+        $contact->setFirstName('givenname');
+        $contact->setLastName('surname');
+        $contact->setEmail('emailaddress');
+        $contact->setPhone('telephonenumber');
+
+        $entity->setSupportContact($contact);
+
+        $entity->setClientSecret('test');
+
+        $entity->shouldReceive('isAllowedAll')->andReturn(true);
+        return $entity;
+    }
+}

--- a/tests/unit/Infrastructure/DashboardBundle/Factory/EntityTypeFactoryTest.php
+++ b/tests/unit/Infrastructure/DashboardBundle/Factory/EntityTypeFactoryTest.php
@@ -21,6 +21,8 @@ namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\DashboardBu
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcEntityCommand;
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngEntityCommand;
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngResourceServerEntityCommand;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveSamlEntityCommand;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
@@ -28,6 +30,8 @@ use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Factory\EntityTypeFactory;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity\OidcEntityType;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity\OidcngEntityType;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity\OidcngResourceServerEntityType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity\SamlEntityType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Mailer\Message;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
@@ -196,6 +200,134 @@ class EntityTypeFactoryTest extends MockeryTestCase
 
         $form = $this->factory->createCreateForm(
             Entity::TYPE_OPENID_CONNECT,
+            $this->service,
+            Entity::ENVIRONMENT_PRODUCTION,
+            $this->entity
+        );
+
+        $this->assertInstanceOf(FormType::class, $form);
+    }
+
+    public function test_build_create_new_oidcng_form()
+    {
+        $this->formFactory
+            ->shouldReceive('create')
+            ->with(\Mockery::on(function ($entityType) {
+                $this->assertSame(OidcngEntityType::class, $entityType);
+                return true;
+            }), \Mockery::on(function ($command) {
+                $this->assertInstanceOf(SaveOidcngEntityCommand::class, $command);
+                return true;
+            }), \Mockery::on(function ($options) {
+                $this->assertSame([
+                    'validation_groups' => [
+                        0 => 'Default',
+                        1 => 'production',
+                    ],
+                ], $options);
+                return true;
+            }))
+            ->once()
+            ->andReturn($this->form);
+
+        $form = $this->factory->createCreateForm(
+            Entity::TYPE_OPENID_CONNECT_TNG,
+            $this->service,
+            Entity::ENVIRONMENT_PRODUCTION,
+            null
+        );
+
+        $this->assertInstanceOf(FormType::class, $form);
+    }
+
+    public function test_build_create_new_oidcng_form_from_entity()
+    {
+        $this->formFactory
+            ->shouldReceive('create')
+            ->with(\Mockery::on(function ($entityType) {
+                $this->assertSame(OidcngEntityType::class, $entityType);
+                return true;
+            }), \Mockery::on(function ($command) {
+                $this->assertInstanceOf(SaveOidcngEntityCommand::class, $command);
+                return true;
+            }), \Mockery::on(function ($options) {
+                $this->assertSame([
+                    'validation_groups' => [
+                        0 => 'Default',
+                        1 => 'production',
+                    ],
+                ], $options);
+                return true;
+            }))
+            ->once()
+            ->andReturn($this->form);
+
+        $form = $this->factory->createCreateForm(
+            Entity::TYPE_OPENID_CONNECT_TNG,
+            $this->service,
+            Entity::ENVIRONMENT_PRODUCTION,
+            $this->entity
+        );
+
+        $this->assertInstanceOf(FormType::class, $form);
+    }
+
+    public function test_build_create_new_oidcng_rs_form()
+    {
+        $this->formFactory
+            ->shouldReceive('create')
+            ->with(\Mockery::on(function ($entityType) {
+                $this->assertSame(OidcngResourceServerEntityType::class, $entityType);
+                return true;
+            }), \Mockery::on(function ($command) {
+                $this->assertInstanceOf(SaveOidcngResourceServerEntityCommand::class, $command);
+                return true;
+            }), \Mockery::on(function ($options) {
+                $this->assertSame([
+                    'validation_groups' => [
+                        0 => 'Default',
+                        1 => 'production',
+                    ],
+                ], $options);
+                return true;
+            }))
+            ->once()
+            ->andReturn($this->form);
+
+        $form = $this->factory->createCreateForm(
+            Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER,
+            $this->service,
+            Entity::ENVIRONMENT_PRODUCTION,
+            null
+        );
+
+        $this->assertInstanceOf(FormType::class, $form);
+    }
+
+    public function test_build_create_new_oidcng_rs_form_from_entity()
+    {
+        $this->formFactory
+            ->shouldReceive('create')
+            ->with(\Mockery::on(function ($entityType) {
+                $this->assertSame(OidcngResourceServerEntityType::class, $entityType);
+                return true;
+            }), \Mockery::on(function ($command) {
+                $this->assertInstanceOf(SaveOidcngResourceServerEntityCommand::class, $command);
+                return true;
+            }), \Mockery::on(function ($options) {
+                $this->assertSame([
+                    'validation_groups' => [
+                        0 => 'Default',
+                        1 => 'production',
+                    ],
+                ], $options);
+                return true;
+            }))
+            ->once()
+            ->andReturn($this->form);
+
+        $form = $this->factory->createCreateForm(
+            Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER,
             $this->service,
             Entity::ENVIRONMENT_PRODUCTION,
             $this->entity

--- a/tests/webtests/EntityCreateOidcngResourceServerTest.php
+++ b/tests/webtests/EntityCreateOidcngResourceServerTest.php
@@ -252,8 +252,6 @@ class EntityCreateOidcngResourceServerTest extends WebTestCase
                     'nameEn' => 'The A Team',
                     'nameNl' => 'The A Team',
                     'clientId' => 'https://entity-id',
-                    'grantType' => 'client_credentials',
-                    'isResourceServer' => true,
                 ],
                 'contactInformation' => [
                     'administrativeContact' => [

--- a/tests/webtests/EntityCreateOidcngResourceServerTest.php
+++ b/tests/webtests/EntityCreateOidcngResourceServerTest.php
@@ -1,0 +1,281 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Webtests;
+
+use GuzzleHttp\Psr7\Response;
+use InvalidArgumentException;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+class EntityCreateOidcngResourceServerTest extends WebTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->loadFixtures();
+
+        $this->logIn('ROLE_ADMINISTRATOR');
+
+        $this->switchToService('Ibuildings B.V.');
+    }
+
+    public function test_it_renders_the_form()
+    {
+        $crawler = $this->client->request('GET', "/entity/create/2/oidcng_rs/test");
+        $form = $crawler->filter('.page-container')
+            ->selectButton('Save')
+            ->form();
+
+        $nameEnfield = $form->get('dashboard_bundle_entity_type[metadata][nameEn]');
+
+        $this->assertEquals(
+            '',
+            $nameEnfield->getValue(),
+            'Expect the NameEN field to be empty'
+        );
+    }
+
+    public function test_it_can_cancel_out_of_the_form()
+    {
+        $crawler = $this->client->request('GET', "/entity/create/2/oidcng_rs/test");
+        $form = $crawler
+            ->selectButton('Cancel')
+            ->form();
+
+        $this->client->submit($form);
+        // The form is now redirected to the list view
+        $this->assertTrue(
+            $this->client->getResponse() instanceof RedirectResponse,
+            'Expecting a redirect response after saving an entity'
+        );
+
+        // The entity list queries manage for published entities
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->prodMockHandler->append(new Response(200, [], '[]'));
+        $this->prodMockHandler->append(new Response(200, [], '[]'));
+
+        $crawler = $this->client->followRedirect();
+        $pageTitle = $crawler->filter('h1')->first()->text();
+        $message = $crawler->filter('.page-container .card')->eq(1)->text();
+
+        $this->assertContains("Entities of service 'Ibuildings B.V.'", $pageTitle);
+        $this->assertContains('There are no entities configured', $message);
+    }
+
+    public function test_it_can_save_the_form()
+    {
+        $formData = $this->buildValidFormData();
+
+        $crawler = $this->client->request('GET', "/entity/create/2/oidcng_rs/test");
+
+        $form = $crawler
+            ->selectButton('Save')
+            ->form();
+
+        $this->client->submit($form, $formData);
+
+        // The form is now redirected to the list view
+        $this->assertTrue(
+            $this->client->getResponse() instanceof RedirectResponse,
+            'Expecting a redirect response after saving an entity'
+        );
+
+        // The entity list queries manage for published entities
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->prodMockHandler->append(new Response(200, [], '[]'));
+        $this->prodMockHandler->append(new Response(200, [], '[]'));
+
+        $crawler = $this->client->followRedirect();
+
+        // Assert the entity id is in one of the td's of the first table row.
+        $entityTr = $crawler->filter('.page-container table tbody tr')->first();
+        $this->assertRegexp('/entity-id/', $entityTr->text());
+    }
+
+    public function test_it_can_publish_the_form()
+    {
+        $formData = $this->buildValidFormData();
+
+        $crawler = $this->client->request('GET', "/entity/create/2/oidcng_rs/test");
+
+        $form = $crawler
+            ->selectButton('Publish')
+            ->form();
+
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        // ClientId validator
+        $this->testMockHandler->append(new Response(200, [], '{"id":"f1e394b2-08b1-4882-8b32-43876c15c743"}'));
+        // Publish json
+        $this->testMockHandler->append(new Response(200, [], '{"id":"f1e394b2-08b1-4882-8b32-43876c15c743"}'));
+        // Push to EB through manage
+        $this->testMockHandler->append(new Response(200, [], '{"status":"OK"}'));
+
+        $this->client->submit($form, $formData);
+        // The form is now redirected to the list view
+        $this->assertTrue(
+            $this->client->getResponse() instanceof RedirectResponse,
+            'Expecting a redirect to the published "thank you" endpoint'
+        );
+
+        // The entity list queries manage for published entities
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->prodMockHandler->append(new Response(200, [], '[]'));
+        $this->prodMockHandler->append(new Response(200, [], '[]'));
+
+        $this->client->followRedirect(); // redirect to published page
+        $crawler = $this->client->followRedirect(); // redirect to list page to show secret
+
+        // Publishing an entity saves and then attempts a publish to Manage, removing the entity afterwards in sp dash.
+        $confirmation = $crawler->filter('.oidc-confirmation');
+        $label = $confirmation->filter('label')->text();
+        $span = $confirmation->filter('span')->text();
+
+        // A secret should be displayed
+        $this->assertEquals('Secret', $label);
+        $this->assertSame(20, strlen($span));
+    }
+
+    public function test_it_forwards_to_edit_action_when_publish_failed()
+    {
+        $formData = $this->buildValidFormData();
+
+        $crawler = $this->client->request('GET', "/entity/create/2/oidcng_rs/test");
+
+        $form = $crawler
+            ->selectButton('Publish')
+            ->form();
+
+        // ClientId validator
+        $this->testMockHandler->append(new Response(200, [], '{"id":"f1e394b2-08b1-4882-8b32-43876c15c743"}'));
+        // Publish json
+        $this->testMockHandler->append(new Response(200, [], '{"id":"f1e394b2-08b1-4882-8b32-43876c15c743"}'));
+        // Push to Manage
+        $this->testMockHandler->append(new Response(400, [], '{
+            "timestamp": 1558969891003,
+            "status": "400",
+            "error": "org.springframework.web.client.HttpClientErrorException",
+            "exception": "org.springframework.web.client.HttpClientErrorException",
+            "message": "{\"error\":\"ClientId is already used\"}",
+            "path": "//internal/metadata/"
+        }'));
+
+        $this->client->submit($form, $formData);
+
+        // The form is now redirected to the list view
+        $this->assertTrue(
+            $this->client->getResponse() instanceof RedirectResponse,
+            'Expecting redirect to entity edit form'
+        );
+
+        $crawler = $this->client->followRedirect();
+        // Publishing an entity saves and then attempts a publish to Manage, removing the entity afterwards in sp dash.
+        $pageTitle = $crawler->filter('h1')->first()->text();
+
+        $this->assertEquals('Service Provider registration form', $pageTitle);
+
+        $errorMessage = $crawler->filter('div.message.error')->first()->text();
+        $this->assertEquals('Unable to publish the entity, try again later', trim($errorMessage));
+
+        $uri = $this->client->getRequest()->getRequestUri();
+        $this->assertRegExp('/\/entity\/edit/', $uri);
+    }
+
+    public function test_creating_draft_for_production_is_not_allowed()
+    {
+        // SURFnet is not allowed to create production entities.
+        $this->switchToService('SURFnet');
+
+        $this->client->request('GET', "/entity/create/1/oidcng_rs/production");
+
+        $this->assertEquals(403, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function test_a_privileged_user_can_create_a_production_draft()
+    {
+        $formData = $this->buildValidFormData();
+
+        $crawler = $this->client->request('GET', "/entity/create/2/oidcng_rs/production");
+
+        $form = $crawler
+            ->selectButton('Save')
+            ->form();
+
+        $this->client->submit($form, $formData);
+
+        // The form is now redirected to the list view
+        $this->assertTrue(
+            $this->client->getResponse() instanceof RedirectResponse,
+            'Expecting a redirect response after saving an entity'
+        );
+
+        // The entity list queries manage for published entities
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->prodMockHandler->append(new Response(200, [], '[]'));
+        $this->prodMockHandler->append(new Response(200, [], '[]'));
+
+        $crawler = $this->client->followRedirect();
+
+        // Assert the entity is saved for the production environment.
+        $row = $crawler->filter('table tbody tr')->eq(1);
+
+        $this->assertEquals('https://entity-id', $row->filter('td')->eq(1)->text(), 'Entity ID not found in entity list');
+    }
+
+    private function buildValidFormData()
+    {
+        return [
+            'dashboard_bundle_entity_type' => [
+                'metadata' => [
+                    'descriptionNl' => 'Description NL',
+                    'descriptionEn' => 'Description EN',
+                    'nameEn' => 'The A Team',
+                    'nameNl' => 'The A Team',
+                    'clientId' => 'https://entity-id',
+                    'grantType' => 'client_credentials',
+                    'isResourceServer' => true,
+                ],
+                'contactInformation' => [
+                    'administrativeContact' => [
+                        'firstName' => 'John',
+                        'lastName' => 'Doe',
+                        'email' => 'john@doe.com',
+                        'phone' => '999',
+                    ],
+                    'technicalContact' => [
+                        'firstName' => 'Johnny',
+                        'lastName' => 'Doe',
+                        'email' => 'john@doe.com',
+                        'phone' => '888',
+                    ],
+                    'supportContact' => [
+                        'firstName' => 'Jack',
+                        'lastName' => 'Doe',
+                        'email' => 'john@doe.com',
+                        'phone' => '777',
+                    ],
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Warning: Another big one. Sorry about that!

This PR adds the OIDC TNG Resource Server entity type to SP Dashboard. From an SP dashboard standpoint, it is a thinned down version of a regular OIDC TNG client entity. The most notable change is that no ARP attributes can be configured for these entities. Other details like the redirect URLs, playground options, entity URLs (application/eula/logo/..) are not available. The differences between the entity types made me choose to create a completely new type implementation instead of an integration in the existing OIDC TNG entity.

I'd like this to be code and functionally reviewed. I tried my best to make the commit history in a reviewer friendly manner.

More details, and some back and forth between @quartje and me can be found on the Pivotal ticket:
https://www.pivotaltracker.com/story/show/167511565