### PR TITLE
Make secret generator url encode safe

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Secret.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Secret.php
@@ -24,8 +24,7 @@ class Secret
     /**
      * @var string
      */
-    private static $allowedChars = '0123456789abcdefghijklmnopqrstuvwxyz~!@#$%^&*_+=';
-    private static $requiredChars = '~!@#$%^&*_+=';
+    private static $allowedChars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
     /**
      * @var string
@@ -38,18 +37,16 @@ class Secret
      */
     public function __construct($length)
     {
-        if ($length < 8) {
-            throw new Exception('The secret length should be a value greater then 7');
+        if ($length < 20) {
+            throw new Exception('The secret length should be a value greater or equal to 20');
         }
-        do {
-            $this->secret = '';
-            $nofAllowedChars = strlen(self::$allowedChars) - 1;
-            for ($pos = 0; $pos < $length; $pos++) {
-                $i = random_int(0, $nofAllowedChars);
-                $char = self::$allowedChars[$i];
-                $this->secret .= $char;
-            }
-        } while (!$this->isValid($this->secret));
+        $this->secret = '';
+        $nofAllowedChars = strlen(self::$allowedChars) - 1;
+        for ($pos = 0; $pos < $length; $pos++) {
+            $i = random_int(0, $nofAllowedChars);
+            $char = self::$allowedChars[$i];
+            $this->secret .= $char;
+        }
     }
 
     /**
@@ -58,18 +55,5 @@ class Secret
     public function getSecret()
     {
         return $this->secret;
-    }
-
-    /**
-     * @param string $secret
-     * @return bool
-     */
-    private function isValid($secret)
-    {
-        if (strpbrk($secret, self::$requiredChars) !== false) {
-            return true;
-        }
-
-        return false;
     }
 }

--- a/tests/unit/Domain/ValueObject/SecretTest.php
+++ b/tests/unit/Domain/ValueObject/SecretTest.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Domain\ValueObject;
 
+use Exception;
 use PHPUnit\Framework\TestCase;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Secret;
 
@@ -29,35 +30,25 @@ class SecretTest extends TestCase
 
         $this->assertEquals(20, strlen($secret->getSecret()));
 
-        // The charlist should match characters in Secret::$requiredChars
-        $this->assertNotFalse(strpbrk($secret->getSecret(), '~!@#$%^&*_+='));
+        $this->assertNotFalse(strpbrk($secret->getSecret(), '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage The secret length should be a value greater then 7
-     */
     public function test_secret_generation_with_length_of_0_should_fail()
     {
-        $secret = new Secret(0);
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('The secret length should be a value greater or equal to 20');
+        new Secret(0);
+    }
+    public function test_secret_generation_with_length_of_19_should_fail()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('The secret length should be a value greater or equal to 20');
+        new Secret(19);
     }
 
-
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage The secret length should be a value greater then 7
-     */
-    public function test_secret_generation_with_length_of_7_should_fail()
+    public function test_secret_generation_with_length_of_20_should_succeed()
     {
-        $secret = new Secret(7);
-    }
-
-    public function test_secret_generation_with_length_of_8_should_succeed()
-    {
-        $secret = new Secret(8);
-
-        // The charlist should match characters in Secret::$requiredChars
-        $this->assertNotFalse(strpbrk($secret->getSecret(), '~!@#$%^&*_+='));
+        $secret = new Secret(20);
 
         $this->assertInstanceOf(Secret::class, $secret);
     }


### PR DESCRIPTION
The special characters have been removed from the client secret generator. And uppercase characters have been added to the list of allowed characters. The list of required chars (which where the special chars) have been removed. Making the constructor slightly less complex.

https://www.pivotaltracker.com/story/show/170892653