### PR TITLE
Allow empty contact type on the contact information from Manage

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Dto/Contact.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Dto/Contact.php
@@ -30,13 +30,13 @@ class Contact
 
     public static function from(array $contactData)
     {
-        $type = isset($contactData['contactType']) ? $contactData['contactType'] : '';
+        $type = $contactData['contactType'];
         $givenName = isset($contactData['givenName']) ? $contactData['givenName'] : '';
         $surName = isset($contactData['surName']) ? $contactData['surName'] : '';
         $email = isset($contactData['emailAddress']) ? $contactData['emailAddress'] : '';
         $phone = isset($contactData['phone']) ? $contactData['phone'] : '';
 
-        Assert::string($type);
+        Assert::stringNotEmpty($type);
         Assert::string($givenName);
         Assert::string($surName);
         Assert::string($email);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Dto/Contact.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Dto/Contact.php
@@ -30,13 +30,13 @@ class Contact
 
     public static function from(array $contactData)
     {
-        $type = $contactData['contactType'];
+        $type = isset($contactData['contactType']) ? $contactData['contactType'] : '';
         $givenName = isset($contactData['givenName']) ? $contactData['givenName'] : '';
         $surName = isset($contactData['surName']) ? $contactData['surName'] : '';
         $email = isset($contactData['emailAddress']) ? $contactData['emailAddress'] : '';
         $phone = isset($contactData['phone']) ? $contactData['phone'] : '';
 
-        Assert::stringNotEmpty($type);
+        Assert::string($type);
         Assert::string($givenName);
         Assert::string($surName);
         Assert::string($email);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Dto/ContactList.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Dto/ContactList.php
@@ -20,6 +20,12 @@ namespace Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto;
 
 class ContactList
 {
+    private static $supportedContactTypes = [
+        'technical',
+        'administrative',
+        'support',
+    ];
+
     private $contacts = [];
 
     public static function fromApiResponse(array $metaDataFields)
@@ -36,7 +42,9 @@ class ContactList
         // 2. Build the Contact DTOs
         $list = new self();
         foreach ($contactsData as $contact) {
-            $list->add(Contact::from($contact));
+            if (array_key_exists('contactType', $contact) && in_array($contact['contactType'], self::$supportedContactTypes)) {
+                $list->add(Contact::from($contact));
+            }
         }
 
         return $list;

--- a/tests/unit/Infrastructure/Manage/Dto/ManageEntityTest.php
+++ b/tests/unit/Infrastructure/Manage/Dto/ManageEntityTest.php
@@ -19,6 +19,7 @@
 namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\DashboardBundle\Manage\Dto;
 
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\Contact;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
 
 class ManageEntityTest extends MockeryTestCase
@@ -33,5 +34,24 @@ class ManageEntityTest extends MockeryTestCase
         $this->assertEquals('Technical Support', $entity->getMetaData()->getContacts()->findTechnicalContact()->getSurName());
         $this->assertEquals('SURFnet BV', $entity->getMetaData()->getOrganization()->getNameEn());
         $this->assertEquals(160, $entity->getMetaData()->getLogo()->getHeight());
+    }
+
+    public function test_create_dto_with_invalid_contacts_from_manage_response()
+    {
+        $entity = ManageEntity::fromApiResponse(json_decode(file_get_contents(__DIR__ . '/fixture/saml20_sp_contacts_response.json'), true));
+        $this->assertInstanceOf(ManageEntity::class, $entity);
+
+        $contactList = $entity->getMetaData()->getContacts();
+
+        $this->assertSame(null, $contactList->findAdministrativeContact());
+        $this->assertSame(null, $contactList->findSupportContact());
+        $this->assertInstanceOf(Contact::class, $contactList->findTechnicalContact());
+
+        $contact = $contactList->findTechnicalContact();
+        $this->assertSame('technical', $contact->getType());
+        $this->assertSame('SURFconext', $contact->getGivenName());
+        $this->assertSame('Technical Support', $contact->getSurName());
+        $this->assertSame('support@surfconext.nl', $contact->getEmail());
+        $this->assertSame('', $contact->getPhone());
     }
 }

--- a/tests/unit/Infrastructure/Manage/Dto/fixture/saml20_sp_contacts_response.json
+++ b/tests/unit/Infrastructure/Manage/Dto/fixture/saml20_sp_contacts_response.json
@@ -1,0 +1,35 @@
+{
+  "id": "411f8e0f-87a6-4ea7-8194-66b3e77f97d5",
+  "version": 0,
+  "type": "saml20_sp",
+  "revision": {
+    "number": 0,
+    "created": 1543851541.752,
+    "parentId": null,
+    "updatedBy": "sp-dashboard",
+    "terminated": null
+  },
+  "data": {
+    "entityid": "https:\/\/monitorstands.example.com",
+    "metadataurl": "https:\/\/engine.surfconext.nl\/authentication\/sp\/metadata",
+    "active": true,
+    "allowedEntities": [],
+    "allowedall": true,
+    "state": "testaccepted",
+    "type": "saml20-sp",
+    "metaDataFields": {
+      "contacts:0:contactType": "invalid",
+      "contacts:0:givenName": "SURFconext",
+      "contacts:0:surName": "Helpdesk",
+      "contacts:0:emailAddress": "help@surfconext.nl",
+      "contacts:1:givenName": "SURFconext",
+      "contacts:1:surName": "Administrative Contact",
+      "contacts:1:emailAddress": "support@surfconext.nl",
+      "contacts:2:contactType": "technical",
+      "contacts:2:givenName": "SURFconext",
+      "contacts:2:surName": "Technical Support",
+      "contacts:2:emailAddress": "support@surfconext.nl"
+    },
+    "eid": 31
+  }
+}


### PR DESCRIPTION
The ContactType can be empty when fetching an entity from manage.

https://www.pivotaltracker.com/story/show/166232238