### PR TITLE
Make RP/RS connection request more verbose

### DIFF
--- a/app/scss/components/flash.scss
+++ b/app/scss/components/flash.scss
@@ -51,7 +51,12 @@ div.flash {
 }
 
 div.card.messages {
+  border-top-color: $green;
   padding-bottom: 5px;
+  i {
+    font-size: larger;
+    font-style: normal;
+  }
   .message {
     margin-bottom: 5px;
   }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -172,7 +172,7 @@ entity.list.modal.oidc_confirmation:
     label: Secret
   warning: This message will be displayed only once
   info.html: <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-entity.list.oidcng_connection.info.html: <p><strong>Select OIDC RP to connect this Resource Server to</strong></p><p>Only access_tokens from connected clients can be introspected by the resource server.</p>
+entity.list.oidcng_connection.info.html: <p><strong>Select OIDC RP to connect this Resource Server to</strong></p><p><i class="fa fa-exclamation-triangle"></i> Only access_tokens from connected clients can be introspected by the resource server.</p>
 entity.edit.error.publish: "Unable to publish the entity, try again later"
 entity.edit.error.push: "Unable to publish the entity, try again later"
 entity.edit.title: Service Provider registration form

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Twig/WysiwygExtension.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Twig/WysiwygExtension.php
@@ -69,8 +69,8 @@ class WysiwygExtension extends AbstractExtension
 
         $config->set('HTML.Doctype', 'HTML5');
         $config->set('Core.Encoding', 'UTF-8');
-        $config->set('HTML.AllowedElements', 'p,em,strong,span,h1,h2,h3,h4,h5,h6,ul,ol,li,a,sup,sub,code,blockquote,br');
-        $config->set('HTML.AllowedAttributes', 'a.target,a.href,p.style,span.style');
+        $config->set('HTML.AllowedElements', 'p,em,strong,span,h1,h2,h3,h4,h5,h6,ul,ol,li,a,sup,sub,code,blockquote,br,i');
+        $config->set('HTML.AllowedAttributes', 'a.target,a.href,p.style,span.style,i.class');
         $config->set('CSS.AllowedProperties', 'text-decoration,text-align');
         $config->set('Attr.AllowedFrameTargets', '_blank,_self,_parent,_top');
         $config->set('Cache.DefinitionImpl', null);


### PR DESCRIPTION
The request (flash message) to select one or more resource servers to
introspect the relying party has been made more verbose.

1. The card border top color has been made green
2. A warning icon was added to the 'only access_tokens..' text

As requested in:
https://github.com/SURFnet/sp-dashboard/pull/306#pullrequestreview-287255417