### PR TITLE
Only allow publication of OIDC RS entities

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcngResourceServerEntityCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcngResourceServerEntityCommandHandler.php
@@ -19,8 +19,6 @@
 namespace Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity;
 
 use Ramsey\Uuid\Uuid;
-use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveEntityCommandInterface;
-use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngEntityCommand;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngResourceServerEntityCommand;
 use Surfnet\ServiceProviderDashboard\Application\CommandHandler\CommandHandler;
 use Surfnet\ServiceProviderDashboard\Application\Exception\EntityNotFoundException;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
@@ -165,6 +165,11 @@ class EntityCreateController extends Controller
         $form = $this->entityTypeFactory->createCreateForm($type, $service, $targetEnvironment);
         $command = $form->getData();
 
+        // The resource server entity type does not support saving of local drafts
+        if ($type === Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER) {
+            $form->remove('save');
+        }
+
         if ($request->isMethod('post')) {
             $form->handleRequest($request);
         }


### PR DESCRIPTION
Saving drafts will be deprecated in the near future. The OIDC TNG
Resource Server will be the first entity type where this is not allowed.