### PR TITLE
Render service switcher when services present

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/TwigExtension/service_switcher.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/TwigExtension/service_switcher.html.twig
@@ -1,4 +1,6 @@
+{% if form.selected_service_id is defined %}
 {{ form_start(form, {'attr': {'novalidate': 'novalidate', 'action': path('select_service') } }) }}
 {{ form_widget(form.selected_service_id, {'id': 'service-switcher'}) }}
 {{ form_rest(form) }}
 {{ form_end(form) }}
+{% endif %}


### PR DESCRIPTION
When no services are present yet, the form view would yield a 500 error as no services are present yet to build the view with.

Making rendering conditional based on the presence of the 'selected_service_id' should remedy this issue