### PR TITLE
Reposition the contact information popup balloon

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detailContactField.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detailContactField.html.twig
@@ -1,13 +1,13 @@
 {% if value is not empty %}
 <h3>{{ label }}</h3>
-{% if informationPopup is defined %}
-    <span title="{{ informationPopup|trans }}" class="help-button">
-        <i class="fa fa-question-circle"></i>
-    </span>
-{% endif %}
 <div class="container contact">
     {% if value.firstName is not empty %}
     <div class="detail">
+        {% if informationPopup is defined %}
+            <span title="{{ informationPopup|trans }}" class="help-button">
+                <i class="fa fa-question-circle"></i>
+            </span>
+        {% endif %}
         <label>{{ 'entity.detail.contact.first_name'|trans }}</label>
         <span>{{ value.firstName }}</span>
     </div>

--- a/tests/webtests/EntityDetailTest.php
+++ b/tests/webtests/EntityDetailTest.php
@@ -43,7 +43,7 @@ class EntityDetailTest extends WebTestCase
 
         $this->assertDetailEquals(0, 'Entity ID', 'SP1');
         $this->assertDetailEquals(1, 'Name EN', 'SP1');
-        $this->assertDetailEquals(2, 'First name', 'John', false);
+        $this->assertDetailEquals(2, 'First name', 'John', true);
         $this->assertDetailEquals(3, 'Last name', 'Doe', false);
     }
 
@@ -104,7 +104,7 @@ class EntityDetailTest extends WebTestCase
 
         $this->assertDetailEquals(0, 'Entity ID', 'SP3');
         $this->assertDetailEquals(1, 'Name EN', 'SP3');
-        $this->assertDetailEquals(2, 'First name', 'Test', false);
+        $this->assertDetailEquals(2, 'First name', 'Test', true);
         $this->assertDetailEquals(3, 'Last name', 'Test', false);
     }
 


### PR DESCRIPTION
This balloon was previously situated on the top right. They are now
displayed nest to the first name attribute value.

https://www.pivotaltracker.com/story/show/172048805