### PR TITLE
Use array merge to prevent overwriting array keys

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/QueryClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/QueryClient.php
@@ -235,7 +235,7 @@ class QueryClient implements QueryEntityRepository
                 json_encode($params),
                 sprintf('/manage/api/internal/search/%s', $protocol)
             );
-            $results += $response;
+            $results = array_merge($response, $results);
         }
         return $results;
     }

--- a/tests/unit/Infrastructure/Manage/Client/fixture/search_result_overwrite_bug/read_response_oidc1.json
+++ b/tests/unit/Infrastructure/Manage/Client/fixture/search_result_overwrite_bug/read_response_oidc1.json
@@ -1,0 +1,79 @@
+{
+  "id": "710c61af-411d-4bfb-af16-251d9f7b8027",
+  "version": 1,
+  "type": "oidc10_rp",
+  "revision": {
+    "number": 1,
+    "created": 1570441986.983,
+    "parentId": null,
+    "updatedBy": "urn:collab:person:example.com:admin",
+    "terminated": null
+  },
+  "data": {
+    "entityid": "test.oidcng.example.com",
+    "state": "prodaccepted",
+    "allowedall": true,
+    "arp": {
+      "enabled": true,
+      "attributes": {
+        "urn:mace:dir:attribute-def:displayName": [
+          {
+            "value": "*",
+            "source": "idp",
+            "motivation": ""
+          }
+        ],
+        "urn:mace:dir:attribute-def:uid": [
+          {
+            "value": "*",
+            "source": "idp",
+            "motivation": ""
+          }
+        ]
+      }
+    },
+    "metaDataFields": {
+      "name:en": "MijnUu app | Uu",
+      "secret": "$2a$10$DX5wtBQtWT3SkhJVzEeb1uBGOJyBjVNcsOFkoJtABKmd7tYxy9UQy",
+      "redirectUrls": [
+        "http://localhost",
+        "https://oidc-playground.test.openconext.nl/redirect",
+        "http://localhost:8000/app/redirect.html"
+      ],
+      "scopes": [
+        "openid"
+      ],
+      "grants": [
+        "authorization_code",
+        "refresh_token"
+      ],
+      "NameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+      "isResourceServer": false,
+      "contacts:2:givenName": "Test",
+      "contacts:1:surName": "Test",
+      "contacts:2:emailAddress": "test@uu.example.com",
+      "logo:0:width": 200,
+      "contacts:0:emailAddress": "test@uu.example.com",
+      "contacts:0:contactType": "technical",
+      "contacts:2:contactType": "administrative",
+      "contacts:1:contactType": "support",
+      "contacts:1:givenName": "Test",
+      "name:nl": "MijnUu app | Uu",
+      "description:en": "MijnUu app",
+      "coin:service_team_id": "team-UU",
+      "contacts:2:surName": "Test",
+      "description:nl": "MijnUu app",
+      "logo:0:url": "https://static.openconext.nl/media/sp/Uu.png",
+      "contacts:0:givenName": "Test",
+      "contacts:0:surName": "Test",
+      "contacts:1:emailAddress": "test@uu.example.com",
+      "logo:0:height": 160,
+      "isPublicClient": true
+    },
+    "allowedEntities": [],
+    "allowedResourceServers": [],
+    "type": "oidc10-rp",
+    "revisionnote": "Some revision note",
+    "eid": 57
+  }
+}

--- a/tests/unit/Infrastructure/Manage/Client/fixture/search_result_overwrite_bug/read_response_oidc2.json
+++ b/tests/unit/Infrastructure/Manage/Client/fixture/search_result_overwrite_bug/read_response_oidc2.json
@@ -1,0 +1,79 @@
+{
+  "id": "810c61af-411d-4bfb-af16-251d9f7b8027",
+  "version": 1,
+  "type": "oidc10_rp",
+  "revision": {
+    "number": 1,
+    "created": 1570441986.983,
+    "parentId": null,
+    "updatedBy": "urn:collab:person:example.com:admin",
+    "terminated": null
+  },
+  "data": {
+    "entityid": "test2.oidcng.example.com",
+    "state": "prodaccepted",
+    "allowedall": true,
+    "arp": {
+      "enabled": true,
+      "attributes": {
+        "urn:mace:dir:attribute-def:displayName": [
+          {
+            "value": "*",
+            "source": "idp",
+            "motivation": ""
+          }
+        ],
+        "urn:mace:dir:attribute-def:uid": [
+          {
+            "value": "*",
+            "source": "idp",
+            "motivation": ""
+          }
+        ]
+      }
+    },
+    "metaDataFields": {
+      "name:en": "MijnUu app | Uu",
+      "secret": "$2a$10$DX5wtBQtWT3SkhJVzEeb1uBGOJyBjVNcsOFkoJtABKmd7tYxy9UQy",
+      "redirectUrls": [
+        "http://localhost",
+        "https://oidc-playground.test.openconext.nl/redirect",
+        "http://localhost:8000/app/redirect.html"
+      ],
+      "scopes": [
+        "openid"
+      ],
+      "grants": [
+        "authorization_code",
+        "refresh_token"
+      ],
+      "NameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+      "isResourceServer": false,
+      "contacts:2:givenName": "Test",
+      "contacts:1:surName": "Test",
+      "contacts:2:emailAddress": "test@uu.example.com",
+      "logo:0:width": 200,
+      "contacts:0:emailAddress": "test@uu.example.com",
+      "contacts:0:contactType": "technical",
+      "contacts:2:contactType": "administrative",
+      "contacts:1:contactType": "support",
+      "contacts:1:givenName": "Test",
+      "name:nl": "MijnUu app | Uu",
+      "description:en": "MijnUu app",
+      "coin:service_team_id": "team-UU",
+      "contacts:2:surName": "Test",
+      "description:nl": "MijnUu app",
+      "logo:0:url": "https://static.openconext.nl/media/sp/Uu.png",
+      "contacts:0:givenName": "Test",
+      "contacts:0:surName": "Test",
+      "contacts:1:emailAddress": "test@uu.example.com",
+      "logo:0:height": 160,
+      "isPublicClient": true
+    },
+    "allowedEntities": [],
+    "allowedResourceServers": [],
+    "type": "oidc10-rp",
+    "revisionnote": "Some revision note",
+    "eid": 57
+  }
+}

--- a/tests/unit/Infrastructure/Manage/Client/fixture/search_result_overwrite_bug/read_response_oidc3.json
+++ b/tests/unit/Infrastructure/Manage/Client/fixture/search_result_overwrite_bug/read_response_oidc3.json
@@ -1,0 +1,79 @@
+{
+  "id": "910c61af-411d-4bfb-af16-251d9f7b8027",
+  "version": 1,
+  "type": "oidc10_rp",
+  "revision": {
+    "number": 1,
+    "created": 1570441986.983,
+    "parentId": null,
+    "updatedBy": "urn:collab:person:example.com:admin",
+    "terminated": null
+  },
+  "data": {
+    "entityid": "test3.oidcng.example.com",
+    "state": "prodaccepted",
+    "allowedall": true,
+    "arp": {
+      "enabled": true,
+      "attributes": {
+        "urn:mace:dir:attribute-def:displayName": [
+          {
+            "value": "*",
+            "source": "idp",
+            "motivation": ""
+          }
+        ],
+        "urn:mace:dir:attribute-def:uid": [
+          {
+            "value": "*",
+            "source": "idp",
+            "motivation": ""
+          }
+        ]
+      }
+    },
+    "metaDataFields": {
+      "name:en": "MijnUu app | Uu",
+      "secret": "$2a$10$DX5wtBQtWT3SkhJVzEeb1uBGOJyBjVNcsOFkoJtABKmd7tYxy9UQy",
+      "redirectUrls": [
+        "http://localhost",
+        "https://oidc-playground.test.openconext.nl/redirect",
+        "http://localhost:8000/app/redirect.html"
+      ],
+      "scopes": [
+        "openid"
+      ],
+      "grants": [
+        "authorization_code",
+        "refresh_token"
+      ],
+      "NameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+      "isResourceServer": false,
+      "contacts:2:givenName": "Test",
+      "contacts:1:surName": "Test",
+      "contacts:2:emailAddress": "test@uu.example.com",
+      "logo:0:width": 200,
+      "contacts:0:emailAddress": "test@uu.example.com",
+      "contacts:0:contactType": "technical",
+      "contacts:2:contactType": "administrative",
+      "contacts:1:contactType": "support",
+      "contacts:1:givenName": "Test",
+      "name:nl": "MijnUu app | Uu",
+      "description:en": "MijnUu app",
+      "coin:service_team_id": "team-UU",
+      "contacts:2:surName": "Test",
+      "description:nl": "MijnUu app",
+      "logo:0:url": "https://static.openconext.nl/media/sp/Uu.png",
+      "contacts:0:givenName": "Test",
+      "contacts:0:surName": "Test",
+      "contacts:1:emailAddress": "test@uu.example.com",
+      "logo:0:height": 160,
+      "isPublicClient": true
+    },
+    "allowedEntities": [],
+    "allowedResourceServers": [],
+    "type": "oidc10-rp",
+    "revisionnote": "Some revision note",
+    "eid": 57
+  }
+}

--- a/tests/unit/Infrastructure/Manage/Client/fixture/search_result_overwrite_bug/read_response_saml1.json
+++ b/tests/unit/Infrastructure/Manage/Client/fixture/search_result_overwrite_bug/read_response_saml1.json
@@ -1,0 +1,1 @@
+{"id":"1c7b3d8b-7897-4cc1-8521-df4f65b615c5","type": "saml20_sp","version":0,"data":{"entityid":"https:\/\/engine.dev.support.surfconext.nl\/authentication\/sp\/metadata","state":"prodaccepted","metaDataFields":{"name:nl":"OpenConext Engine","name:en":"OpenConext Engine"}}}

--- a/tests/unit/Infrastructure/Manage/Client/fixture/search_result_overwrite_bug/read_response_saml2.json
+++ b/tests/unit/Infrastructure/Manage/Client/fixture/search_result_overwrite_bug/read_response_saml2.json
@@ -1,0 +1,1 @@
+{"id":"2c7b3d8b-7897-4cc1-8521-df4f65b615c5","type": "saml20_sp","version":0,"data":{"entityid":"https:\/\/engine.dev.support.surfconext.nl\/authentication\/sp\/metadata","state":"prodaccepted","metaDataFields":{"name:nl":"OpenConext Engine","name:en":"OpenConext Engine"}}}

--- a/tests/unit/Infrastructure/Manage/Client/fixture/search_result_overwrite_bug/search_oidc.json
+++ b/tests/unit/Infrastructure/Manage/Client/fixture/search_result_overwrite_bug/search_oidc.json
@@ -1,0 +1,38 @@
+[
+  {
+    "_id": "710c61af-411d-4bfb-af16-251d9f7b8027",
+    "version": 1,
+    "data": {
+      "entityid": "test.oidcng.example.com",
+      "state": "prodaccepted",
+      "metaDataFields": {
+        "name:en": "Test 1 | UU",
+        "name:nl": "Test 1 | UU"
+      }
+    }
+  },
+  {
+    "_id": "810c61af-411d-4bfb-af16-251d9f7b8027",
+    "version": 1,
+    "data": {
+      "entityid": "test2.oidcng.example.com",
+      "state": "prodaccepted",
+      "metaDataFields": {
+        "name:en": "Test 2 | UU",
+        "name:nl": "Test 2 | UU"
+      }
+    }
+  },
+  {
+    "_id": "910c61af-411d-4bfb-af16-251d9f7b8027",
+    "version": 1,
+    "data": {
+      "entityid": "test3.oidcng.example.com",
+      "state": "prodaccepted",
+      "metaDataFields": {
+        "name:en": "Test 3 | UU",
+        "name:nl": "Test 3 | UU"
+      }
+    }
+  }
+]

--- a/tests/unit/Infrastructure/Manage/Client/fixture/search_result_overwrite_bug/search_saml.json
+++ b/tests/unit/Infrastructure/Manage/Client/fixture/search_result_overwrite_bug/search_saml.json
@@ -1,0 +1,26 @@
+[
+  {
+    "_id": "1c7b3d8b-7897-4cc1-8521-df4f65b615c5",
+    "version": 0,
+    "data": {
+      "entityid": "https://test1.saml.example.com",
+      "state": "prodaccepted",
+      "metaDataFields": {
+        "name:en": "Test SP 1 | UU",
+        "name:nl": "Test SP 1 | UU"
+      }
+    }
+  },
+  {
+    "_id": "2c7b3d8b-7897-4cc1-8521-df4f65b615c5",
+    "version": 0,
+    "data": {
+      "entityid": "https://test2.saml.example.com",
+      "state": "prodaccepted",
+      "metaDataFields": {
+        "name:en": "Test SP 2 | UU",
+        "name:nl": "Test SP 2 | UU"
+      }
+    }
+  }
+]

--- a/tests/webtests/EntityListTest.php
+++ b/tests/webtests/EntityListTest.php
@@ -111,7 +111,7 @@ class EntityListTest extends WebTestCase
         $this->assertContains("Entities of service 'SURFnet'", $pageTitle->text());
         $data =  $this->rowsToArray($crawler->filter('table'));
 
-        $this->assertCount(4, $data, 'Expecting three rows (including header)');
+        $this->assertCount(5, $data, 'Expecting four rows (2 drafts, 2 published and the header)');
 
         unset($data[0][5]); // remove buttons
         $this->assertEquals([
@@ -140,9 +140,18 @@ class EntityListTest extends WebTestCase
             'published',
         ], $data[2]);
 
+        unset($data[3][5]); // remove buttons
+        $this->assertEquals([
+            'SP3',
+            'SP3',
+            'Test Test (test@example.org)',
+            'saml20',
+            'published',
+        ], $data[3]);
+
         $this->assertEquals([
             'There are no entities configured',
-        ], $data[3]);
+        ], $data[4]);
     }
 
     public function test_entity_list_shows_add_to_test_link()


### PR DESCRIPTION
The += solution overwrites previously added keys with the ones found in
the array that is added.

The fix is to use array_merge

https://www.pivotaltracker.com/story/show/168834919