### PR TITLE
Set default grant type value when empty argument provided

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/OidcGrantType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/OidcGrantType.php
@@ -39,6 +39,12 @@ class OidcGrantType
      */
     public function __construct($grantType = self::GRANT_TYPE_AUTHORIZATION_CODE)
     {
+        // In certain cases the grant type might be empty (for example draft entities from before enforcing a
+        // default value). In those cases we are setting the default grant type, preventing a hard error.
+        if (empty($grantType)) {
+            $grantType = self::GRANT_TYPE_AUTHORIZATION_CODE;
+        }
+
         if (!in_array($grantType, self::$validGrantTypes)) {
             throw new \InvalidArgumentException("invalid grant type");
         }


### PR DESCRIPTION
The grant type now converts an empty value to the default value. This is
required for pre transition draft entities. These would cause the
invalid arg exception being raised.

https://www.pivotaltracker.com/story/show/167511241/comments/206739007