### PR TITLE
Interpret missing exclude from push correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,6 @@ branches:
   only:
     - develop
     - master
-    - feature/php72-support
+    - /^feature\/(.*)$/
+    - /^bugfix\/(.*)$/
+    - /^release\/(.*)$/

--- a/src/Surfnet/ServiceProviderDashboard/Application/Dto/MetadataConversionDto.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Dto/MetadataConversionDto.php
@@ -562,6 +562,11 @@ class MetadataConversionDto
         return $this->manageEntity->isExcludedFromPush();
     }
 
+    public function isExcludedFromPushSet()
+    {
+        return $this->manageEntity->isExcludedFromPushSet();
+    }
+
     /**
      * @return array
      */

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
@@ -225,24 +225,7 @@ class OidcngJsonGenerator implements GeneratorInterface
             $metadata['scopes'] = ['openid'];
         }
 
-        // Scenario 1: When publishing to production, the coin:exclude_from_push must be present and set to '1'.
-        // This prevents the entity from being pushed to EngineBlock.
-        if ($entity->isProduction()) {
-            $metadata['coin:exclude_from_push'] = '1';
-        }
-
-        // Scenario 2: When dealing with a client secret reset, keep the current exclude from push state.
-        $secret = $entity->getClientSecret();
-        if ($secret && $entity->isManageEntity() && !$entity->isExcludedFromPush()) {
-            $metadata['coin:exclude_from_push'] = '0';
-        }
-
-        // Scenario 3: We are resetting the client secret, the service desk removed the exclude from push coin
-        // attribute. This also indicates the entity is published. But now we do not want to reset the coin to '0', we
-        // simply unset it.
-        if ($secret && $entity->isManageEntity() && !$entity->isExcludedFromPushSet()) {
-            unset($metadata['coin:exclude_from_push']);
-        }
+        $this->setExcludeFromPush($metadata, $entity);
 
         $metadata += $this->generateOidcClient($entity);
 
@@ -432,5 +415,27 @@ class OidcngJsonGenerator implements GeneratorInterface
         return [
             'allowedResourceServers' => $allowedResourceServers,
         ];
+    }
+
+    private function setExcludeFromPush(&$metadata, MetadataConversionDto $entity)
+    {
+        // Scenario 1: When publishing to production, the coin:exclude_from_push must be present and set to '1'.
+        // This prevents the entity from being pushed to EngineBlock.
+        if ($entity->isProduction()) {
+            $metadata['coin:exclude_from_push'] = '1';
+        }
+
+        // Scenario 2: When dealing with a client secret reset, keep the current exclude from push state.
+        $secret = $entity->getClientSecret();
+        if ($secret && $entity->isManageEntity() && !$entity->isExcludedFromPush()) {
+            $metadata['coin:exclude_from_push'] = '0';
+        }
+
+        // Scenario 3: We are resetting the client secret, the service desk removed the exclude from push coin
+        // attribute. This also indicates the entity is published. But now we do not want to reset the coin to '0', we
+        // simply unset it.
+        if ($secret && $entity->isManageEntity() && !$entity->isExcludedFromPushSet()) {
+            unset($metadata['coin:exclude_from_push']);
+        }
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
@@ -225,16 +225,23 @@ class OidcngJsonGenerator implements GeneratorInterface
             $metadata['scopes'] = ['openid'];
         }
 
-        // When publishing to production, the coin:exclude_from_push must be present and set to '1'. This prevents the
-        // entity from being pushed to engineblock.
+        // Scenario 1: When publishing to production, the coin:exclude_from_push must be present and set to '1'.
+        // This prevents the entity from being pushed to EngineBlock.
         if ($entity->isProduction()) {
             $metadata['coin:exclude_from_push'] = '1';
         }
 
-        // When dealing with a client secret reset, keep the current exclude from push state.
+        // Scenario 2: When dealing with a client secret reset, keep the current exclude from push state.
         $secret = $entity->getClientSecret();
         if ($secret && $entity->isManageEntity() && !$entity->isExcludedFromPush()) {
             $metadata['coin:exclude_from_push'] = '0';
+        }
+
+        // Scenario 3: We are resetting the client secret, the service desk removed the exclude from push coin
+        // attribute. This also indicates the entity is published. But now we do not want to reset the coin to '0', we
+        // simply unset it.
+        if ($secret && $entity->isManageEntity() && !$entity->isExcludedFromPushSet()) {
+            unset($metadata['coin:exclude_from_push']);
         }
 
         $metadata += $this->generateOidcClient($entity);

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
@@ -188,24 +188,7 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
         // Will become configurable some time in the future.
         $metadata['scopes'] = ['openid'];
 
-        // Scenario 1: When publishing to production, the coin:exclude_from_push must be present and set to '1'.
-        // This prevents the entity from being pushed to EngineBlock.
-        if ($entity->isProduction()) {
-            $metadata['coin:exclude_from_push'] = '1';
-        }
-
-        // Scenario 2: When dealing with a client secret reset, keep the current exclude from push state.
-        $secret = $entity->getClientSecret();
-        if ($secret && $entity->isManageEntity() && !$entity->isExcludedFromPush()) {
-            $metadata['coin:exclude_from_push'] = '0';
-        }
-
-        // Scenario 3: We are resetting the client secret, the service desk removed the exclude from push coin
-        // attribute. This also indicates the entity is published. But now we do not want to reset the coin to '0', we
-        // simply unset it.
-        if ($secret && $entity->isManageEntity() && !$entity->isExcludedFromPushSet()) {
-            unset($metadata['coin:exclude_from_push']);
-        }
+        $this->setExcludeFromPush($metadata, $entity);
 
         $metadata += $this->generateOidcClient($entity);
 
@@ -331,5 +314,27 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
             'allowedEntities' => $providers,
             'allowedall' => false,
         ];
+    }
+
+    private function setExcludeFromPush(&$metadata, MetadataConversionDto $entity)
+    {
+        // Scenario 1: When publishing to production, the coin:exclude_from_push must be present and set to '1'.
+        // This prevents the entity from being pushed to EngineBlock.
+        if ($entity->isProduction()) {
+            $metadata['coin:exclude_from_push'] = '1';
+        }
+
+        // Scenario 2: When dealing with a client secret reset, keep the current exclude from push state.
+        $secret = $entity->getClientSecret();
+        if ($secret && $entity->isManageEntity() && !$entity->isExcludedFromPush()) {
+            $metadata['coin:exclude_from_push'] = '0';
+        }
+
+        // Scenario 3: We are resetting the client secret, the service desk removed the exclude from push coin
+        // attribute. This also indicates the entity is published. But now we do not want to reset the coin to '0', we
+        // simply unset it.
+        if ($secret && $entity->isManageEntity() && !$entity->isExcludedFromPushSet()) {
+            unset($metadata['coin:exclude_from_push']);
+        }
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
@@ -188,16 +188,23 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
         // Will become configurable some time in the future.
         $metadata['scopes'] = ['openid'];
 
-        // When publishing to production, the coin:exclude_from_push must be present and set to '1'. This prevents the
-        // entity from being pushed to engineblock.
+        // Scenario 1: When publishing to production, the coin:exclude_from_push must be present and set to '1'.
+        // This prevents the entity from being pushed to EngineBlock.
         if ($entity->isProduction()) {
             $metadata['coin:exclude_from_push'] = '1';
         }
 
-        // When dealing with a client secret reset, keep the current exclude from push state.
+        // Scenario 2: When dealing with a client secret reset, keep the current exclude from push state.
         $secret = $entity->getClientSecret();
         if ($secret && $entity->isManageEntity() && !$entity->isExcludedFromPush()) {
             $metadata['coin:exclude_from_push'] = '0';
+        }
+
+        // Scenario 3: We are resetting the client secret, the service desk removed the exclude from push coin
+        // attribute. This also indicates the entity is published. But now we do not want to reset the coin to '0', we
+        // simply unset it.
+        if ($secret && $entity->isManageEntity() && !$entity->isExcludedFromPushSet()) {
+            unset($metadata['coin:exclude_from_push']);
         }
 
         $metadata += $this->generateOidcClient($entity);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Dto/ManageEntity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Dto/ManageEntity.php
@@ -167,10 +167,18 @@ class ManageEntity
         return false;
     }
 
+    public function isExcludedFromPushSet()
+    {
+        if (is_null($this->getMetaData()->getCoin()->getExcludeFromPush())) {
+            return false;
+        }
+        return true;
+    }
+
     public function isExcludedFromPush()
     {
         if (is_null($this->getMetaData()->getCoin()->getExcludeFromPush())) {
-            return true;
+            return false;
         }
         return $this->getMetaData()->getCoin()->getExcludeFromPush() == 1 ? true : false;
     }


### PR DESCRIPTION
When resetting a client secret on production and the exclude from push attribute is missing, this indicates we are dealing with a published attribute. As the service desk not unchecks the coin checkbox, but simply removes it.

This additional logic covers that (understandable) 'misbehavior' of that coin.

Merge targets:
- `release/2.5`
- `develop`

https://www.pivotaltracker.com/story/show/171313433/comments/214527925