### PR TITLE
Persist ACL data on entity edit publication

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
@@ -1536,6 +1536,17 @@ class Entity
     }
 
     /**
+     * If you have a list of idp entity ID's (from manage response) this is the way to set the
+     * whitelist on the Entity.
+     *
+     * @param string[] $providers
+     */
+    public function setIdpWhitelistRaw(array $providers)
+    {
+        $this->idpWhitelist = $providers;
+    }
+
+    /**
      * @return string[]
      */
     public function getIdpWhitelist()

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -105,6 +105,7 @@ services:
         arguments:
             - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\EntityRepository'
             - '@Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\PublishEntityClient'
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient'
             - '@logger'
             - '@session.flash_bag'
         public: true

--- a/tests/integration/Application/CommandHandler/Entity/PublishEntityTestCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/PublishEntityTestCommandHandlerTest.php
@@ -27,6 +27,8 @@ use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityTes
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityRepository;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\PublishEntityClient;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\PublishMetadataException;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\PushMetadataException;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
@@ -58,16 +60,23 @@ class PublishEntityTestCommandHandlerTest extends MockeryTestCase
      */
     private $client;
 
+    /**
+     * @var m\MockInterface&QueryClient
+     */
+    private $manageClient;
+
     public function setUp()
     {
         $this->repository = m::mock(EntityRepository::class);
         $this->client = m::mock(PublishEntityClient::class);
+        $this->manageClient = m::mock(QueryClient::class);
         $this->logger = m::mock(LoggerInterface::class);
         $this->flashBag = m::mock(FlashBagInterface::class);
 
         $this->commandHandler = new PublishEntityTestCommandHandler(
             $this->repository,
             $this->client,
+            $this->manageClient,
             $this->logger,
             $this->flashBag
         );
@@ -83,6 +92,8 @@ class PublishEntityTestCommandHandlerTest extends MockeryTestCase
             ->andReturn('Test Entity Name')
             ->shouldReceive('getManageId')
             ->shouldReceive('getProtocol')
+            ->shouldReceive('setIdpAllowAll')
+            ->shouldReceive('setIdpWhitelistRaw')
             ->andReturn(Entity::TYPE_OPENID_CONNECT_TNG);
 
         $this->repository
@@ -102,6 +113,18 @@ class PublishEntityTestCommandHandlerTest extends MockeryTestCase
                 'id' => 123,
             ]);
 
+        $manageEntity = m::mock(ManageEntity::class);
+        $manageEntity
+            ->shouldReceive('getAllowedIdentityProviders->getAllowedIdentityProviders')
+            ->andReturn([]);
+        $manageEntity
+            ->shouldReceive('getAllowedIdentityProviders->isAllowAll')
+            ->andReturn(true);
+
+        $this->manageClient
+            ->shouldReceive('findByManageId')
+            ->andReturn($manageEntity);
+
         $this->client
             ->shouldReceive('pushMetadata')
             ->once();
@@ -118,12 +141,26 @@ class PublishEntityTestCommandHandlerTest extends MockeryTestCase
             ->andReturn('Test Entity Name')
             ->shouldReceive('getManageId')
             ->shouldReceive('getProtocol')
+            ->shouldReceive('setIdpAllowAll')
+            ->shouldReceive('setIdpWhitelistRaw')
             ->andReturn(Entity::TYPE_SAML);
 
         $this->repository
             ->shouldReceive('findById')
             ->with('d6f394b2-08b1-4882-8b32-81688c15c489')
             ->andReturn($entity);
+
+        $manageEntity = m::mock(ManageEntity::class);
+        $manageEntity
+            ->shouldReceive('getAllowedIdentityProviders->getAllowedIdentityProviders')
+            ->andReturn([]);
+        $manageEntity
+            ->shouldReceive('getAllowedIdentityProviders->isAllowAll')
+            ->andReturn(true);
+
+        $this->manageClient
+            ->shouldReceive('findByManageId')
+            ->andReturn($manageEntity);
 
         $this->logger
             ->shouldReceive('info')
@@ -162,12 +199,26 @@ class PublishEntityTestCommandHandlerTest extends MockeryTestCase
             ->andReturn('Test Entity Name')
             ->shouldReceive('getManageId')
             ->shouldReceive('getProtocol')
+            ->shouldReceive('setIdpAllowAll')
+            ->shouldReceive('setIdpWhitelistRaw')
             ->andReturn(Entity::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER);
 
         $this->repository
             ->shouldReceive('findById')
             ->with('d6f394b2-08b1-4882-8b32-81688c15c489')
             ->andReturn($entity);
+
+        $manageEntity = m::mock(ManageEntity::class);
+        $manageEntity
+            ->shouldReceive('getAllowedIdentityProviders->getAllowedIdentityProviders')
+            ->andReturn([]);
+        $manageEntity
+            ->shouldReceive('getAllowedIdentityProviders->isAllowAll')
+            ->andReturn(true);
+
+        $this->manageClient
+            ->shouldReceive('findByManageId')
+            ->andReturn($manageEntity);
 
         $this->logger
             ->shouldReceive('info')

--- a/tests/webtests/EntityCreateOidcTest.php
+++ b/tests/webtests/EntityCreateOidcTest.php
@@ -130,8 +130,10 @@ class EntityCreateOidcTest extends WebTestCase
             ->form();
 
         $this->testMockHandler->append(new Response(200, [], '[]'));
-        // ClientId validator
-        $this->testMockHandler->append(new Response(200, [], '{"id":"f1e394b2-08b1-4882-8b32-43876c15c743"}'));
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        // The Entity is queried from manage in to set IdP ACL data
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->testMockHandler->append(new Response(200, [], '[]'));
         // Publish json
         $this->testMockHandler->append(new Response(200, [], '{"id":"f1e394b2-08b1-4882-8b32-43876c15c743"}'));
         // Push to EB through manage

--- a/tests/webtests/EntityCreateOidcngResourceServerTest.php
+++ b/tests/webtests/EntityCreateOidcngResourceServerTest.php
@@ -108,9 +108,12 @@ class EntityCreateOidcngResourceServerTest extends WebTestCase
             ->form();
 
         $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+
+        // The Entity is queried from manage in to set IdP ACL data
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->testMockHandler->append(new Response(200, [], '[]'));
         // ClientId validator
-        $this->testMockHandler->append(new Response(200, [], '{"id":"f1e394b2-08b1-4882-8b32-43876c15c743"}'));
-        // Publish json
         $this->testMockHandler->append(new Response(200, [], '{"id":"f1e394b2-08b1-4882-8b32-43876c15c743"}'));
         // Push to EB through manage
         $this->testMockHandler->append(new Response(200, [], '{"status":"OK"}'));

--- a/tests/webtests/EntityCreateOidcngTest.php
+++ b/tests/webtests/EntityCreateOidcngTest.php
@@ -150,8 +150,10 @@ class EntityCreateOidcngTest extends WebTestCase
             ->form();
         // Manage is queried for resource servers
         $this->testMockHandler->append(new Response(200, [], '[]'));
-        // ClientId validator
-        $this->testMockHandler->append(new Response(200, [], '{"id":"f1e394b2-08b1-4882-8b32-43876c15c743"}'));
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        // The Entity is queried from manage in to set IdP ACL data
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->testMockHandler->append(new Response(200, [], '[]'));
         // Publish json
         $this->testMockHandler->append(new Response(200, [], '{"id":"f1e394b2-08b1-4882-8b32-43876c15c743"}'));
         // Push to EB through manage

--- a/tests/webtests/EntityCreateSamlTest.php
+++ b/tests/webtests/EntityCreateSamlTest.php
@@ -189,6 +189,9 @@ class EntitySamlCreateSamlTest extends WebTestCase
         // Unique entity validator
         $this->testMockHandler->append(new Response(200, [], '[]'));
         $this->testMockHandler->append(new Response(200, [], '[]'));
+        // The Entity is queried from manage in to set IdP ACL data
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->testMockHandler->append(new Response(200, [], '[]'));
         // Publish json
         $this->testMockHandler->append(new Response(200, [], '{"id":"f1e394b2-08b1-4882-8b32-43876c15c743"}'));
         // Push to EB through manage

--- a/tests/webtests/EntityPublishToTestTest.php
+++ b/tests/webtests/EntityPublishToTestTest.php
@@ -98,6 +98,9 @@ class EntityPublishToTestTest extends WebTestCase
         // Entity id validation
         $this->testMockHandler->append(new Response(200, [], '[]'));
         $this->testMockHandler->append(new Response(200, [], '[]'));
+        // The Entity is queried from manage in to set IdP ACL data
+        $this->testMockHandler->append(new Response(200, [], '[]'));
+        $this->testMockHandler->append(new Response(200, [], '[]'));
         // Push to Manage
         $this->testMockHandler->append(new Response(200, [], '{"id":"1"}'));
         // Push to EB through manage


### PR DESCRIPTION
The IdP ACL data would be overwritten when a published manage entity was edited. This was the case because the data was still present on the entity (with the default allow all settings) and the entity is used to build the Manage Merge Metadata on.

The solution is to load the manage entity prior to publishing it, and loading the required ACL data on the Entity (that the JSON is based on).

https://www.pivotaltracker.com/story/show/168800119
Alternative to: https://github.com/SURFnet/sp-dashboard/pull/313