### PR TITLE
Prevent overriding the 'exclude_from_push' attribute

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityProductionCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityProductionCommandHandler.php
@@ -22,10 +22,8 @@ use Exception;
 use Psr\Log\LoggerInterface;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityProductionCommand;
 use Surfnet\ServiceProviderDashboard\Application\CommandHandler\CommandHandler;
-use Surfnet\ServiceProviderDashboard\Application\Exception\NotAuthenticatedException;
 use Surfnet\ServiceProviderDashboard\Application\Service\TicketService;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Domain\Mailer\Mailer;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityRepository;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\PublishEntityRepository;
@@ -47,7 +45,7 @@ class PublishEntityProductionCommandHandler implements CommandHandler
     private $repository;
 
     /**
-     * @var EntityRepository
+     * @var ServiceRepository
      */
     private $serviceRepository;
 
@@ -140,7 +138,6 @@ class PublishEntityProductionCommandHandler implements CommandHandler
      *  - A jira ticket is created to inform the service desk of the pending publication request
      *
      * @param PublishEntityProductionCommand $command
-     * @throws NotAuthenticatedException
      *
      * @SuppressWarnings(PHPMD.ElseExpression)
      */

--- a/src/Surfnet/ServiceProviderDashboard/Application/Dto/MetadataConversionDto.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Dto/MetadataConversionDto.php
@@ -556,4 +556,9 @@ class MetadataConversionDto
     {
         return !is_null($this->manageEntity);
     }
+
+    public function isExcludedFromPush()
+    {
+        return $this->manageEntity->isExcludedFromPush();
+    }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
@@ -246,11 +246,14 @@ class JsonGenerator implements GeneratorInterface
         }
 
         // When publishing to production, the coin:exclude_from_push must be present and set to '1'. This prevents the
-        // entity from being pushed to engineblock.
+        // entity from being pushed to EngineBlock. Once the entity is checked a final time, the flag is set to 0
+        // by one of the administrators. If the entity was included for push, we make sure it is not overridden.
         if ($entity->isProduction()) {
             $metadata['coin:exclude_from_push'] = '1';
         }
-
+        if ($entity->isManageEntity() && !$entity->isExcludedFromPush()) {
+            $metadata['coin:exclude_from_push'] = '0';
+        }
         if (!empty($entity->getLogoUrl())) {
             $metadata = array_merge($metadata, $this->generateLogoMetadata($entity));
         }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityResetSecretController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityResetSecretController.php
@@ -23,7 +23,6 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\ResetOidcSecretCommand;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\Protocol;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -66,7 +65,7 @@ class EntityResetSecretController extends Controller
             );
         }
 
-        // fetch entity from managae and reset secret
+        // fetch entity from manage and reset secret
         // the entity gets stored local temporarily
         $resetOidcSecretCommand = new ResetOidcSecretCommand($id, $manageId, $environment, $service);
         $this->commandBus->handle($resetOidcSecretCommand);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -267,8 +267,7 @@ services:
 
     Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\UniqueEntityIdValidator:
         arguments:
-            - '@Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient'
-            - '@surfnet.manage.client.query_client.prod_environment'
+            - '@surfnet.manage.query_service'
             - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\EntityRepository'
         tags:
             - { name: validator.constraint_validator, alias: unique_entity_id }
@@ -372,6 +371,12 @@ services:
         class: Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient
         arguments:
         - '@surfnet.manage.http.http_client.prod_environment'
+
+    surfnet.manage.query_service:
+        class: Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Service\MangeQueryService
+        arguments:
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient'
+            - '@surfnet.manage.client.query_client.prod_environment'
 
     Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Http\HttpClient:
         arguments:

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/UniqueEntityIdValidator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/UniqueEntityIdValidator.php
@@ -21,21 +21,16 @@ namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Valida
 use Exception;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveEntityCommandInterface;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityRepository as DoctrineRepository;
-use Surfnet\ServiceProviderDashboard\Domain\Repository\QueryEntityRepository;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Service\MangeQueryService;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
 class UniqueEntityIdValidator extends ConstraintValidator
 {
     /**
-     * @var QueryEntityRepository
+     * @var MangeQueryService
      */
-    private $manageTestRepository;
-
-    /**
-     * @var QueryEntityRepository
-     */
-    private $manageProductionRepository;
+    private $queryService;
 
     /**
      * @var DoctrineRepository
@@ -43,17 +38,13 @@ class UniqueEntityIdValidator extends ConstraintValidator
     private $doctrineRepository;
 
     /**
-     * @param QueryEntityRepository $manageTestRepository
-     * @param QueryEntityRepository $manageProductionRepository
      * @param DoctrineRepository $doctrineRepository
      */
     public function __construct(
-        QueryEntityRepository $manageTestRepository,
-        QueryEntityRepository $manageProductionRepository,
+        MangeQueryService $queryService,
         DoctrineRepository $doctrineRepository
     ) {
-        $this->manageTestRepository = $manageTestRepository;
-        $this->manageProductionRepository = $manageProductionRepository;
+        $this->queryService = $queryService;
         $this->doctrineRepository = $doctrineRepository;
     }
 
@@ -70,13 +61,10 @@ class UniqueEntityIdValidator extends ConstraintValidator
             throw new Exception('invalid validator command exception');
         }
 
-        $manage = $this->manageTestRepository;
-        if ($entityCommand->isForProduction()) {
-            $manage = $this->manageProductionRepository;
-        }
+        $mode = $entityCommand->isForProduction() ? 'production' : 'test';
 
         try {
-            $manageId = $manage->findManageIdByEntityId($value);
+            $manageId = $this->queryService->findManageIdByEntityId($mode, $value);
         } catch (Exception $e) {
             $this->context->addViolation('validator.entity_id.registry_failure');
             return;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Dto/ManageEntity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Dto/ManageEntity.php
@@ -166,4 +166,9 @@ class ManageEntity
 
         return false;
     }
+
+    public function isExcludedFromPush()
+    {
+        return $this->getMetaData()->getCoin()->getExcludeFromPush() == 1 ? true : false;
+    }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Service/MangeQueryService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Service/MangeQueryService.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Copyright 2020 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Service;
+
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\InvalidArgumentException;
+
+class MangeQueryService
+{
+    private $validEnvironments = ['test', 'production'];
+
+    /**
+     * @var QueryClient
+     */
+    private $testQueryClient;
+
+    /**
+     * @var QueryClient
+     */
+    private $productionQueryClient;
+
+    public function __construct(QueryClient $test, QueryClient $production)
+    {
+        $this->testQueryClient = $test;
+        $this->productionQueryClient = $production;
+    }
+
+    public function findManageIdByEntityId($environment, $entityId)
+    {
+        return $this->getClient($environment)->findManageIdByEntityId($entityId);
+    }
+
+    public function findByManageId($environment, $manageId)
+    {
+        return $this->getClient($environment)->findByManageId($manageId);
+    }
+
+    public function getMetadataXmlByManageId($environment, $manageId)
+    {
+        return $this->getClient($environment)->getMetadataXmlByManageId($manageId);
+    }
+
+    public function findByTeamName($environment, $teamName, $state)
+    {
+        return $this->getClient($environment)->findByTeamName($teamName, $state);
+    }
+
+    private function getClient($environment)
+    {
+        if (!in_array($environment, $this->validEnvironments)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Please set the query mode to one of these environments (%s)',
+                    implode(', ', $this->validEnvironments)
+                )
+            );
+        }
+        if ($environment === 'test') {
+            return $this->testQueryClient;
+        }
+        return $this->productionQueryClient;
+    }
+}

--- a/tests/unit/Infrastructure/Manage/Dto/ManageEntityTest.php
+++ b/tests/unit/Infrastructure/Manage/Dto/ManageEntityTest.php
@@ -34,6 +34,13 @@ class ManageEntityTest extends MockeryTestCase
         $this->assertEquals('Technical Support', $entity->getMetaData()->getContacts()->findTechnicalContact()->getSurName());
         $this->assertEquals('SURFnet BV', $entity->getMetaData()->getOrganization()->getNameEn());
         $this->assertEquals(160, $entity->getMetaData()->getLogo()->getHeight());
+        $this->assertTrue($entity->isExcludedFromPush());
+    }
+
+    public function test_create_dto_from_manage_response_not_excluded_from_push()
+    {
+        $entity = ManageEntity::fromApiResponse(json_decode(file_get_contents(__DIR__ . '/fixture/saml20_sp_response_not_excluded_from_push.json'), true));
+        $this->assertFalse($entity->isExcludedFromPush());
     }
 
     public function test_create_dto_with_invalid_contacts_from_manage_response()

--- a/tests/unit/Infrastructure/Manage/Dto/fixture/saml20_sp_response_not_excluded_from_push.json
+++ b/tests/unit/Infrastructure/Manage/Dto/fixture/saml20_sp_response_not_excluded_from_push.json
@@ -1,0 +1,76 @@
+{
+  "id": "411f8e0f-87a6-4ea7-8194-66b3e77f97d5",
+  "version": 0,
+  "type": "saml20_sp",
+  "revision": {
+    "number": 0,
+    "created": 1543851541.752,
+    "parentId": null,
+    "updatedBy": "sp-dashboard",
+    "terminated": null
+  },
+  "data": {
+    "arp": {
+      "attributes": {
+        "urn:mace:dir:attribute-def:displayName": [
+          {
+            "source": "idp",
+            "value": "*",
+            "motivation": "asddsafadfsafdsfdasfadsafds dafs ad fsad fsafd saf ds"
+          }
+        ],
+        "urn:mace:dir:attribute-def:uid": [
+          {
+            "source": "idp",
+            "value": "*",
+            "motivation": "fd fads fdasafd s fdasfda s dfas dfa"
+          }
+        ]
+      },
+      "enabled": true
+    },
+    "entityid": "https:\/\/monitorstands.example.com",
+    "metadataurl": "https:\/\/engine.surfconext.nl\/authentication\/sp\/metadata",
+    "active": true,
+    "allowedEntities": [],
+    "allowedall": true,
+    "state": "testaccepted",
+    "type": "saml20-sp",
+    "metaDataFields": {
+      "AssertionConsumerService:0:Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+      "AssertionConsumerService:0:Location": "https:\/\/engine.surfconext.nl\/authentication\/sp\/consume-assertion",
+      "NameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+      "description:en": "SURFconext is a collaboration infrastructure that creates new opportunities to collaborate online based on a combination of applications from different providers.",
+      "description:nl": "SURFconext is een samenwerkingsinfrastructuur die nieuwe vormen van samenwerken mogelijk maakt door diensten van verschillende aanbieders te combineren.",
+      "name:en": "Monitor stands",
+      "name:nl": "Monitor stands",
+      "coin:signature_method": "http:\/\/www.w3.org\/2001\/04\/xmldsig-more#rsa-sha256",
+      "certData": "MIID3zCCAsegAwIBAgIJAMVC9xn1ZfsuMA0GCSqGSIb3DQEBCwUAMIGFMQswCQYD\r\nVQQGEwJOTDEQMA4GA1UECAwHVXRyZWNodDEQMA4GA1UEBwwHVXRyZWNodDEVMBMG\r\nA1UECgwMU1VSRm5ldCBCLlYuMRMwEQYDVQQLDApTVVJGY29uZXh0MSYwJAYDVQQD\r\nDB1lbmdpbmUuc3VyZmNvbmV4dC5ubCAyMDE0MDUwNTAeFw0xNDA1MDUxNDIyMzVa\r\nFw0xOTA1MDUxNDIyMzVaMIGFMQswCQYDVQQGEwJOTDEQMA4GA1UECAwHVXRyZWNo\r\ndDEQMA4GA1UEBwwHVXRyZWNodDEVMBMGA1UECgwMU1VSRm5ldCBCLlYuMRMwEQYD\r\nVQQLDApTVVJGY29uZXh0MSYwJAYDVQQDDB1lbmdpbmUuc3VyZmNvbmV4dC5ubCAy\r\nMDE0MDUwNTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKthMDbB0jKH\r\nefPzmRu9t2h7iLP4wAXr42bHpjzTEk6gttHFb4l\/hFiz1YBI88TjiH6hVjnozo\/Y\r\nHA2c51us+Y7g0XoS7653lbUN\/EHzvDMuyis4Xi2Ijf1A\/OUQfH1iFUWttIgtWK9+\r\nfatXoGUS6tirQvrzVh6ZstEp1xbpo1SF6UoVl+fh7tM81qz+Crr\/Kroan0UjpZOF\r\nTwxPoK6fdLgMAieKSCRmBGpbJHbQ2xxbdykBBrBbdfzIX4CDepfjE9h\/40ldw5jR\r\nn3e392jrS6htk23N9BWWrpBT5QCk0kH3h\/6F1Dm6TkyG9CDtt73\/anuRkvXbeygI\r\n4wml9bL3rE8CAwEAAaNQME4wHQYDVR0OBBYEFD+Ac7akFxaMhBQAjVfvgGfY8hNK\r\nMB8GA1UdIwQYMBaAFD+Ac7akFxaMhBQAjVfvgGfY8hNKMAwGA1UdEwQFMAMBAf8w\r\nDQYJKoZIhvcNAQELBQADggEBAC8L9D67CxIhGo5aGVu63WqRHBNOdo\/FAGI7LURD\r\nFeRmG5nRw\/VXzJLGJksh4FSkx7aPrxNWF1uFiDZ80EuYQuIv7bDLblK31ZEbdg1R\r\n9LgiZCdYSr464I7yXQY9o6FiNtSKZkQO8EsscJPPy\/Zp4uHAnADWACkOUHiCbcKi\r\nUUFu66dX0Wr\/v53Gekz487GgVRs8HEeT9MU1reBKRgdENR8PNg4rbQfLc3YQKLWK\r\n7yWnn\/RenjDpuCiePj8N8\/80tGgrNgK\/6fzM3zI18sSywnXLswxqDb\/J+jgVxnQ6\r\nMrsTf1urM8MnfcxG\/82oHIwfMh\/sXPCZpo+DTLkhQxctJ3M=",
+      "contacts:0:contactType": "support",
+      "contacts:0:givenName": "SURFconext",
+      "contacts:0:surName": "Helpdesk",
+      "contacts:0:emailAddress": "help@surfconext.nl",
+      "contacts:1:contactType": "administrative",
+      "contacts:1:givenName": "SURFconext",
+      "contacts:1:surName": "Administrative Contact",
+      "contacts:1:emailAddress": "support@surfconext.nl",
+      "contacts:2:contactType": "technical",
+      "contacts:2:givenName": "SURFconext",
+      "contacts:2:surName": "Technical Support",
+      "contacts:2:emailAddress": "support@surfconext.nl",
+      "OrganizationName:en": "SURFnet BV",
+      "OrganizationDisplayName:en": "SURFnet",
+      "OrganizationURL:en": "http:\/\/www.surfnet.nl\/en\/Pages\/default.aspx",
+      "OrganizationName:nl": "SURFnet BV",
+      "OrganizationDisplayName:nl": "SURFnet",
+      "OrganizationURL:nl": "http:\/\/www.surfnet.nl\/nl\/Pages\/default.aspx",
+      "coin:service_team_id": "team-2",
+      "coin:original_metadata_url": "https:\/\/engine.surfconext.nl\/authentication\/sp\/metadata",
+      "coin:exclude_from_push": "0",
+      "logo:0:url": "https:\/\/static.surfconext.nl\/media\/idp\/surfnet.png",
+      "logo:0:width": "200",
+      "logo:0:height": "160"
+    },
+    "eid": 31
+  }
+}

--- a/tests/unit/Infrastructure/Manage/Service/ManageQueryServiceTest.php
+++ b/tests/unit/Infrastructure/Manage/Service/ManageQueryServiceTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Copyright 2020 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\Manage\Service;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery\Mock;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\InvalidArgumentException;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Service\MangeQueryService;
+
+class ManageQueryServiceTest extends MockeryTestCase
+{
+    private $queryService;
+    /**
+     * @var Mock&QueryClient
+     */
+    private $testClient;
+    /**
+     * @var Mock&QueryClient
+     */
+    private $productionClient;
+
+    protected function setUp(): void
+    {
+        $this->testClient = m::mock(QueryClient::class);
+        $this->productionClient = m::mock(QueryClient::class);
+        $this->queryService = new MangeQueryService($this->testClient, $this->productionClient);
+    }
+
+    public function test_calling_find_method_on_service_on_test_client()
+    {
+        $this->testClient
+            ->shouldReceive('findByManageId')
+            ->with('my-manage-id')
+            ->once();
+
+        $this->queryService
+            ->findByManageId('test', 'my-manage-id');
+    }
+    public function test_calling_find_method_on_service_on_prod_client()
+    {
+        $this->productionClient
+            ->shouldReceive('findByManageId')
+            ->with('my-manage-id')
+            ->once();
+
+        $this->queryService
+            ->findByManageId('production', 'my-manage-id');
+    }
+
+    public function test_method_calling_without_setting_mode()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Please set the query mode to one of these environments (test, production)');
+        $this->queryService->findByManageId('prod', 'my-manage-id');
+    }
+}


### PR DESCRIPTION
The main purpose of this PR is to ensure we do not override the exclude from push setting in Manage once an entity is included for push in production mode.

In addition, related files that where touched during investigation have been cleaned up.

Finally boyscout work was done, and a ManageQueryService was introduced. This service is not implemented thorugout yet, but is used to prevent the double injection of the manage test/prod query clients.