### PR TITLE
Prevent overriding of attributes

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Dto/MetadataConversionDto.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Dto/MetadataConversionDto.php
@@ -1,0 +1,559 @@
+<?php
+
+/**
+ * Copyright 2020 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Dto;
+
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\IdentityProvider;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact as ContactPerson;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\ResourceServerCollection;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
+
+/**
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ * @SuppressWarnings(PHPMD.ExcessivePublicCount)
+ */
+class MetadataConversionDto
+{
+    /**
+     * @var Entity
+     */
+    private $entity;
+
+    /**
+     * @var ManageEntity
+     */
+    private $manageEntity = null;
+
+    private function __construct(Entity $entity, ManageEntity $manageEntity = null)
+    {
+        $this->entity = $entity;
+        $this->manageEntity = $manageEntity;
+    }
+
+    /**
+     * When used for creation, no Mnaage entity is present yet to create the Dto from
+     * @param Entity $entity
+     */
+    public static function fromEntity(Entity $entity)
+    {
+        return new self($entity);
+    }
+
+    public static function fromManageEntity(ManageEntity $manageEntity, Entity $entity)
+    {
+        return new self($entity, $manageEntity);
+    }
+
+    /**
+     * @return Service
+     */
+    public function getService()
+    {
+        return $this->entity->getService();
+    }
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->entity->getId();
+    }
+
+    /**
+     * @return string
+     */
+    public function getEnvironment()
+    {
+        return $this->entity->getEnvironment();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isArchived()
+    {
+        return $this->entity->isArchived();
+    }
+
+    /**
+     * @return string
+     */
+    public function getManageId()
+    {
+        return $this->entity->getManageId();
+    }
+
+    /**
+     * @return string
+     */
+    public function getImportUrl()
+    {
+        return $this->entity->getImportUrl();
+    }
+
+    /**
+     * @return string
+     */
+    public function getMetadataUrl()
+    {
+        return $this->entity->getMetadataUrl();
+    }
+
+    /**
+     * @return string
+     */
+    public function getAcsLocation()
+    {
+        return $this->entity->getAcsLocation();
+    }
+
+    /**
+     * @return string
+     */
+    public function getClientSecret()
+    {
+        return $this->entity->getClientSecret();
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getRedirectUris()
+    {
+        return $this->entity->getRedirectUris();
+    }
+
+    /**
+     * @return OidcGrantType
+     */
+    public function getGrantType()
+    {
+        return $this->entity->getGrantType();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnablePlayground()
+    {
+        return $this->entity->isEnablePlayground();
+    }
+
+    /**
+     * @return string
+     */
+    public function getProtocol()
+    {
+        return $this->entity->getProtocol();
+    }
+
+    /**
+     * @return string
+     */
+    public function getAcsBinding()
+    {
+        return $this->entity->getAcsBinding();
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameIdFormat()
+    {
+        return $this->entity->getNameIdFormat();
+    }
+
+    /**
+     * @return string
+     */
+    public function getEntityId()
+    {
+        return $this->entity->getEntityId();
+    }
+
+    /**
+     * @return string
+     */
+    public function getCertificate()
+    {
+        return $this->entity->getCertificate();
+    }
+
+    /**
+     * @return string
+     */
+    public function getLogoUrl()
+    {
+        return $this->entity->getLogoUrl();
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameNl()
+    {
+        return $this->entity->getNameNl();
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameEn()
+    {
+        return $this->entity->getNameEn();
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescriptionNl()
+    {
+        return $this->entity->getDescriptionNl();
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescriptionEn()
+    {
+        return $this->entity->getDescriptionEn();
+    }
+
+    /**
+     * @return string
+     */
+    public function getApplicationUrl()
+    {
+        return $this->entity->getApplicationUrl();
+    }
+
+    /**
+     * @return string
+     */
+    public function getEulaUrl()
+    {
+        return $this->entity->getEulaUrl();
+    }
+
+    /**
+     * @return ContactPerson|null
+     */
+    public function getAdministrativeContact()
+    {
+        $administrativeContact = $this->entity->getAdministrativeContact();
+        if (!is_null($administrativeContact) && !$administrativeContact->isContactSet()) {
+            return null;
+        }
+        return $administrativeContact;
+    }
+
+    /**
+     * @return ContactPerson|null
+     */
+    public function getTechnicalContact()
+    {
+        $technicalContact = $this->entity->getTechnicalContact();
+        if (!is_null($technicalContact) && !$technicalContact->isContactSet()) {
+            return null;
+        }
+        return $technicalContact;
+    }
+
+    /**
+     * @return ContactPerson|null
+     */
+    public function getSupportContact()
+    {
+        $supportContact = $this->entity->getSupportContact();
+        if (!is_null($supportContact) && !$supportContact->isContactSet()) {
+            return null;
+        }
+        return $supportContact;
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getGivenNameAttribute()
+    {
+        return $this->entity->getGivenNameAttribute();
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getSurNameAttribute()
+    {
+        return $this->entity->getSurNameAttribute();
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getCommonNameAttribute()
+    {
+        return $this->entity->getCommonNameAttribute();
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getDisplayNameAttribute()
+    {
+        return $this->entity->getDisplayNameAttribute();
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getEmailAddressAttribute()
+    {
+        return $this->entity->getEmailAddressAttribute();
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getOrganizationAttribute()
+    {
+        return $this->entity->getOrganizationAttribute();
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getOrganizationTypeAttribute()
+    {
+        return $this->entity->getOrganizationTypeAttribute();
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getAffiliationAttribute()
+    {
+        return $this->entity->getAffiliationAttribute();
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getEntitlementAttribute()
+    {
+        return $this->entity->getEntitlementAttribute();
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getPrincipleNameAttribute()
+    {
+        return $this->entity->getPrincipleNameAttribute();
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getUidAttribute()
+    {
+        return $this->entity->getUidAttribute();
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getPreferredLanguageAttribute()
+    {
+        return $this->entity->getPreferredLanguageAttribute();
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getPersonalCodeAttribute()
+    {
+        return $this->entity->getPersonalCodeAttribute();
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getScopedAffiliationAttribute()
+    {
+        return $this->entity->getScopedAffiliationAttribute();
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function getEduPersonTargetedIDAttribute()
+    {
+        return $this->entity->getEduPersonTargetedIDAttribute();
+    }
+
+    /**
+     * @return string
+     */
+    public function getComments()
+    {
+        return $this->entity->getComments();
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasComments()
+    {
+        return !(empty($this->getComments()));
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationNameEn()
+    {
+        return $this->entity->getOrganizationNameEn();
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationDisplayNameEn()
+    {
+        return $this->entity->getOrganizationDisplayNameEn();
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationUrlEn()
+    {
+        return $this->entity->getOrganizationUrlEn();
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationNameNl()
+    {
+        return $this->entity->getOrganizationNameNl();
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationDisplayNameNl()
+    {
+        return $this->entity->getOrganizationDisplayNameNl();
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationUrlNl()
+    {
+        return $this->entity->getOrganizationUrlNl();
+    }
+
+    /**
+     * @return string
+     */
+    public function getStatus()
+    {
+        return $this->entity->getStatus();
+    }
+
+    public function isDraft()
+    {
+        return $this->entity->isDraft();
+    }
+
+    public function isPublished()
+    {
+        return $this->entity->isPublished();
+    }
+
+    public function isProduction()
+    {
+        return $this->entity->isProduction();
+    }
+
+    /**
+     * @param IdentityProvider $provider
+     * @return bool
+     */
+    public function isWhitelisted(IdentityProvider $provider)
+    {
+        return in_array($provider->getEntityId(), $this->getIdpWhitelist());
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getIdpWhitelist()
+    {
+        return $this->entity->getIdpWhitelist();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isIdpAllowAll()
+    {
+        return $this->entity->isIdpAllowAll();
+    }
+
+    /**
+     * @return int
+     */
+    public function getAccessTokenValidity()
+    {
+        return $this->entity->getAccessTokenValidity();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPublicClient()
+    {
+        return $this->entity->isPublicClient();
+    }
+
+    /**
+     * @return ResourceServerCollection
+     */
+    public function getOidcngResourceServers()
+    {
+        return $this->entity->getOidcngResourceServers();
+    }
+
+    public function getArpAttributes()
+    {
+        return $this->manageEntity->getAttributes();
+    }
+
+    public function isManageEntity()
+    {
+        return !is_null($this->manageEntity);
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/GeneratorInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/GeneratorInterface.php
@@ -19,6 +19,7 @@
 namespace Surfnet\ServiceProviderDashboard\Application\Metadata;
 
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
 
 interface GeneratorInterface
 {
@@ -40,8 +41,9 @@ interface GeneratorInterface
      * entities).
      *
      * @param Entity $entity
+     * @param ManageEntity $manageEntity
      * @param string $workflowState
      * @return array
      */
-    public function generateForExistingEntity(Entity $entity, $workflowState);
+    public function generateForExistingEntity(Entity $entity, ManageEntity $manageEntity, $workflowState);
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/GeneratorInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/GeneratorInterface.php
@@ -18,19 +18,18 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Metadata;
 
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
-use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
+use Surfnet\ServiceProviderDashboard\Application\Dto\MetadataConversionDto;
 
 interface GeneratorInterface
 {
     /**
      * Convert a new, unpublished entity to json-serializable array.
      *
-     * @param Entity $entity
+     * @param MetadataConversionDto $entity
      * @param string $workflowState
      * @return array
      */
-    public function generateForNewEntity(Entity $entity, $workflowState);
+    public function generateForNewEntity(MetadataConversionDto $entity, $workflowState);
 
     /**
      * Convert entity to an array for the manage merge-write API call.
@@ -40,10 +39,9 @@ interface GeneratorInterface
      * never overwrites fields not managed by the dashboard (such as allowed
      * entities).
      *
-     * @param Entity $entity
-     * @param ManageEntity $manageEntity
+     * @param MetadataConversionDto $entity
      * @param string $workflowState
      * @return array
      */
-    public function generateForExistingEntity(Entity $entity, ManageEntity $manageEntity, $workflowState);
+    public function generateForExistingEntity(MetadataConversionDto $entity, $workflowState);
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
@@ -24,6 +24,7 @@ use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\SpDashbo
 use Surfnet\ServiceProviderDashboard\Application\Parser\OidcClientIdParser;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
 
 /**
  * The JsonGenerator is able to generate Manage SAML 2.0 and OpenID Connect entities (oidc).
@@ -37,7 +38,6 @@ use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
  */
 class JsonGenerator implements GeneratorInterface
 {
-
     /**
      * @var ArpGenerator
      */
@@ -100,14 +100,15 @@ class JsonGenerator implements GeneratorInterface
 
     /**
      * @param Entity $entity
+     * @param ManageEntity $manageEntity
      * @param string $workflowState
      * @return array
      */
-    public function generateForExistingEntity(Entity $entity, $workflowState)
+    public function generateForExistingEntity(Entity $entity, ManageEntity $manageEntity, $workflowState)
     {
         // the type for entities is always saml because manage is using saml internally
         $data = [
-            'pathUpdates' => $this->generateDataForExistingEntity($entity, $workflowState),
+            'pathUpdates' => $this->generateDataForExistingEntity($entity, $manageEntity, $workflowState),
             'type' => 'saml20_sp',
             'id' => $entity->getManageId(),
         ];
@@ -158,13 +159,14 @@ class JsonGenerator implements GeneratorInterface
 
     /**
      * @param Entity $entity
+     * @param ManageEntity $manageEntity
      * @param string $workflowState
      * @return array
      */
-    private function generateDataForExistingEntity(Entity $entity, $workflowState)
+    private function generateDataForExistingEntity(Entity $entity, ManageEntity $manageEntity, $workflowState)
     {
         $metadata = [
-            'arp' => $this->arpMetadataGenerator->build($entity),
+            'arp' => $this->arpMetadataGenerator->build($entity, $manageEntity),
             'entityid' => $entity->getEntityId(),
             'state' => $workflowState,
         ];
@@ -176,7 +178,7 @@ class JsonGenerator implements GeneratorInterface
         }
 
         $metadata += $this->flattenMetadataFields(
-            $this->generateMetadataFields($entity)
+            $this->generateMetadataFields($entity, $manageEntity)
         );
 
         if ($entity->hasComments()) {
@@ -219,7 +221,7 @@ class JsonGenerator implements GeneratorInterface
      * @param Entity $entity
      * @return array
      */
-    private function generateMetadataFields(Entity $entity)
+    private function generateMetadataFields(Entity $entity, ManageEntity $manageEntity = null)
     {
         $metadata = array_merge(
             [

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
@@ -18,10 +18,10 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator;
 
+use Surfnet\ServiceProviderDashboard\Application\Dto\MetadataConversionDto;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\AttributesMetadataRepository;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute;
-use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
 
 /**
  * Builds ARP metadata for the JSON export.
@@ -38,7 +38,7 @@ class ArpGenerator implements MetadataGenerator
         $this->repository = $repository;
     }
 
-    public function build(Entity $entity, ManageEntity $manageEntity = null)
+    public function build(MetadataConversionDto $entity)
     {
         $attributes = [];
 
@@ -67,9 +67,19 @@ class ArpGenerator implements MetadataGenerator
             }
         }
 
-        if ($manageEntity) {
+        $this->addExtraFields($attributes, $entity);
+
+        return [
+            'attributes' => $attributes,
+            'enabled' => true,
+        ];
+    }
+
+    private function addExtraFields(array &$attributes, MetadataConversionDto $entity)
+    {
+        if ($entity->isManageEntity()) {
             // Also add the attributes that are not managed in the SPD entity, but have been configured in Manage
-            foreach ($manageEntity->getAttributes()->getAttributes() as $manageAttribute) {
+            foreach ($entity->getArpAttributes()->getAttributes() as $manageAttribute) {
                 if (!array_key_exists($manageAttribute->getName(), $attributes)) {
                     $attributes[$manageAttribute->getName()] = [
                         [
@@ -81,9 +91,16 @@ class ArpGenerator implements MetadataGenerator
             }
         }
 
-        return [
-            'attributes' => $attributes,
-            'enabled' => true,
-        ];
+        if ($entity->getProtocol() === Entity::TYPE_OPENID_CONNECT_TNG) {
+            // The EPTI is to be added to the ARP invisibly. See: https://www.pivotaltracker.com/story/show/167511328
+            // The user cannot configure EPTI @ ARP settings but the value is used internally.
+            $attributes['urn:mace:dir:attribute-def:eduPersonTargetedID'] = [
+                [
+                    'source' => 'idp',
+                    'value' => '*',
+                    'motivation' => 'OIDC requires EduPersonTargetedID by default',
+                ]
+            ];
+        }
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
@@ -18,10 +18,10 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator;
 
-use DateTime;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\AttributesMetadataRepository;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
 
 /**
  * Builds ARP metadata for the JSON export.
@@ -38,7 +38,7 @@ class ArpGenerator implements MetadataGenerator
         $this->repository = $repository;
     }
 
-    public function build(Entity $entity)
+    public function build(Entity $entity, ManageEntity $manageEntity = null)
     {
         $attributes = [];
 
@@ -63,6 +63,20 @@ class ArpGenerator implements MetadataGenerator
 
                 if ($attr->hasMotivation()) {
                     $attributes[$urn][0]['motivation'] = $attr->getMotivation();
+                }
+            }
+        }
+
+        if ($manageEntity) {
+            // Also add the attributes that are not managed in the SPD entity, but have been configured in Manage
+            foreach ($manageEntity->getAttributes()->getAttributes() as $manageAttribute) {
+                if (!array_key_exists($manageAttribute->getName(), $attributes)) {
+                    $attributes[$manageAttribute->getName()] = [
+                        [
+                            'source' => $manageAttribute->getSource(),
+                            'value' => $manageAttribute->getValue(),
+                        ]
+                    ];
                 }
             }
         }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/MetadataGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/MetadataGenerator.php
@@ -19,8 +19,9 @@
 namespace Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator;
 
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
 
 interface MetadataGenerator
 {
-    public function build(Entity $entity);
+    public function build(Entity $entity, ManageEntity $manageEntity = null);
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/MetadataGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/MetadataGenerator.php
@@ -18,10 +18,9 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator;
 
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
-use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
+use Surfnet\ServiceProviderDashboard\Application\Dto\MetadataConversionDto;
 
 interface MetadataGenerator
 {
-    public function build(Entity $entity, ManageEntity $manageEntity = null);
+    public function build(MetadataConversionDto $entity);
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/PrivacyQuestionsMetadataGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/PrivacyQuestionsMetadataGenerator.php
@@ -21,6 +21,7 @@ namespace Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator;
 use DateTime;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\AttributesMetadataRepository;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
 
 /**
  * Reads the PrivacyQuestions from the Entity that is injected, It than references the answers found in the
@@ -51,7 +52,7 @@ class PrivacyQuestionsMetadataGenerator implements MetadataGenerator
         $this->repository = $repository;
     }
 
-    public function build(Entity $entity)
+    public function build(Entity $entity, ManageEntity $manageEntity = null)
     {
         $privacyQuestionAnswers = $entity->getService()->getPrivacyQuestions();
         $privacyQuestions = $this->repository->findAllPrivacyQuestionsAttributes();

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/PrivacyQuestionsMetadataGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/PrivacyQuestionsMetadataGenerator.php
@@ -19,6 +19,7 @@
 namespace Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator;
 
 use DateTime;
+use Surfnet\ServiceProviderDashboard\Application\Dto\MetadataConversionDto;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\AttributesMetadataRepository;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
@@ -52,7 +53,7 @@ class PrivacyQuestionsMetadataGenerator implements MetadataGenerator
         $this->repository = $repository;
     }
 
-    public function build(Entity $entity, ManageEntity $manageEntity = null)
+    public function build(MetadataConversionDto $entity)
     {
         $privacyQuestionAnswers = $entity->getService()->getPrivacyQuestions();
         $privacyQuestions = $this->repository->findAllPrivacyQuestionsAttributes();

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/SpDashboardMetadataGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/SpDashboardMetadataGenerator.php
@@ -18,9 +18,8 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator;
 
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Application\Dto\MetadataConversionDto;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\AttributesMetadataRepository;
-use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
 
 /**
  * Adds the team name original metadata url to a list of attributes that can be stored in the serivce registry (Manage)
@@ -40,7 +39,7 @@ class SpDashboardMetadataGenerator implements MetadataGenerator
     /**
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
-    public function build(Entity $entity, ManageEntity $manageEntity = null)
+    public function build(MetadataConversionDto $entity)
     {
         $spDashboardAttributes = $this->repository->findAllSpDashboardAttributes();
         $attributes = [];

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/SpDashboardMetadataGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/SpDashboardMetadataGenerator.php
@@ -18,10 +18,9 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator;
 
-use DateTime;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\AttributesMetadataRepository;
-use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
 
 /**
  * Adds the team name original metadata url to a list of attributes that can be stored in the serivce registry (Manage)
@@ -41,7 +40,7 @@ class SpDashboardMetadataGenerator implements MetadataGenerator
     /**
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
-    public function build(Entity $entity)
+    public function build(Entity $entity, ManageEntity $manageEntity = null)
     {
         $spDashboardAttributes = $this->repository->findAllSpDashboardAttributes();
         $attributes = [];

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGeneratorStrategy.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGeneratorStrategy.php
@@ -18,9 +18,8 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Metadata;
 
+use Surfnet\ServiceProviderDashboard\Application\Dto\MetadataConversionDto;
 use Surfnet\ServiceProviderDashboard\Application\Exception\JsonGeneratorStrategyNotFoundException;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
-use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
 
 /**
  * Determines which strategy to use when generating Manage json metadata
@@ -46,26 +45,25 @@ class JsonGeneratorStrategy
     }
 
     /**
-     * @param Entity $entity
+     * @param MetadataConversionDto $entity
      * @param string $workflowState
      * @return array
      * @throws JsonGeneratorStrategyNotFoundException
      */
-    public function generateForNewEntity(Entity $entity, $workflowState)
+    public function generateForNewEntity(MetadataConversionDto $entity, $workflowState)
     {
         return $this->getStrategy($entity->getProtocol())->generateForNewEntity($entity, $workflowState);
     }
 
     /**
-     * @param Entity $entity
-     * @param ManageEntity $manageEntity
+     * @param MetadataConversionDto $entity
      * @param string $workflowState
      * @return array
      * @throws JsonGeneratorStrategyNotFoundException
      */
-    public function generateForExistingEntity(Entity $entity, ManageEntity $manageEntity, $workflowState)
+    public function generateForExistingEntity(MetadataConversionDto $entity, $workflowState)
     {
-        return $this->getStrategy($entity->getProtocol())->generateForExistingEntity($entity, $manageEntity, $workflowState);
+        return $this->getStrategy($entity->getProtocol())->generateForExistingEntity($entity, $workflowState);
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGeneratorStrategy.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGeneratorStrategy.php
@@ -20,6 +20,7 @@ namespace Surfnet\ServiceProviderDashboard\Application\Metadata;
 
 use Surfnet\ServiceProviderDashboard\Application\Exception\JsonGeneratorStrategyNotFoundException;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
 
 /**
  * Determines which strategy to use when generating Manage json metadata
@@ -57,13 +58,14 @@ class JsonGeneratorStrategy
 
     /**
      * @param Entity $entity
+     * @param ManageEntity $manageEntity
      * @param string $workflowState
      * @return array
      * @throws JsonGeneratorStrategyNotFoundException
      */
-    public function generateForExistingEntity(Entity $entity, $workflowState)
+    public function generateForExistingEntity(Entity $entity, ManageEntity $manageEntity, $workflowState)
     {
-        return $this->getStrategy($entity->getProtocol())->generateForExistingEntity($entity, $workflowState);
+        return $this->getStrategy($entity->getProtocol())->generateForExistingEntity($entity, $manageEntity, $workflowState);
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
@@ -22,9 +22,9 @@ use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\PrivacyQ
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\SpDashboardMetadataGenerator;
 use Surfnet\ServiceProviderDashboard\Application\Parser\OidcngClientIdParser;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
-use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
 
 /**
  * The OidcngResourceServerJsonGenerator generates oidc10_rp resource server entity json
@@ -63,7 +63,6 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
      */
     public function generateForNewEntity(Entity $entity, $workflowState)
     {
-        // the type for entities is always saml because manage is using saml internally
         return [
             'data' => $this->generateDataForNewEntity($entity, $workflowState),
             'type' => 'oidc10_rp',
@@ -72,14 +71,14 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
 
     /**
      * @param Entity $entity
+     * @param ManageEntity $manageEntity
      * @param string $workflowState
      * @return array
      */
-    public function generateForExistingEntity(Entity $entity, $workflowState)
+    public function generateForExistingEntity(Entity $entity, ManageEntity $manageEntity, $workflowState)
     {
-        // the type for entities is always saml because manage is using saml internally
         $data = [
-            'pathUpdates' => $this->generateDataForExistingEntity($entity, $workflowState),
+            'pathUpdates' => $this->generateDataForExistingEntity($entity, $manageEntity, $workflowState),
             'type' => 'oidc10_rp',
             'id' => $entity->getManageId(),
         ];
@@ -117,7 +116,7 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
      * @param string $workflowState
      * @return array
      */
-    private function generateDataForExistingEntity(Entity $entity, $workflowState)
+    private function generateDataForExistingEntity(Entity $entity, ManageEntity $manageEntity, $workflowState)
     {
         $metadata = [
             'entityid' => OidcngClientIdParser::parse($entity->getEntityId()),
@@ -127,7 +126,7 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
         $metadata += $this->generateAclData($entity);
 
         $metadata += $this->flattenMetadataFields(
-            $this->generateMetadataFields($entity)
+            $this->generateMetadataFields($entity, $manageEntity)
         );
 
         if ($entity->hasComments()) {
@@ -170,7 +169,7 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
      * @param Entity $entity
      * @return array
      */
-    private function generateMetadataFields(Entity $entity)
+    private function generateMetadataFields(Entity $entity, ManageEntity $manageEntity = null)
     {
         $metadata = array_merge(
             [

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
@@ -18,13 +18,13 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Metadata;
 
+use Surfnet\ServiceProviderDashboard\Application\Dto\MetadataConversionDto;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\PrivacyQuestionsMetadataGenerator;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\SpDashboardMetadataGenerator;
 use Surfnet\ServiceProviderDashboard\Application\Parser\OidcngClientIdParser;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
-use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
 
 /**
  * The OidcngResourceServerJsonGenerator generates oidc10_rp resource server entity json
@@ -57,11 +57,11 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
     }
 
     /**
-     * @param Entity $entity
+     * @param MetadataConversionDto $entity
      * @param string $workflowState
      * @return array
      */
-    public function generateForNewEntity(Entity $entity, $workflowState)
+    public function generateForNewEntity(MetadataConversionDto $entity, $workflowState)
     {
         return [
             'data' => $this->generateDataForNewEntity($entity, $workflowState),
@@ -70,15 +70,14 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
     }
 
     /**
-     * @param Entity $entity
-     * @param ManageEntity $manageEntity
+     * @param MetadataConversionDto $entity
      * @param string $workflowState
      * @return array
      */
-    public function generateForExistingEntity(Entity $entity, ManageEntity $manageEntity, $workflowState)
+    public function generateForExistingEntity(MetadataConversionDto $entity, $workflowState)
     {
         $data = [
-            'pathUpdates' => $this->generateDataForExistingEntity($entity, $manageEntity, $workflowState),
+            'pathUpdates' => $this->generateDataForExistingEntity($entity, $workflowState),
             'type' => 'oidc10_rp',
             'id' => $entity->getManageId(),
         ];
@@ -87,11 +86,11 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
     }
 
     /**
-     * @param Entity $entity
+     * @param MetadataConversionDto $entity
      * @param string $workflowState
      * @return array
      */
-    private function generateDataForNewEntity(Entity $entity, $workflowState)
+    private function generateDataForNewEntity(MetadataConversionDto $entity, $workflowState)
     {
         // the type for entities is always oidc10-rp because manage is using saml internally
         $metadata = [
@@ -112,11 +111,11 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
     }
 
     /**
-     * @param Entity $entity
+     * @param MetadataConversionDto $entity
      * @param string $workflowState
      * @return array
      */
-    private function generateDataForExistingEntity(Entity $entity, ManageEntity $manageEntity, $workflowState)
+    private function generateDataForExistingEntity(MetadataConversionDto $entity, $workflowState)
     {
         $metadata = [
             'entityid' => OidcngClientIdParser::parse($entity->getEntityId()),
@@ -126,7 +125,7 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
         $metadata += $this->generateAclData($entity);
 
         $metadata += $this->flattenMetadataFields(
-            $this->generateMetadataFields($entity, $manageEntity)
+            $this->generateMetadataFields($entity)
         );
 
         if ($entity->hasComments()) {
@@ -169,7 +168,7 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
      * @param Entity $entity
      * @return array
      */
-    private function generateMetadataFields(Entity $entity, ManageEntity $manageEntity = null)
+    private function generateMetadataFields(MetadataConversionDto $entity)
     {
         $metadata = array_merge(
             [
@@ -201,10 +200,10 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
     }
 
     /**
-     * @param Entity $entity
+     * @param MetadataConversionDto $entity
      * @return array
      */
-    private function generateOidcClient(Entity $entity)
+    private function generateOidcClient(MetadataConversionDto $entity)
     {
         $metadata = [];
         $secret = $entity->getClientSecret();
@@ -219,10 +218,10 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
     }
 
     /**
-     * @param Entity $entity
+     * @param MetadataConversionDto $entity
      * @return array
      */
-    private function generateAllContactsMetadata(Entity $entity)
+    private function generateAllContactsMetadata(MetadataConversionDto $entity)
     {
         $metadata = [];
         $index = 0;
@@ -247,10 +246,10 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
     }
 
     /**
-     * @param Entity $entity
+     * @param MetadataConversionDto $entity
      * @return array
      */
-    private function generateOrganizationMetadata(Entity $entity)
+    private function generateOrganizationMetadata(MetadataConversionDto $entity)
     {
         $metadata = [
             'OrganizationName:en' => $entity->getOrganizationNameEn(),
@@ -296,10 +295,10 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
     }
 
     /**
-     * @param Entity $entity
+     * @param MetadataConversionDto $entity
      * @return array
      */
-    private function generateAclData(Entity $entity)
+    private function generateAclData(MetadataConversionDto $entity)
     {
         if ($entity->isIdpAllowAll()) {
             return [

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -340,6 +340,7 @@ services:
     Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\PublishEntityClient:
         arguments:
             - '@Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Http\HttpClient'
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient'
             - '@Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGeneratorStrategy'
             - '@surfnet.manage.configuration.test'
             - '@logger'
@@ -362,6 +363,7 @@ services:
         class: Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\PublishEntityClient
         arguments:
         - '@surfnet.manage.http.http_client.prod_environment'
+        - '@surfnet.manage.client.query_client.prod_environment'
         - '@Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGeneratorStrategy'
         - '@surfnet.manage.configuration.production'
         - '@logger'

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php
@@ -36,6 +36,11 @@ class PublishEntityClient implements PublishEntityRepositoryInterface
     private $client;
 
     /**
+     * @var QueryClient
+     */
+    private $queryClient;
+
+    /**
      * @var JsonGeneratorStrategy
      */
     private $generator;
@@ -52,11 +57,13 @@ class PublishEntityClient implements PublishEntityRepositoryInterface
 
     public function __construct(
         HttpClient $client,
+        QueryClient $queryClient,
         JsonGeneratorStrategy $generator,
         Config $manageConfig,
         LoggerInterface $logger
     ) {
         $this->client = $client;
+        $this->queryClient = $queryClient;
         $this->generator = $generator;
         $this->manageConfig = $manageConfig;
         $this->logger = $logger;
@@ -84,9 +91,10 @@ class PublishEntityClient implements PublishEntityRepositoryInterface
                 );
             } else {
                 $this->logger->info(sprintf('Updating existing \'%s\' entity in manage', $entity->getEntityId()));
-
+                $manageEntity = $this->queryClient->findByManageId($entity->getManageId());
                 $data = json_encode($this->generator->generateForExistingEntity(
                     $entity,
+                    $manageEntity,
                     $this->manageConfig->getPublicationStatus()->getStatus()
                 ));
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php
@@ -19,6 +19,7 @@
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client;
 
 use Psr\Log\LoggerInterface;
+use Surfnet\ServiceProviderDashboard\Application\Dto\MetadataConversionDto;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGeneratorStrategy;
 use Surfnet\ServiceProviderDashboard\Application\ViewObject\Manage\Config;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
@@ -84,7 +85,7 @@ class PublishEntityClient implements PublishEntityRepositoryInterface
 
                 $response = $this->client->post(
                     json_encode($this->generator->generateForNewEntity(
-                        $entity,
+                        MetadataConversionDto::fromEntity($entity),
                         $this->manageConfig->getPublicationStatus()->getStatus()
                     )),
                     '/manage/api/internal/metadata'
@@ -93,8 +94,7 @@ class PublishEntityClient implements PublishEntityRepositoryInterface
                 $this->logger->info(sprintf('Updating existing \'%s\' entity in manage', $entity->getEntityId()));
                 $manageEntity = $this->queryClient->findByManageId($entity->getManageId());
                 $data = json_encode($this->generator->generateForExistingEntity(
-                    $entity,
-                    $manageEntity,
+                    MetadataConversionDto::fromManageEntity($manageEntity, $entity),
                     $this->manageConfig->getPublicationStatus()->getStatus()
                 ));
 

--- a/tests/unit/Application/Metadata/JsonGenerator/ArpGeneratorTest.php
+++ b/tests/unit/Application/Metadata/JsonGenerator/ArpGeneratorTest.php
@@ -23,6 +23,8 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\ArpGenerator;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\Attribute as ManageAttribute;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Legacy\Repository\AttributesMetadataRepository;
 
 class ArpGeneratorTest extends MockeryTestCase
@@ -48,9 +50,66 @@ class ArpGeneratorTest extends MockeryTestCase
 
         $metadata = $factory->build($entity);
 
-        $this->assertCount(2, $metadata);
+        $this->assertCount(2, $metadata['attributes']);
 
         $this->assertNotEmpty($metadata['attributes']['urn:mace:dir:attribute-def:displayName']);
         $this->assertNotEmpty($metadata['attributes']['urn:mace:dir:attribute-def:cn']);
+    }
+
+    public function test_does_not_override_existing_manage_attributes()
+    {
+        /** @var Entity $entity */
+        $entity = m::mock(Entity::class)->makePartial();
+
+        $attribute = new Attribute();
+        $attribute->setRequested(true);
+        $attribute->setMotivation('commonname');
+        $entity->setCommonNameAttribute($attribute);
+
+        $attribute = new Attribute();
+        $attribute->setRequested(true);
+        $attribute->setMotivation('displayname');
+        $entity->setDisplayNameAttribute($attribute);
+
+        $metadataRepository = new AttributesMetadataRepository(__DIR__ . '/../../../../../app/Resources');
+
+        $factory = new ArpGenerator($metadataRepository);
+
+        $manageEntity = $this->getManageEntity();
+
+        $metadata = $factory->build($entity, $manageEntity);
+        $this->assertCount(4, $metadata['attributes']);
+
+        $this->assertNotEmpty($metadata['attributes']['urn:mace:dir:attribute-def:displayName']);
+        $this->assertNotEmpty($metadata['attributes']['urn:mace:dir:attribute-def:cn']);
+        $this->assertNotEmpty($metadata['attributes']['urn:mace:dir:attribute-def:manage-1']);
+        $this->assertNotEmpty($metadata['attributes']['urn:mace:dir:attribute-def:manage-2']);
+    }
+
+    private function getManageEntity()
+    {
+        $manageAttributes = [
+            $this->buildManageAttribute('urn:mace:dir:attribute-def:manage-1'),
+            $this->buildManageAttribute('urn:mace:dir:attribute-def:manage-2'),
+        ];
+
+        $manageEntity = m::mock(ManageEntity::class);
+        $manageEntity
+            ->shouldReceive('getAttributes->getAttributes')
+            ->andReturn($manageAttributes);
+
+        return $manageEntity;
+    }
+
+    private function buildManageAttribute(string $attributeName)
+    {
+        $attribute = m::mock(ManageAttribute::class);
+        $attribute->shouldReceive('getName')
+            ->andReturn($attributeName);
+        $attribute->shouldReceive('getSource')
+            ->andReturn('idp');
+        $attribute->shouldReceive('getValue')
+            ->andReturn('The Manage attr value');
+        return $attribute;
     }
 }

--- a/tests/unit/Application/Metadata/JsonGenerator/PrivacyQuestionsMetadataGeneratorTest.php
+++ b/tests/unit/Application/Metadata/JsonGenerator/PrivacyQuestionsMetadataGeneratorTest.php
@@ -21,6 +21,7 @@ namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Application\Metadata\JsonG
 use DateTime;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Surfnet\ServiceProviderDashboard\Application\Dto\MetadataConversionDto;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\PrivacyQuestionsMetadataGenerator;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions;
@@ -61,6 +62,8 @@ class PrivacyQuestionsMetadataGeneratorTest extends MockeryTestCase
         $service->setPrivacyQuestions($privacyQuestions);
         $entity->setService($service);
 
+        $entity = MetadataConversionDto::fromEntity($entity);
+
         $metadataRepository = new AttributesMetadataRepository(__DIR__ . '/../../../../../app/Resources');
 
         $factory = new PrivacyQuestionsMetadataGenerator($metadataRepository);
@@ -92,7 +95,7 @@ class PrivacyQuestionsMetadataGeneratorTest extends MockeryTestCase
         $metadataRepository = new AttributesMetadataRepository(__DIR__ . '/../../../../../app/Resources');
 
         $factory = new PrivacyQuestionsMetadataGenerator($metadataRepository);
-
+        $entity = MetadataConversionDto::fromEntity($entity);
         $metadata = $factory->build($entity);
 
         $this->assertEmpty($metadata);

--- a/tests/unit/Application/Metadata/JsonGenerator/SpDashboardMetadataGeneratorTest.php
+++ b/tests/unit/Application/Metadata/JsonGenerator/SpDashboardMetadataGeneratorTest.php
@@ -20,6 +20,7 @@ namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Application\Metadata\JsonG
 
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Surfnet\ServiceProviderDashboard\Application\Dto\MetadataConversionDto;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\SpDashboardMetadataGenerator;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
@@ -37,7 +38,7 @@ class SpDashboardMetadataGeneratorTest extends MockeryTestCase
         $entity->setImportUrl('http://the-a-team.com/saml/metadata');
 
         $entity->setService($service);
-
+        $entity = MetadataConversionDto::fromEntity($entity);
         $metadataRepository = new AttributesMetadataRepository(__DIR__ . '/../../../../../app/Resources');
 
         $factory = new SpDashboardMetadataGenerator($metadataRepository);

--- a/tests/unit/Application/Metadata/JsonGeneratorStrategyTest.php
+++ b/tests/unit/Application/Metadata/JsonGeneratorStrategyTest.php
@@ -25,6 +25,7 @@ use Surfnet\ServiceProviderDashboard\Application\Exception\JsonGeneratorStrategy
 use Surfnet\ServiceProviderDashboard\Application\Metadata\GeneratorInterface;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGeneratorStrategy;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
 
 class JsonGeneratorStrategyTest extends MockeryTestCase
 {
@@ -69,38 +70,41 @@ class JsonGeneratorStrategyTest extends MockeryTestCase
     public function test_generate_for_new_entity()
     {
         $entity = m::mock(Entity::class);
+        $manageEntity = m::mock(ManageEntity::class);
 
         $entity->shouldReceive('getProtocol')->andReturn('saml');
-        $this->strategy->generateForNewEntity($entity, 'prodaccepted');
+        $this->strategy->generateForNewEntity($entity, $manageEntity, 'prodaccepted');
 
         $entity->shouldReceive('getProtocol')->andReturn('oidc');
-        $this->strategy->generateForNewEntity($entity, 'prodaccepted');
+        $this->strategy->generateForNewEntity($entity, $manageEntity, 'prodaccepted');
 
         $entity->shouldReceive('getProtocol')->andReturn('oidcng');
-        $this->strategy->generateForNewEntity($entity, 'prodaccepted');
+        $this->strategy->generateForNewEntity($entity, $manageEntity, 'prodaccepted');
     }
 
     public function test_generate_for_existing_entity()
     {
         $entity = m::mock(Entity::class);
+        $manageEntity = m::mock(ManageEntity::class);
 
         $entity->shouldReceive('getProtocol')->andReturn('saml');
-        $this->strategy->generateForExistingEntity($entity, 'prodaccepted');
+        $this->strategy->generateForExistingEntity($entity, $manageEntity, 'prodaccepted');
 
         $entity->shouldReceive('getProtocol')->andReturn('oidc');
-        $this->strategy->generateForExistingEntity($entity, 'prodaccepted');
+        $this->strategy->generateForExistingEntity($entity, $manageEntity, 'prodaccepted');
 
         $entity->shouldReceive('getProtocol')->andReturn('oidcng');
-        $this->strategy->generateForExistingEntity($entity, 'prodaccepted');
+        $this->strategy->generateForExistingEntity($entity, $manageEntity, 'prodaccepted');
     }
 
     public function test_add_invalid_strategy()
     {
         $entity = m::mock(Entity::class);
+        $manageEntity = m::mock(ManageEntity::class);
         $entity->shouldReceive('getProtocol')->andReturn('saml30');
 
         $this->expectException(JsonGeneratorStrategyNotFoundException::class);
         $this->expectExceptionMessage('The requested JsonGenerator for protocol "saml30" is not registered');
-        $this->strategy->generateForExistingEntity($entity, 'prodaccepted');
+        $this->strategy->generateForExistingEntity($entity, $manageEntity, 'prodaccepted');
     }
 }

--- a/tests/unit/Application/Metadata/JsonGeneratorStrategyTest.php
+++ b/tests/unit/Application/Metadata/JsonGeneratorStrategyTest.php
@@ -21,11 +21,10 @@ namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Application\Factory;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Mock;
+use Surfnet\ServiceProviderDashboard\Application\Dto\MetadataConversionDto;
 use Surfnet\ServiceProviderDashboard\Application\Exception\JsonGeneratorStrategyNotFoundException;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\GeneratorInterface;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGeneratorStrategy;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
-use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
 
 class JsonGeneratorStrategyTest extends MockeryTestCase
 {
@@ -69,42 +68,40 @@ class JsonGeneratorStrategyTest extends MockeryTestCase
 
     public function test_generate_for_new_entity()
     {
-        $entity = m::mock(Entity::class);
-        $manageEntity = m::mock(ManageEntity::class);
+        $entity = m::mock(MetadataConversionDto::class);
 
         $entity->shouldReceive('getProtocol')->andReturn('saml');
-        $this->strategy->generateForNewEntity($entity, $manageEntity, 'prodaccepted');
+        $this->strategy->generateForNewEntity($entity, 'prodaccepted');
 
         $entity->shouldReceive('getProtocol')->andReturn('oidc');
-        $this->strategy->generateForNewEntity($entity, $manageEntity, 'prodaccepted');
+        $this->strategy->generateForNewEntity($entity, 'prodaccepted');
 
         $entity->shouldReceive('getProtocol')->andReturn('oidcng');
-        $this->strategy->generateForNewEntity($entity, $manageEntity, 'prodaccepted');
+        $this->strategy->generateForNewEntity($entity, 'prodaccepted');
     }
 
     public function test_generate_for_existing_entity()
     {
-        $entity = m::mock(Entity::class);
-        $manageEntity = m::mock(ManageEntity::class);
+        $entity = m::mock(MetadataConversionDto::class);
 
         $entity->shouldReceive('getProtocol')->andReturn('saml');
-        $this->strategy->generateForExistingEntity($entity, $manageEntity, 'prodaccepted');
+        $this->strategy->generateForExistingEntity($entity, 'prodaccepted');
 
         $entity->shouldReceive('getProtocol')->andReturn('oidc');
-        $this->strategy->generateForExistingEntity($entity, $manageEntity, 'prodaccepted');
+        $this->strategy->generateForExistingEntity($entity, 'prodaccepted');
 
         $entity->shouldReceive('getProtocol')->andReturn('oidcng');
-        $this->strategy->generateForExistingEntity($entity, $manageEntity, 'prodaccepted');
+        $this->strategy->generateForExistingEntity($entity, 'prodaccepted');
     }
 
     public function test_add_invalid_strategy()
     {
-        $entity = m::mock(Entity::class);
-        $manageEntity = m::mock(ManageEntity::class);
+        $entity = m::mock(MetadataConversionDto::class);
+
         $entity->shouldReceive('getProtocol')->andReturn('saml30');
 
         $this->expectException(JsonGeneratorStrategyNotFoundException::class);
         $this->expectExceptionMessage('The requested JsonGenerator for protocol "saml30" is not registered');
-        $this->strategy->generateForExistingEntity($entity, $manageEntity, 'prodaccepted');
+        $this->strategy->generateForExistingEntity($entity, 'prodaccepted');
     }
 }

--- a/tests/unit/Application/Metadata/JsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/JsonGeneratorTest.php
@@ -28,6 +28,7 @@ use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\IdentityProvider;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
 
 class JsonGeneratorTest extends MockeryTestCase
 {
@@ -129,7 +130,7 @@ class JsonGeneratorTest extends MockeryTestCase
             'http://playground-prod'
         );
 
-        $metadata = $generator->generateForExistingEntity($this->createSamlEntity(), 'testaccepted');
+        $metadata = $generator->generateForExistingEntity($this->createSamlEntity(), m::mock(ManageEntity::class), 'testaccepted');
         $metadata = $metadata['pathUpdates'];
 
         $this->assertArrayNotHasKey('active', $metadata);
@@ -237,7 +238,7 @@ class JsonGeneratorTest extends MockeryTestCase
             'http://playground-prod'
         );
 
-        $metadata = $generator->generateForExistingEntity($this->createOidcEntity(), 'testaccepted');
+        $metadata = $generator->generateForExistingEntity($this->createOidcEntity(), m::mock(ManageEntity::class), 'testaccepted');
         $metadata = $metadata['pathUpdates'];
 
         $this->assertArrayNotHasKey('active', $metadata);
@@ -348,7 +349,7 @@ class JsonGeneratorTest extends MockeryTestCase
             'http://playground-prod'
         );
 
-        $data = $generator->generateForExistingEntity($this->createSamlEntity(), 'testaccepted');
+        $data = $generator->generateForExistingEntity($this->createSamlEntity(), m::mock(ManageEntity::class), 'testaccepted');
 
         $this->assertEquals(array (
             'pathUpdates' =>
@@ -475,7 +476,7 @@ class JsonGeneratorTest extends MockeryTestCase
             'http://playground-prod'
         );
 
-        $data = $generator->generateForExistingEntity($this->createOidcEntity(), 'testaccepted');
+        $data = $generator->generateForExistingEntity($this->createOidcEntity(), m::mock(ManageEntity::class), 'testaccepted');
 
         $this->assertEquals(array (
             'pathUpdates' =>
@@ -546,8 +547,7 @@ class JsonGeneratorTest extends MockeryTestCase
 
         $entity = $this->createSamlEntity();
 
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
-
+        $data = $generator->generateForExistingEntity($entity, m::mock(ManageEntity::class), 'testaccepted');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(true, $data['pathUpdates']['allowedall']);
@@ -568,7 +568,7 @@ class JsonGeneratorTest extends MockeryTestCase
         $entity = $this->createSamlEntity();
         $entity->setIdpAllowAll(true);
 
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
+        $data = $generator->generateForExistingEntity($entity, m::mock(ManageEntity::class), 'testaccepted');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(true, $data['pathUpdates']['allowedall']);
@@ -589,8 +589,7 @@ class JsonGeneratorTest extends MockeryTestCase
         $entity = $this->createSamlEntity();
         $entity->setIdpAllowAll(false);
 
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
-
+        $data = $generator->generateForExistingEntity($entity, m::mock(ManageEntity::class), 'testaccepted');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(false, $data['pathUpdates']['allowedall']);
@@ -614,8 +613,7 @@ class JsonGeneratorTest extends MockeryTestCase
             new IdentityProvider('manage-id', 'entity-id', 'name-nl', 'name-en'),
         ]);
 
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
-
+        $data = $generator->generateForExistingEntity($entity, m::mock(ManageEntity::class), 'testaccepted');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(false, $data['pathUpdates']['allowedall']);
@@ -640,7 +638,7 @@ class JsonGeneratorTest extends MockeryTestCase
             new IdentityProvider('manage-id2', 'entity-id2', 'name-nl2', 'name-en2'),
         ]);
 
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
+        $data = $generator->generateForExistingEntity($entity, m::mock(ManageEntity::class), 'testaccepted');
 
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);

--- a/tests/unit/Application/Metadata/JsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/JsonGeneratorTest.php
@@ -20,6 +20,7 @@ namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Application\Factory;
 
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Surfnet\ServiceProviderDashboard\Application\Dto\MetadataConversionDto;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\ArpGenerator;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\PrivacyQuestionsMetadataGenerator;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\SpDashboardMetadataGenerator;
@@ -76,7 +77,7 @@ class JsonGeneratorTest extends MockeryTestCase
             'http://playground-prod'
         );
 
-        $metadata = $generator->generateForNewEntity($this->createSamlEntity(), 'testaccepted');
+        $metadata = $generator->generateForNewEntity($this->createMetadataConversionDto(), 'testaccepted');
         $metadata = $metadata['data'];
 
         $this->assertEquals('saml20-sp', $metadata['type']);
@@ -130,7 +131,7 @@ class JsonGeneratorTest extends MockeryTestCase
             'http://playground-prod'
         );
 
-        $metadata = $generator->generateForExistingEntity($this->createSamlEntity(), m::mock(ManageEntity::class), 'testaccepted');
+        $metadata = $generator->generateForExistingEntity($this->createMetadataConversionDto(), 'testaccepted');
         $metadata = $metadata['pathUpdates'];
 
         $this->assertArrayNotHasKey('active', $metadata);
@@ -180,7 +181,7 @@ class JsonGeneratorTest extends MockeryTestCase
             'http://playground-prod'
         );
 
-        $metadata = $generator->generateForNewEntity($this->createOidcEntity(), 'testaccepted');
+        $metadata = $generator->generateForNewEntity($this->createOidcMetadataConversionDto(), 'testaccepted');
         $metadata = $metadata['data'];
 
         $this->assertTrue($metadata['active']);
@@ -238,7 +239,12 @@ class JsonGeneratorTest extends MockeryTestCase
             'http://playground-prod'
         );
 
-        $metadata = $generator->generateForExistingEntity($this->createOidcEntity(), m::mock(ManageEntity::class), 'testaccepted');
+        $metadata = $generator->generateForExistingEntity(
+            $this->createOidcMetadataConversionDto(),
+            m::mock(ManageEntity::class),
+            'testaccepted'
+        );
+
         $metadata = $metadata['pathUpdates'];
 
         $this->assertArrayNotHasKey('active', $metadata);
@@ -290,7 +296,7 @@ class JsonGeneratorTest extends MockeryTestCase
             'http://playground-prod'
         );
 
-        $data = $generator->generateForNewEntity($this->createSamlEntity(), 'prodaccepted');
+        $data = $generator->generateForNewEntity($this->createMetadataConversionDto(), 'prodaccepted');
 
         $this->assertEquals(array (
             'data' =>
@@ -349,7 +355,7 @@ class JsonGeneratorTest extends MockeryTestCase
             'http://playground-prod'
         );
 
-        $data = $generator->generateForExistingEntity($this->createSamlEntity(), m::mock(ManageEntity::class), 'testaccepted');
+        $data = $generator->generateForExistingEntity($this->createMetadataConversionDto(), 'testaccepted');
 
         $this->assertEquals(array (
             'pathUpdates' =>
@@ -404,7 +410,7 @@ class JsonGeneratorTest extends MockeryTestCase
             'http://playground-prod'
         );
 
-        $data = $generator->generateForNewEntity($this->createOidcEntity(), 'testaccepted');
+        $data = $generator->generateForNewEntity($this->createOidcMetadataConversionDto(), 'testaccepted');
 
         $this->assertEquals(array (
             'data' =>
@@ -476,7 +482,7 @@ class JsonGeneratorTest extends MockeryTestCase
             'http://playground-prod'
         );
 
-        $data = $generator->generateForExistingEntity($this->createOidcEntity(), m::mock(ManageEntity::class), 'testaccepted');
+        $data = $generator->generateForExistingEntity($this->createOidcMetadataConversionDto(), 'testaccepted');
 
         $this->assertEquals(array (
             'pathUpdates' =>
@@ -545,9 +551,9 @@ class JsonGeneratorTest extends MockeryTestCase
             'http://playground-prod'
         );
 
-        $entity = $this->createSamlEntity();
+        $entity = $this->createMetadataConversionDto();
 
-        $data = $generator->generateForExistingEntity($entity, m::mock(ManageEntity::class), 'testaccepted');
+        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(true, $data['pathUpdates']['allowedall']);
@@ -565,10 +571,9 @@ class JsonGeneratorTest extends MockeryTestCase
             'http://playground-prod'
         );
 
-        $entity = $this->createSamlEntity();
-        $entity->setIdpAllowAll(true);
+        $entity = $this->createMetadataConversionDto(true);
 
-        $data = $generator->generateForExistingEntity($entity, m::mock(ManageEntity::class), 'testaccepted');
+        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(true, $data['pathUpdates']['allowedall']);
@@ -586,10 +591,9 @@ class JsonGeneratorTest extends MockeryTestCase
             'http://playground-prod'
         );
 
-        $entity = $this->createSamlEntity();
-        $entity->setIdpAllowAll(false);
+        $entity = $this->createMetadataConversionDto(false);
 
-        $data = $generator->generateForExistingEntity($entity, m::mock(ManageEntity::class), 'testaccepted');
+        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(false, $data['pathUpdates']['allowedall']);
@@ -607,13 +611,10 @@ class JsonGeneratorTest extends MockeryTestCase
             'http://playground-prod'
         );
 
-        $entity = $this->createSamlEntity();
-        $entity->setIdpAllowAll(false);
-        $entity->setIdpWhitelist([
-            new IdentityProvider('manage-id', 'entity-id', 'name-nl', 'name-en'),
-        ]);
+        $idpWhitlest = [new IdentityProvider('manage-id', 'entity-id', 'name-nl', 'name-en')];
+        $entity = $this->createMetadataConversionDto(false, $idpWhitlest);
 
-        $data = $generator->generateForExistingEntity($entity, m::mock(ManageEntity::class), 'testaccepted');
+        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(false, $data['pathUpdates']['allowedall']);
@@ -631,15 +632,13 @@ class JsonGeneratorTest extends MockeryTestCase
             'http://playground-prod'
         );
 
-        $entity = $this->createSamlEntity();
-        $entity->setIdpAllowAll(false);
-        $entity->setIdpWhitelist([
+        $idpWhitelist = [
             new IdentityProvider('manage-id', 'entity-id', 'name-nl', 'name-en'),
             new IdentityProvider('manage-id2', 'entity-id2', 'name-nl2', 'name-en2'),
-        ]);
+        ];
+        $entity = $this->createMetadataConversionDto(false, $idpWhitelist);
 
-        $data = $generator->generateForExistingEntity($entity, m::mock(ManageEntity::class), 'testaccepted');
-
+        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(false, $data['pathUpdates']['allowedall']);
@@ -657,8 +656,7 @@ class JsonGeneratorTest extends MockeryTestCase
             'http://playground-prod'
         );
 
-        $entity = $this->createSamlEntity();
-        $entity->setCertificate('');
+        $entity = $this->createMetadataConversionDto(null, null, '');
 
         $data = $generator->generateForNewEntity($entity, 'prodaccepted');
 
@@ -709,9 +707,12 @@ class JsonGeneratorTest extends MockeryTestCase
     }
 
     /**
-     * @return Entity
+     * @param bool|null $idpAllowAll
+     * @param array|null $idpWhitelist
+     * @param string|null $certificate
+     * @return MetadataConversionDto
      */
-    private function createSamlEntity()
+    private function createMetadataConversionDto($idpAllowAll = null, $idpWhitelist = null, $certificate = null)
     {
         /** @var Entity $entity */
         $entity = m::mock(Entity::class)->makePartial();
@@ -750,16 +751,29 @@ CERT
 
         $entity->setSupportContact($contact);
 
+        if (!is_null($idpAllowAll)) {
+            $entity->setIdpAllowAll($idpAllowAll);
+        }
+
+        if (!is_null($idpWhitelist)) {
+            $entity->setIdpWhitelist($idpWhitelist);
+        }
+
+        if (!is_null($certificate)) {
+            $entity->setCertificate($certificate);
+        }
+
+        $entity = MetadataConversionDto::fromEntity($entity);
+
         return $entity;
     }
 
     /**
-     * @return Entity
+     * @return MetadataConversionDto
      */
-    private function createOidcEntity()
+    private function createOidcMetadataConversionDto()
     {
         /** @var Entity $entity */
-
         $entity = m::mock(Entity::class)->makePartial();
 
         $entity->setProtocol('oidc');
@@ -793,7 +807,7 @@ CERT
         $contact->setPhone('telephonenumber');
 
         $entity->setSupportContact($contact);
-
+        $entity = MetadataConversionDto::fromEntity($entity);
         return $entity;
     }
 }

--- a/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
@@ -20,6 +20,7 @@ namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Application\Factory;
 
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Surfnet\ServiceProviderDashboard\Application\Dto\MetadataConversionDto;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\ArpGenerator;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\PrivacyQuestionsMetadataGenerator;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\SpDashboardMetadataGenerator;
@@ -75,21 +76,9 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
 
         $this->arpMetadataGenerator
             ->shouldReceive('build')
-            ->with(
-                m::on(
-                    function (Entity $entity) {
-                        $epti = $entity->getEduPersonTargetedIDAttribute();
-                        $this->assertTrue($epti->isRequested());
-                        $this->assertTrue($epti->hasMotivation());
-                        $this->assertEquals('OIDC requires EduPersonTargetedID by default', $epti->getMotivation());
-
-                        return true;
-                    }
-                )
-            )
             ->andReturn(['arp' => 'arp']);
 
-        $data = $generator->generateForNewEntity($this->createOidcngEntity(), 'testaccepted');
+        $data = $generator->generateForNewEntity($this->createMetadataConversionDto(), 'testaccepted');
         $this->assertEquals(
             [
                 'data' => [
@@ -154,7 +143,7 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
             'http://oidc.prod.playground.example.com'
         );
 
-        $data = $generator->generateForExistingEntity($this->createOidcngEntity(), m::mock(ManageEntity::class), 'testaccepted');
+        $data = $generator->generateForExistingEntity($this->createMetadataConversionDto(), 'testaccepted');
 
         $this->assertEquals(
             array(
@@ -220,10 +209,7 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
             'http://oidc.prod.playground.example.com'
         );
 
-        $entity = $this->createOidcngEntity();
-
-        $data = $generator->generateForExistingEntity($entity, m::mock(ManageEntity::class), 'testaccepted');
-
+        $data = $generator->generateForExistingEntity($this->createMetadataConversionDto(), 'testaccepted');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(true, $data['pathUpdates']['allowedall']);
@@ -245,10 +231,9 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
             'http://oidc.prod.playground.example.com'
         );
 
-        $entity = $this->createOidcngEntity();
-        $entity->setIdpAllowAll(true);
+        $entity = $this->createMetadataConversionDto(true);
 
-        $data = $generator->generateForExistingEntity($entity, m::mock(ManageEntity::class), 'testaccepted');
+        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(true, $data['pathUpdates']['allowedall']);
@@ -270,10 +255,9 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
             'http://oidc.prod.playground.example.com'
         );
 
-        $entity = $this->createOidcngEntity();
-        $entity->setIdpAllowAll(false);
+        $entity = $this->createMetadataConversionDto(false);
 
-        $data = $generator->generateForExistingEntity($entity, m::mock(ManageEntity::class), 'testaccepted');
+        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
 
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
@@ -296,16 +280,11 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
             'http://oidc.prod.playground.example.com'
         );
 
-        $entity = $this->createOidcngEntity();
-        $entity->setIdpAllowAll(false);
-        $entity->setIdpWhitelist(
-            [
-                new IdentityProvider('manage-id', 'entity-id', 'name-nl', 'name-en'),
-            ]
-        );
+        $entity = $this->createMetadataConversionDto(false, [
+            new IdentityProvider('manage-id', 'entity-id', 'name-nl', 'name-en'),
+        ]);
 
-        $data = $generator->generateForExistingEntity($entity, m::mock(ManageEntity::class), 'testaccepted');
-
+        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(false, $data['pathUpdates']['allowedall']);
@@ -328,17 +307,12 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
             'http://oidc.prod.playground.example.com'
         );
 
-        $entity = $this->createOidcngEntity();
-        $entity->setIdpAllowAll(false);
-        $entity->setIdpWhitelist(
-            [
-                new IdentityProvider('manage-id', 'entity-id', 'name-nl', 'name-en'),
-                new IdentityProvider('manage-id2', 'entity-id2', 'name-nl2', 'name-en2'),
-            ]
-        );
+        $entity = $this->createMetadataConversionDto(false, [
+            new IdentityProvider('manage-id', 'entity-id', 'name-nl', 'name-en'),
+            new IdentityProvider('manage-id2', 'entity-id2', 'name-nl2', 'name-en2'),
+        ]);
 
-        $data = $generator->generateForExistingEntity($entity, m::mock(ManageEntity::class), 'testaccepted');
-
+        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(false, $data['pathUpdates']['allowedall']);
@@ -351,9 +325,9 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
 
 
     /**
-     * @return Entity
+     * @return MetadataConversionDto
      */
-    private function createOidcngEntity()
+    private function createMetadataConversionDto($idpAllowAll = null, $idpWhitelist = null, $certificate = null)
     {
         /** @var Entity $entity */
         $entity = m::mock(Entity::class)->makePartial();
@@ -400,6 +374,18 @@ CERT
         $entity->setAccessTokenValidity(3600);
 
         $entity->shouldReceive('isAllowedAll')->andReturn(true);
-        return $entity;
+        if (!is_null($idpAllowAll)) {
+            $entity->setIdpAllowAll($idpAllowAll);
+        }
+
+        if (!is_null($idpWhitelist)) {
+            $entity->setIdpWhitelist($idpWhitelist);
+        }
+
+        if (!is_null($certificate)) {
+            $entity->setCertificate($certificate);
+        }
+
+        return MetadataConversionDto::fromEntity($entity);
     }
 }

--- a/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
@@ -29,6 +29,7 @@ use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\IdentityProvider;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
 
 class OidcngJsonGeneratorTest extends MockeryTestCase
 {
@@ -153,7 +154,7 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
             'http://oidc.prod.playground.example.com'
         );
 
-        $data = $generator->generateForExistingEntity($this->createOidcngEntity(), 'testaccepted');
+        $data = $generator->generateForExistingEntity($this->createOidcngEntity(), m::mock(ManageEntity::class), 'testaccepted');
 
         $this->assertEquals(
             array(
@@ -221,7 +222,7 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
 
         $entity = $this->createOidcngEntity();
 
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
+        $data = $generator->generateForExistingEntity($entity, m::mock(ManageEntity::class), 'testaccepted');
 
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
@@ -247,7 +248,7 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
         $entity = $this->createOidcngEntity();
         $entity->setIdpAllowAll(true);
 
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
+        $data = $generator->generateForExistingEntity($entity, m::mock(ManageEntity::class), 'testaccepted');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(true, $data['pathUpdates']['allowedall']);
@@ -272,7 +273,7 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
         $entity = $this->createOidcngEntity();
         $entity->setIdpAllowAll(false);
 
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
+        $data = $generator->generateForExistingEntity($entity, m::mock(ManageEntity::class), 'testaccepted');
 
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
@@ -303,7 +304,7 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
             ]
         );
 
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
+        $data = $generator->generateForExistingEntity($entity, m::mock(ManageEntity::class), 'testaccepted');
 
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
@@ -336,7 +337,7 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
             ]
         );
 
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
+        $data = $generator->generateForExistingEntity($entity, m::mock(ManageEntity::class), 'testaccepted');
 
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);

--- a/tests/unit/Application/Metadata/OidcngResourceServerJsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/OidcngResourceServerJsonGeneratorTest.php
@@ -26,6 +26,7 @@ use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\SpDashbo
 use Surfnet\ServiceProviderDashboard\Application\Metadata\OidcngResourceServerJsonGenerator;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
 
 class OidcngResourceServerJsonGeneratorTest extends MockeryTestCase
 {
@@ -115,7 +116,11 @@ class OidcngResourceServerJsonGeneratorTest extends MockeryTestCase
             $this->spDashboardMetadataGenerator
         );
 
-        $data = $generator->generateForExistingEntity($this->createOidcngEntity(), 'testaccepted');
+        $data = $generator->generateForExistingEntity(
+            $this->createOidcngEntity(),
+            m::mock(ManageEntity::class),
+            'testaccepted'
+        );
 
         $this->assertEquals(
             array(

--- a/tests/unit/Application/Metadata/OidcngResourceServerJsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/OidcngResourceServerJsonGeneratorTest.php
@@ -20,6 +20,7 @@ namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Application\Factory;
 
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Surfnet\ServiceProviderDashboard\Application\Dto\MetadataConversionDto;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\ArpGenerator;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\PrivacyQuestionsMetadataGenerator;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\SpDashboardMetadataGenerator;
@@ -116,11 +117,7 @@ class OidcngResourceServerJsonGeneratorTest extends MockeryTestCase
             $this->spDashboardMetadataGenerator
         );
 
-        $data = $generator->generateForExistingEntity(
-            $this->createOidcngEntity(),
-            m::mock(ManageEntity::class),
-            'testaccepted'
-        );
+        $data = $generator->generateForExistingEntity($this->createOidcngEntity(), 'testaccepted');
 
         $this->assertEquals(
             array(
@@ -162,7 +159,7 @@ class OidcngResourceServerJsonGeneratorTest extends MockeryTestCase
     }
 
     /**
-     * @return Entity
+     * @return MetadataConversionDto
      */
     private function createOidcngEntity()
     {
@@ -200,10 +197,9 @@ CERT
         $contact->setPhone('telephonenumber');
 
         $entity->setSupportContact($contact);
-
         $entity->setClientSecret('test');
-
         $entity->shouldReceive('isAllowedAll')->andReturn(true);
-        return $entity;
+
+        return MetadataConversionDto::fromEntity($entity);
     }
 }

--- a/tests/unit/Infrastructure/Manage/Client/PublishEntityClientTest.php
+++ b/tests/unit/Infrastructure/Manage/Client/PublishEntityClientTest.php
@@ -31,6 +31,8 @@ use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGeneratorStrategy;
 use Surfnet\ServiceProviderDashboard\Application\ViewObject\Manage\Config;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\PublishEntityClient;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Http\HttpClient;
 
 class PublishEntityClientTest extends MockeryTestCase
@@ -76,6 +78,7 @@ class PublishEntityClientTest extends MockeryTestCase
                 $guzzle,
                 new NullLogger()
             ),
+            $this->buildQueryClient(),
             $this->generator,
             $this->manageConfig,
             $this->logger
@@ -216,5 +219,14 @@ class PublishEntityClientTest extends MockeryTestCase
             ->once();
 
         $this->client->pushMetadata();
+    }
+
+    private function buildQueryClient()
+    {
+        $queryClient = m::mock(QueryClient::class);
+        $queryClient
+            ->shouldReceive('findByManageId')
+            ->andReturn(m::mock(ManageEntity::class));
+        return $queryClient;
     }
 }


### PR DESCRIPTION
Arp attributes not tracked in the SPD forms where overridden. This PR takes care of this by changing the way attributes are filtered.

Most notable is the use of the Manage entity that is now used in the metadata generators.

https://www.pivotaltracker.com/story/show/170868465