### PR TITLE
Show flash message after publishing new OIDC TNG resource server

### DIFF
--- a/app/scss/components/flash.scss
+++ b/app/scss/components/flash.scss
@@ -48,7 +48,11 @@ div.flash {
       padding: 6px;
     }
   }
+}
 
-
-
+div.card.messages {
+  padding-bottom: 5px;
+  .message {
+    margin-bottom: 5px;
+  }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityProductionCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityProductionCommandHandler.php
@@ -144,6 +144,7 @@ class PublishEntityProductionCommandHandler implements CommandHandler
     public function handle(PublishEntityProductionCommand $command)
     {
         $entity = $this->repository->findById($command->getId());
+        $isNewEntity = empty($entity->getManageId());
 
         // 1. Create the Jira ticket
         $ticket = Ticket::fromEntity(
@@ -224,5 +225,9 @@ class PublishEntityProductionCommandHandler implements CommandHandler
         // 3. On failure, remove the Jira ticket that was previously created. The user must retry at a later stage
         $this->logger->info(sprintf('Deleting Jira issue with key: %s after failed publication action', $issue->getKey()));
         $this->ticketService->delete($issue->getKey());
+
+        if ($isNewEntity && $entity->getProtocol() === Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER) {
+            $this->flashBag->add('wysiwyg','entity.list.oidcng_connection.info.html');
+        }
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -169,6 +169,7 @@ entity.list.modal.oidc_confirmation:
     label: Secret
   warning: This message will be displayed only once
   info.html: <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+entity.list.oidcng_connection.info.html: <p><strong>Select OIDC RP to connect this Resource Server to</strong></p><p>Only access_tokens from connected clients can be introspected by the resource server.</p>
 entity.edit.error.publish: "Unable to publish the entity, try again later"
 entity.edit.error.push: "Unable to publish the entity, try again later"
 entity.edit.title: Service Provider registration form

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityList/list.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityList/list.html.twig
@@ -12,10 +12,14 @@
 
     {% set flashes = app.session.flashbag.all %}
     {% if flashes is not empty %}
-    <div class="card">
+    <div class="card messages">
         {% for type, messages in flashes %}
             {% for message in messages %}
-                <div class="message {{ type }}">{{ message|trans }}</div>
+                {% if type == 'wysiwyg' %}
+                    <div class="message {{ type }}">{{ message|trans|wysiwyg }}</div>
+                {% else %}
+                    <div class="message {{ type }}">{{ message|trans }}</div>
+                {% endif %}
             {% endfor %}
         {% endfor %}
     </div>
@@ -165,7 +169,7 @@
 
     {% if showOidcPopup %}
         <div class="modal" id="oidc-published-popup">
-            {{ render(controller('DashboardBundle:EntityPublished:oidcConfirmationModal')) }}
+            {{ render(controller('DashboardBundle:EntityPublished:oidcConfirmationModal', {'entity': publishedEntity})) }}
         </div>
     {% endif %}
 

--- a/tests/integration/Application/CommandHandler/Entity/PublishEntityTestCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/PublishEntityTestCommandHandlerTest.php
@@ -80,7 +80,10 @@ class PublishEntityTestCommandHandlerTest extends MockeryTestCase
         $entity = m::mock(Entity::class);
         $entity
             ->shouldReceive('getNameNl')
-            ->andReturn('Test Entity Name');
+            ->andReturn('Test Entity Name')
+            ->shouldReceive('getManageId')
+            ->shouldReceive('getProtocol')
+            ->andReturn(Entity::TYPE_OPENID_CONNECT_TNG);
 
         $this->repository
             ->shouldReceive('findById')
@@ -112,7 +115,10 @@ class PublishEntityTestCommandHandlerTest extends MockeryTestCase
         $entity = m::mock(Entity::class);
         $entity
             ->shouldReceive('getNameNl')
-            ->andReturn('Test Entity Name');
+            ->andReturn('Test Entity Name')
+            ->shouldReceive('getManageId')
+            ->shouldReceive('getProtocol')
+            ->andReturn(Entity::TYPE_SAML);
 
         $this->repository
             ->shouldReceive('findById')
@@ -153,7 +159,10 @@ class PublishEntityTestCommandHandlerTest extends MockeryTestCase
         $entity = m::mock(Entity::class);
         $entity
             ->shouldReceive('getNameNl')
-            ->andReturn('Test Entity Name');
+            ->andReturn('Test Entity Name')
+            ->shouldReceive('getManageId')
+            ->shouldReceive('getProtocol')
+            ->andReturn(Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER);
 
         $this->repository
             ->shouldReceive('findById')

--- a/tests/webtests/EntityCreateOidcngResourceServerTest.php
+++ b/tests/webtests/EntityCreateOidcngResourceServerTest.php
@@ -139,6 +139,10 @@ class EntityCreateOidcngResourceServerTest extends WebTestCase
         // A secret should be displayed
         $this->assertEquals('Secret', $label);
         $this->assertSame(20, strlen($span));
+
+        // When a new entity is published, a flash message should be displayed
+        $flashMessage = $crawler->filter('.message.wysiwyg')->text();
+        $this->assertContains('Select OIDC RP to connect this Resource Server to', $flashMessage);
     }
 
     public function test_it_forwards_to_edit_action_when_publish_failed()


### PR DESCRIPTION
The scope of the story was narrowed down to just displaying a flash message, instead of rendering a full blown modal window. The clients are no longer displayed on the flash message, as the list view shows them.

https://www.pivotaltracker.com/story/show/168379274