### PR TITLE
Prevent overwriting of ARP motivations

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
@@ -87,6 +87,9 @@ class ArpGenerator implements MetadataGenerator
                             'value' => $manageAttribute->getValue(),
                         ]
                     ];
+                    if (!empty($manageAttribute->getMotivation())) {
+                        $attributes[$manageAttribute->getName()][0]['motivation'] = $manageAttribute->getMotivation();
+                    }
                 }
             }
         }

--- a/tests/unit/Application/Metadata/JsonGenerator/ArpGeneratorTest.php
+++ b/tests/unit/Application/Metadata/JsonGenerator/ArpGeneratorTest.php
@@ -136,6 +136,8 @@ class ArpGeneratorTest extends MockeryTestCase
             ->andReturn('idp');
         $attribute->shouldReceive('getValue')
             ->andReturn('The Manage attr value');
+        $attribute->shouldReceive('getMotivation')
+            ->andReturn('The Manage motivation');
         return $attribute;
     }
 }


### PR DESCRIPTION
The arp motivation would be overwritten when a arp motivations was set in manage for one of the attributes not managed in SPD. This is solved  by checking for the presence of an attribute motivation. If there is a non empty value, it is loaded on the attrbibute. Preventing overwriting
that specific attr. motivation. 

**Merge targets:**
 - `develop`
 - `release/2.5`

See: [Pivoal reject message](https://www.pivotaltracker.com/story/show/170868465/comments/214384755)