### PR TITLE
Resolve jquery at version 3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "tippy.js": "^2.0.2"
   },
   "resolutions": {
-    "jquery": "3.4.1",
+    "jquery": "3.5.0",
     "braces": "^2.3.1"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5304,12 +5304,7 @@ jquery.mousewheel@^3.1.9:
   resolved "https://registry.yarnpkg.com/jquery.mousewheel/-/jquery.mousewheel-3.1.9.tgz#b1e162f1df8aaf6c24fbf923d3d6c58c52d9553e"
   integrity sha1-seFi8d+Kr2wk+/kj09bFjFLZVT4=
 
-jquery@3.4.1, jquery@>=1.8.0:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
-  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
-
-jquery@^3.4.0:
+jquery@3.5.0, jquery@>=1.8.0, jquery@^3.4.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
   integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==


### PR DESCRIPTION
To prevent jquery plugins from being registred on the wrong jquery. This was happening. Parsley was not available on the Jquery distributed by Webpack Encore. Resulting in vague error messages.