### PR TITLE
Feature/vagrant improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,21 @@ The Ansible playbook for SP Dashboard depends on some roles from
 to have that repository checked out in a directory called `OpenConext-deploy` in the parent directory of where this
 project lives.
 
+## Provision the VM
+
+The VM is provisioned using Ansible and Vagrant. After you have installed those, you can run
+```
+vagrant up
+```
+
+Grab some coffee or two, and your VM will be ready.
+
+If you need to run specific roles on the VM, you can use the corresponding tag. The tags can be found in the playbook (ansible/vagrant.yml)
+The tags need to in the environment variable "ANSIBLE_TAGS", seperated by a ,. So if you want to provision the tags eb and profile, you'd run:
+```
+ANSIBLE_TAGS=eb,profile vagrant provision
+```
+
 ## Getting started
 
 First, run `composer install`. This will install all PHP dependencies, including the development dependencies.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,6 @@
 Vagrant.configure(2) do |config|
-  config.vm.box = "CentOS-7.0"
-  config.vm.box_url = "https://build.openconext.org/vagrant_boxes/virtualbox-centos7.box"
-
+  config.vm.box = "OpenConext-CentOS-7.0"
+  config.vm.box_url = "https://build.openconext.org/vagrant_boxes/openconext.json"
   config.vm.network "private_network", ip: "192.168.33.19"
   config.vm.hostname = "dev.support.surfconext.nl"
   config.hostsupdater.aliases = ["aa.dev.support.surfconext.nl","engine.dev.support.surfconext.nl","teams.dev.support.surfconext.nl","voot.dev.support.surfconext.nl","authz.dev.support.surfconext.nl","authz-admin.dev.support.surfconext.nl","aa.dev.support.surfconext.nl","mujina-idp.dev.support.surfconext.nl","manage.dev.support.surfconext.nl","spdashboard.dev.support.surfconext.nl","manage-prod.dev.support.surfconext.nl","oidc.dev.support.surfconext.nl"]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,7 @@ Vagrant.configure(2) do |config|
     ansible.extra_vars = {
       develop_spd: true
     }
+    ansible.tags = ENV['ANSIBLE_TAGS']
   end
 
   # Stop/start Mailcatcher

--- a/ansible/vagrant.yml
+++ b/ansible/vagrant.yml
@@ -26,32 +26,32 @@
     spdashboard_data_dir: /vagrant
     spdashboard_fpm_user: vagrant
   roles:
-    - ../OpenConext-deploy/roles/common
-    - ../OpenConext-deploy/roles/openconext-common
-    - { role: tls,                                          tags: ['tls'] }
-    - ../OpenConext-deploy/roles/httpd
-    - ../OpenConext-deploy/roles/php
-    - { role: ../OpenConext-deploy/roles/mysql,             tags: ['mysql'] }
-    - { role: ../OpenConext-deploy/roles/engineblock,       tags: ['eb'] }
-    - { role: ../OpenConext-deploy/roles/java,              tags: ['java' ] }
-    - { role: spdashboard,                                  tags: ['spdashboard'] } 
-    - { role: ../OpenConext-deploy/roles/mujina-idp,        tags: ['legacy' ] }
-    - { role: ../OpenConext-deploy/roles/mujina-sp,         tags: ['legacy' ] }
-    - { role: ../OpenConext-deploy/roles/shibboleth,        tags: ['shib' ] }
-    - { role: ../OpenConext-deploy/roles/mongo,             tags: ['mongo'] }
-    - { role: ../OpenConext-deploy/roles/manage-gui,        tags: ['manage', 'manage-gui'] }
-    - { role: ../OpenConext-deploy/roles/manage-server,     tags: ['manage', 'manage-server'] }
-    - { role: manage-gui-prod,                              tags: ['manage', 'manage-gui'] }
-    - { role: manage-server-prod,                           tags: ['manage', 'manage-server'] }
-    - { role: ../OpenConext-deploy/roles/authz-server,      tags: ['oauth', 'authz' ] }
-    - { role: ../OpenConext-deploy/roles/authz-admin,       tags: ['oauth', 'authz-admin' ] }
-    - { role: ../OpenConext-deploy/roles/voot,              tags: ['oauth', 'voot' ] }
+    - { role:  ../OpenConext-deploy/roles/common,                      tags: ['common'] }
+    - { role:  ../OpenConext-deploy/roles/openconext-common,           tags: ['common'] }
+    - { role: tls,                                                     tags: ['tls'] }
+    - { role:  ../OpenConext-deploy/roles/httpd,                       tags: ['httpd'] }
+    - { role: ../OpenConext-deploy/roles/php,                          tags: ['php'] }
+    - { role: ../OpenConext-deploy/roles/mysql,                        tags: ['mysql'] }
+    - { role: ../OpenConext-deploy/roles/engineblock,                  tags: ['eb'] }
+    - { role: ../OpenConext-deploy/roles/java,                         tags: ['java' ] }
+    - { role: spdashboard,                                             tags: ['spdashboard'] } 
+    - { role: ../OpenConext-deploy/roles/mujina-idp,                   tags: ['legacy' ] }
+    - { role: ../OpenConext-deploy/roles/mujina-sp,                    tags: ['legacy' ] }
+    - { role: ../OpenConext-deploy/roles/shibboleth,                   tags: ['shib' ] }
+    - { role: ../OpenConext-deploy/roles/mongo,                        tags: ['mongo'] }
+    - { role: ../OpenConext-deploy/roles/manage-gui,                   tags: ['manage', 'manage-gui'] }
+    - { role: ../OpenConext-deploy/roles/manage-server,                tags: ['manage', 'manage-server'] }
+    - { role: manage-gui-prod,                                         tags: ['manage', 'manage-gui'] }
+    - { role: manage-server-prod,                                      tags: ['manage', 'manage-server'] }
+    - { role: ../OpenConext-deploy/roles/authz-server,                 tags: ['oauth', 'authz' ] }
+    - { role: ../OpenConext-deploy/roles/authz-admin,                  tags: ['oauth', 'authz-admin' ] }
+    - { role: ../OpenConext-deploy/roles/voot,                         tags: ['oauth', 'voot' ] }
     - { role: ../OpenConext-deploy/roles/teams-gui,                    tags: ['teams', 'teams-gui'  ] }
     - { role: ../OpenConext-deploy/roles/teams-server,                 tags: ['teams', 'teams-server'  ] }
     - { role: ../OpenConext-deploy/roles/attribute-aggregation-gui,    tags: ['attribute-aggregation', 'attribute-aggregation-gui'] }
     - { role: ../OpenConext-deploy/roles/attribute-aggregation-server, tags: ['attribute-aggregation', 'attribute-aggregation-server'] }
-    - { role: ../OpenConext-deploy/roles/tomcat, tags: ['tomcat'] }
-    - { role: ../OpenConext-deploy/roles/oidc, tags: ['oidc'] }
+    - { role: ../OpenConext-deploy/roles/tomcat,                       tags: ['tomcat'] }
+    - { role: ../OpenConext-deploy/roles/oidc,                         tags: ['oidc'] }
     - { role: ../OpenConext-deploy/roles/vm_only_provision_manage_eb,  tags: ['vm_only_provision_manage_eb'] }
 
 


### PR DESCRIPTION
This PR adds two features:

1) The CentOS7 virtualbox is now versioned, allowing to update the box to the latest version. After a vagrant destroy you will get a fresh box, with the latest CentOS7 on it
2) You can now add tags to the vagrant provision command. Every Ansible has a tag (as expressed in the playbook, ansible/vagrant.yml). The environment variable SPDANSIBLETAGS is used for this. Suppose you only want to deploy eb:
```
SPDANSIBLETAGS=vagrant provision  
```
Multiple tags can be seperated by ",". 