### PR TITLE
Prevent call to ResourceServerCollection function on null

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
@@ -1596,6 +1596,10 @@ class Entity
      */
     public function getOidcngResourceServers()
     {
+        // Doctrine does not call the constructor, preventing us from setting a default value there.
+        if (is_null($this->oidcngResourceServers)) {
+            return new ResourceServerCollection([]);
+        }
         return $this->oidcngResourceServers;
     }
 


### PR DESCRIPTION
Draft entities without a Rersource Server collection would error into a 500 status because the Doctrine entity did not have a suitable default value for the `oidcngResourceServers` field. This field should be set with a `ResourceServerCollection` instance. But this would be null. Causing an internal server error when the entity was converted to a save command.

See bug report in:
https://www.pivotaltracker.com/story/show/168532438