### PR TITLE
Only preserve the exclude-from-push flag on client secret reset

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
@@ -225,6 +225,12 @@ class OidcngJsonGenerator implements GeneratorInterface
             $metadata['coin:exclude_from_push'] = '1';
         }
 
+        // When dealing with a client secret reset, keep the current exclude from push state.
+        $secret = $entity->getClientSecret();
+        if ($secret && $entity->isManageEntity() && !$entity->isExcludedFromPush()) {
+            $metadata['coin:exclude_from_push'] = '0';
+        }
+
         $metadata += $this->generateOidcClient($entity);
 
         if (!empty($entity->getLogoUrl())) {

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
@@ -194,6 +194,12 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
             $metadata['coin:exclude_from_push'] = '1';
         }
 
+        // When dealing with a client secret reset, keep the current exclude from push state.
+        $secret = $entity->getClientSecret();
+        if ($secret && $entity->isManageEntity() && !$entity->isExcludedFromPush()) {
+            $metadata['coin:exclude_from_push'] = '0';
+        }
+
         $metadata += $this->generateOidcClient($entity);
 
         return $metadata;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Dto/Coin.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Dto/Coin.php
@@ -43,7 +43,7 @@ class Coin
         $eula = isset($metaDataFields['coin:eula'])
             ? $metaDataFields['coin:eula'] : '';
         $excludeFromPush = isset($metaDataFields['coin:exclude_from_push'])
-            ? (int) $metaDataFields['coin:exclude_from_push'] : 0;
+            ? (int) $metaDataFields['coin:exclude_from_push'] : null;
         $oidcClient = isset($metaDataFields['coin:oidc_client'])
             ? (int) $metaDataFields['coin:oidc_client'] : 0;
 
@@ -52,7 +52,7 @@ class Coin
         Assert::string($originalMetadataUrl);
         Assert::string($applicationUrl);
         Assert::string($eula);
-        Assert::integer($excludeFromPush);
+        Assert::nullOrIntegerish($excludeFromPush);
         Assert::integer($oidcClient);
 
         return new self(

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Dto/ManageEntity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Dto/ManageEntity.php
@@ -169,6 +169,9 @@ class ManageEntity
 
     public function isExcludedFromPush()
     {
+        if (is_null($this->getMetaData()->getCoin()->getExcludeFromPush())) {
+            return true;
+        }
         return $this->getMetaData()->getCoin()->getExcludeFromPush() == 1 ? true : false;
     }
 }


### PR DESCRIPTION
Only preserve the exclude from push flag when a client secret reset is performed. In all other cases, the flag is reset to be excluded from push

**Merge targets**
 - release/2.5
 - develop

https://www.pivotaltracker.com/story/show/171313433/comments/214387155