### PR TITLE
Remove assignee and reporter from Jira config

### DIFF
--- a/ansible/roles/spdashboard/defaults/main.yml
+++ b/ansible/roles/spdashboard/defaults/main.yml
@@ -22,9 +22,7 @@ spdashboard_nodejs_rpm_url: "https://rpm.nodesource.com/pub_11.x/el/7/x86_64/nod
 spdashboard_jira_host: https://jira-test.surfnet.nl
 spdashboard_jira_username: username
 spdashboard_jira_password: password
-spdashboard_jira_issue_assignee: sp-dashboard
 spdashboard_jira_issue_priority: Medium
-spdashboard_jira_issue_reporter: sp-dashboard
 spdashboard_jira_issue_type: spd-delete-production-entity
 spdashboard_jira_issue_type_publication_request: spd-request-production-entity
 spdashboard_jira_entityid_fieldname: customfield_12914

--- a/ansible/roles/spdashboard/templates/parameters.yml.j2
+++ b/ansible/roles/spdashboard/templates/parameters.yml.j2
@@ -42,9 +42,7 @@ parameters:
     jira_host: {{ spdashboard_jira_host }}
     jira_username: {{ spdashboard_jira_username }}
     jira_password: {{ spdashboard_jira_password }}
-    jira_issue_assignee: {{ spdashboard_jira_assignee }}
     jira_issue_priority: {{ spdashboard_jira_issue_priority }}
-    jira_issue_reporter: {{ spdashboard_jira_issue_reporter }}
     jira_issue_type: {{ spdashboard_jira_issue_type }}
     jira_issue_type_publication_request: {{ spdashboard_jira_issue_type_publication_request }}
     jira_issue_entityid_fieldname: {{ spdashboard_jira_entityid_fieldname }}

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -72,9 +72,7 @@ parameters:
     jira_test_mode_storage_path: '../var/issues.json'
 
     # Jira default issue settings
-    jira_issue_assignee: conext-beheer
     jira_issue_priority: Medium
-    jira_issue_reporter: sp-dashboard
     jira_issue_type: spd-delete-production-entity
     jira_issue_type_publication_request: spd-request-production-entity
     jira_issue_entityid_fieldname: customfield_13018

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -436,12 +436,10 @@ services:
 
     Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Factory\IssueFieldFactory:
         arguments:
-            - '%jira_issue_assignee%'
             - '%jira_issue_entityid_fieldname%'
             - '%jira_issue_manageid_fieldname%'
             - '%jira_issue_priority%'
             - '%jira_issue_project_key%'
-            - '%jira_issue_reporter%'
 
     Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Factory\JiraServiceFactory:
         arguments:

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Factory/IssueFieldFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Factory/IssueFieldFactory.php
@@ -26,12 +26,6 @@ use Webmozart\Assert\Assert;
 class IssueFieldFactory
 {
     /**
-    /**
-     * @var string
-     */
-    private $assignee;
-
-    /**
      * @var string
      */
     private $entityIdFieldName;
@@ -52,34 +46,24 @@ class IssueFieldFactory
     private $projectKey;
 
     /**
-     * @var string
-     */
-    private $reporter;
-
-    /**
      * @var TranslatorInterface
      */
     private $translator;
 
     /**
-     * @param string $assignee
      * @param string $entityIdFieldName
      * @param string $manageIdFieldName
      * @param string $priority
      * @param string $projectKey
-     * @param string $reporter
      * @param TranslatorInterface $translator
      */
     public function __construct(
-        $assignee,
         $entityIdFieldName,
         $manageIdFieldName,
         $priority,
         $projectKey,
-        $reporter,
         TranslatorInterface $translator
     ) {
-        Assert::stringNotEmpty($assignee, 'The assignee may not be empty, configure in parameters.yml');
         Assert::stringNotEmpty(
             $entityIdFieldName,
             'The entity id field name may not be empty, configure in parameters.yml'
@@ -90,14 +74,11 @@ class IssueFieldFactory
         );
         Assert::stringNotEmpty($priority, 'The priority may not be empty, configure in parameters.yml');
         Assert::stringNotEmpty($projectKey, 'The project key may not be empty, configure in parameters.yml');
-        Assert::stringNotEmpty($reporter, 'The reporter may not be empty, configure in parameters.yml');
 
-        $this->assignee = $assignee;
         $this->entityIdFieldName = $entityIdFieldName;
         $this->manageIdFieldName = $manageIdFieldName;
         $this->priority = $priority;
         $this->projectKey = $projectKey;
-        $this->reporter = $reporter;
         $this->translator = $translator;
     }
 
@@ -109,8 +90,6 @@ class IssueFieldFactory
             ->setSummary($this->translateSummary($ticket))
             ->setIssueType($ticket->getIssueType())
             ->setPriorityName($this->priority)
-            ->setAssigneeName($this->assignee)
-            ->setReporterName($this->reporter)
             ->addCustomField($this->entityIdFieldName, $ticket->getEntityId())
             ->addCustomField($this->manageIdFieldName, $ticket->getManageId())
         ;

--- a/tests/unit/Infrastructure/Jira/Factory/IssueFieldFactoryTest.php
+++ b/tests/unit/Infrastructure/Jira/Factory/IssueFieldFactoryTest.php
@@ -40,12 +40,10 @@ class IssueFieldFactoryTest extends TestCase
     {
         $this->translator = m::mock(TranslatorInterface::class);
         $this->factory = new IssueFieldFactory(
-            'Jane Doe',
             'customfield_10107',
             'customfield_10108',
             'Critical',
             'SPD',
-            'John Doe',
             $this->translator
         );
     }
@@ -86,11 +84,9 @@ class IssueFieldFactoryTest extends TestCase
 
         $this->assertEquals('Summary', $issueField->summary);
         $this->assertEquals('Description', $issueField->description);
-        $this->assertEquals('Jane Doe', $issueField->assignee->name);
         // The custom field is used for saving the entity id.
         $this->assertEquals('https://example.com', $issueField->customFields['customfield_10107']);
         $this->assertEquals('arbitrary-issue-type', $ticket->getIssueType());
         $this->assertEquals('Critical', $issueField->priority->name);
-        $this->assertEquals('John Doe', $issueField->reporter->name);
     }
 }


### PR DESCRIPTION
The reporter and assignee are not required. And hence are removed from
the IssueFieldFactory and the config it is based on.

See: https://www.pivotaltracker.com/story/show/167024021