### PR TITLE
Persist IdP whitelist settings

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcEntityCommand.php
@@ -343,6 +343,19 @@ class SaveOidcEntityCommand implements SaveEntityCommandInterface
      */
     private $manageId;
 
+    /**
+     * @var bool
+     */
+    private $idpAllowAll = true;
+
+    /**
+     * The array of IdP's that are whitelisted are displayed in a hidden form field, and are rendered
+     * as a string (json encoded).
+     *
+     * @var string
+     */
+    private $idpWhitelist;
+
     private function __construct()
     {
         $this->grantType = new OidcGrantType();
@@ -410,6 +423,9 @@ class SaveOidcEntityCommand implements SaveEntityCommandInterface
         $command->organizationDisplayNameEn = $entity->getOrganizationDisplayNameEn();
         $command->organizationUrlNl = $entity->getOrganizationUrlNl();
         $command->organizationUrlEn = $entity->getOrganizationUrlEn();
+
+        $command->idpWhitelist = json_encode($entity->getIdpWhitelist());
+        $command->idpAllowAll = $entity->isIdpAllowAll();
 
         return $command;
     }
@@ -1128,5 +1144,51 @@ class SaveOidcEntityCommand implements SaveEntityCommandInterface
     public function setManageId($manageId)
     {
         $this->manageId = $manageId;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getIdpAllowAll()
+    {
+        return $this->idpAllowAll;
+    }
+
+    /**
+     * @param mixed $idpAllowAll
+     */
+    public function setIdpAllowAll($idpAllowAll)
+    {
+        $this->idpAllowAll = $idpAllowAll;
+    }
+
+    /**
+     * Returns the json_encoded string of the IdP whitelist)
+     * @return string
+     */
+    public function getIdpWhitelist()
+    {
+        return $this->idpWhitelist;
+    }
+
+    /**
+     * Returns the json_encoded string of the IdP whitelist)
+     * @return array
+     */
+    public function getIdpWhitelistDecoded()
+    {
+        $idpWhitelist = $this->idpWhitelist;
+        if (empty($idpWhitelist)) {
+            return [];
+        }
+        return json_decode($idpWhitelist, true);
+    }
+
+    /**
+     * @param array $idpWhitelist
+     */
+    public function setIdpWhitelist(array $idpWhitelist)
+    {
+        $this->idpWhitelist = json_encode($idpWhitelist);
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
@@ -385,6 +385,19 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      */
     private $resourceServers = [];
 
+    /**
+     * @var bool
+     */
+    private $idpAllowAll = true;
+
+    /**
+     * The array of IdP's that are whitelisted are displayed in a hidden form field, and are rendered
+     * as a string (json encoded).
+     *
+     * @var string
+     */
+    private $idpWhitelist;
+
     private function __construct()
     {
     }
@@ -456,6 +469,9 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
         $command->accessTokenValidity = (int) $entity->getAccessTokenValidity();
         $command->enablePlayground = $entity->isEnablePlayground();
         $command->resourceServers = $entity->getOidcngResourceServers()->getResourceServers();
+
+        $command->idpWhitelist = json_encode($entity->getIdpWhitelist());
+        $command->idpAllowAll = $entity->isIdpAllowAll();
 
         return $command;
     }
@@ -1246,5 +1262,51 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
     public function setOidcngResourceServers($resourceServers)
     {
         $this->resourceServers = $resourceServers;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getIdpAllowAll()
+    {
+        return $this->idpAllowAll;
+    }
+
+    /**
+     * @param mixed $idpAllowAll
+     */
+    public function setIdpAllowAll($idpAllowAll)
+    {
+        $this->idpAllowAll = $idpAllowAll;
+    }
+
+    /**
+     * Returns the json_encoded string of the IdP whitelist)
+     * @return string
+     */
+    public function getIdpWhitelist()
+    {
+        return $this->idpWhitelist;
+    }
+
+    /**
+     * Returns the json_encoded string of the IdP whitlist)
+     * @return array
+     */
+    public function getIdpWhitelistDecoded()
+    {
+        $idpWhitelist = $this->idpWhitelist;
+        if (empty($idpWhitelist)) {
+            return [];
+        }
+        return json_decode($idpWhitelist, true);
+    }
+
+    /**
+     * @param array $idpWhitelist
+     */
+    public function setIdpWhitelist(array $idpWhitelist)
+    {
+        $this->idpWhitelist = json_encode($idpWhitelist);
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveSamlEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveSamlEntityCommand.php
@@ -359,6 +359,19 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
      */
     private $manageId;
 
+    /**
+     * @var bool
+     */
+    private $idpAllowAll = true;
+
+    /**
+     * The array of IdP's that are whitelisted are displayed in a hidden form field, and are rendered
+     * as a string (json encoded).
+     *
+     * @var string
+     */
+    private $idpWhitelist;
+
     private function __construct()
     {
     }
@@ -427,6 +440,9 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
         $command->organizationDisplayNameEn = $entity->getOrganizationDisplayNameEn();
         $command->organizationUrlNl = $entity->getOrganizationUrlNl();
         $command->organizationUrlEn = $entity->getOrganizationUrlEn();
+
+        $command->idpWhitelist = json_encode($entity->getIdpWhitelist());
+        $command->idpAllowAll = $entity->isIdpAllowAll();
 
         return $command;
     }
@@ -1165,5 +1181,51 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
     public function setManageId($manageId)
     {
         $this->manageId = $manageId;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getIdpAllowAll()
+    {
+        return $this->idpAllowAll;
+    }
+
+    /**
+     * @param mixed $idpAllowAll
+     */
+    public function setIdpAllowAll($idpAllowAll)
+    {
+        $this->idpAllowAll = $idpAllowAll;
+    }
+
+    /**
+     * Returns the json_encoded string of the IdP whitelist)
+     * @return string
+     */
+    public function getIdpWhitelist()
+    {
+        return $this->idpWhitelist;
+    }
+
+    /**
+     * Returns the json_encoded string of the IdP whitelist)
+     * @return array
+     */
+    public function getIdpWhitelistDecoded()
+    {
+        $idpWhitelist = $this->idpWhitelist;
+        if (empty($idpWhitelist)) {
+            return [];
+        }
+        return json_decode($idpWhitelist, true);
+    }
+
+    /**
+     * @param array $idpWhitelist
+     */
+    public function setIdpWhitelist(array $idpWhitelist)
+    {
+        $this->idpWhitelist = json_encode($idpWhitelist);
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcEntityCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcEntityCommandHandler.php
@@ -132,6 +132,9 @@ class SaveOidcEntityCommandHandler implements CommandHandler
         $entity->setOrganizationUrlNl($command->getOrganizationUrlNl());
         $entity->setOrganizationUrlEn($command->getOrganizationUrlEn());
 
+        $entity->setIdpWhitelistRaw($command->getIdpWhitelistDecoded());
+        $entity->setIdpAllowAll($command->getIdpAllowAll());
+
         $this->repository->save($entity);
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandler.php
@@ -140,6 +140,9 @@ class SaveOidcngEntityCommandHandler implements CommandHandler
         $entity->setOrganizationUrlEn($command->getOrganizationUrlEn());
         $entity->setOidcngResourceServers(new ResourceServerCollection($command->getOidcngResourceServers()));
 
+        $entity->setIdpWhitelistRaw($command->getIdpWhitelistDecoded());
+        $entity->setIdpAllowAll($command->getIdpAllowAll());
+
         $this->repository->save($entity);
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveSamlEntityCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveSamlEntityCommandHandler.php
@@ -124,6 +124,9 @@ class SaveSamlEntityCommandHandler implements CommandHandler
         $entity->setOrganizationUrlNl($command->getOrganizationUrlNl());
         $entity->setOrganizationUrlEn($command->getOrganizationUrlEn());
 
+        $entity->setIdpWhitelistRaw($command->getIdpWhitelistDecoded());
+        $entity->setIdpAllowAll($command->getIdpAllowAll());
+
         $this->repository->save($entity);
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
@@ -1536,6 +1536,17 @@ class Entity
     }
 
     /**
+     * If you have a list of idp entity ID's (from manage response) this is the way to set the
+     * whitelist on the Entity.
+     *
+     * @param string[] $providers
+     */
+    public function setIdpWhitelistRaw(array $providers)
+    {
+        $this->idpWhitelist = $providers;
+    }
+
+    /**
      * @return string[]
      */
     public function getIdpWhitelist()

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcEntityType.php
@@ -417,6 +417,10 @@ class OidcEntityType extends AbstractType
             ->add('organizationUrlNl', HiddenType::class)
             ->add('organizationUrlEn', HiddenType::class)
 
+            // Not configurable in form, but we need to include whitelist settings in Manage publications
+            ->add('idpAllowAll', HiddenType::class)
+            ->add('idpWhitelist', HiddenType::class)
+
             ->add('save', SubmitType::class, ['attr' => ['class' => 'button']])
             ->add('publishButton', SubmitType::class, ['label'=> 'Publish', 'attr' => ['class' => 'button']])
             ->add('cancel', SubmitType::class, ['attr' => ['class' => 'button']]);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
@@ -493,6 +493,10 @@ class OidcngEntityType extends AbstractType
             ->add('organizationUrlNl', HiddenType::class)
             ->add('organizationUrlEn', HiddenType::class)
 
+            // Not configurable in form, but we need to include whitelist settings in Manage publications
+            ->add('idpAllowAll', HiddenType::class)
+            ->add('idpWhitelist', HiddenType::class)
+
             ->add('save', SubmitType::class, ['attr' => ['class' => 'button']])
             ->add('publishButton', SubmitType::class, ['label'=> 'Publish', 'attr' => ['class' => 'button']])
             ->add('cancel', SubmitType::class, ['attr' => ['class' => 'button']]);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
@@ -432,6 +432,10 @@ class SamlEntityType extends AbstractType
             ->add('organizationUrlNl', HiddenType::class)
             ->add('organizationUrlEn', HiddenType::class)
 
+            // Not configurable in form, but we need to include whitelist settings in Manage publications
+            ->add('idpAllowAll', HiddenType::class)
+            ->add('idpWhitelist', HiddenType::class)
+
             ->add('save', SubmitType::class, ['attr' => ['class' => 'button']])
             ->add('publishButton', SubmitType::class, ['label'=> 'Publish', 'attr' => ['class' => 'button']])
             ->add('cancel', SubmitType::class, ['attr' => ['class' => 'button']]);

--- a/tests/integration/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandlerTest.php
@@ -80,6 +80,9 @@ class SaveOidcngEntityCommandHandlerTest extends MockeryTestCase
         $command->setPersonalCodeAttribute(m::mock(Attribute::class));
         $command->setScopedAffiliationAttribute(m::mock(Attribute::class));
 
+        $command->setIdpAllowAll(false);
+        $command->setIdpWhitelist(['https://example.org/idp/metadata', 'https://acme.org/idp/metadata']);
+
         $this->repository
             ->shouldReceive('isUnique')
             ->andReturn(true);
@@ -96,6 +99,14 @@ class SaveOidcngEntityCommandHandlerTest extends MockeryTestCase
                         // Without setting it explicitly 3600 is used as the default value
                         // See: https://www.pivotaltracker.com/story/show/167510474
                         $this->assertEquals(3600, $entity->getAccessTokenValidity());
+
+                        $this->assertFalse($entity->isIdpAllowAll());
+                        $this->assertNotEmpty($entity->getIdpWhitelist());
+                        $this->assertEquals(
+                            ['https://example.org/idp/metadata', 'https://acme.org/idp/metadata'],
+                            $entity->getIdpWhitelist()
+                        );
+
                         return true;
                     }
                 )


### PR DESCRIPTION
When working with an entity, the whitelist info is loaded from Manage, this data would not be saved to the entity in SPD except for in the explicit IdP whitelist edit screen.

In other situations (entity publish and edit actions) this information was lost. By storing the whitelist information on the form in hidden form fields, we ensure the data is persisted when publishing the metadata changes.

The IdP metadata is serialized to a JSON encoded string.

Providing a meaningful integration/acceptance test for this bug was not possible. As we do not actually test manage interactions.

https://www.pivotaltracker.com/story/show/168800119