### PR TITLE
Reuse scope attribute, preventing overwriting them

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Dto/MetadataConversionDto.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Dto/MetadataConversionDto.php
@@ -561,4 +561,12 @@ class MetadataConversionDto
     {
         return $this->manageEntity->isExcludedFromPush();
     }
+
+    /**
+     * @return array
+     */
+    public function getScopes()
+    {
+        return $this->manageEntity->getOidcClient()->getScope();
+    }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
@@ -216,8 +216,14 @@ class OidcngJsonGenerator implements GeneratorInterface
 
         $metadata['NameIDFormat'] = $entity->getNameIdFormat();
 
-        // Will become configurable some time in the future.
-        $metadata['scopes'] = ['openid'];
+        // If the entity exists in Manage, use the scopes configured there.
+        if ($entity->isManageEntity()) {
+            // This prevents overwriting the scopes attribute. See: https://www.pivotaltracker.com/story/show/170868465
+            $metadata['scopes'] = $entity->getScopes();
+        } else {
+            // Will become configurable some time in the future.
+            $metadata['scopes'] = ['openid'];
+        }
 
         // When publishing to production, the coin:exclude_from_push must be present and set to '1'. This prevents the
         // entity from being pushed to engineblock.


### PR DESCRIPTION
When scopes are configured in Manage, SPD would overwrite them with the hardcoded 'openid' setting. This is prevented by using the Manage configured setting when an existing manage entity is edited (re-published).

**Merge targets**
 - Develop
- Release 2.5

https://www.pivotaltracker.com/story/show/170868465/comments/214384755