### PR TITLE
Stop showing EPTI on detail views

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityDetail.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityDetail.php
@@ -189,11 +189,6 @@ class EntityDetail
     private $scopedAffiliationAttribute;
 
     /**
-     * @var Attribute
-     */
-    private $eduPersonTargetedIDAttribute;
-
-    /**
      * @var string
      */
     private $nameIdFormat;
@@ -315,7 +310,6 @@ class EntityDetail
         $entityDetail->preferredLanguageAttribute = $entity->getPreferredLanguageAttribute();
         $entityDetail->personalCodeAttribute = $entity->getPersonalCodeAttribute();
         $entityDetail->scopedAffiliationAttribute = $entity->getScopedAffiliationAttribute();
-        $entityDetail->eduPersonTargetedIDAttribute = $entity->getEduPersonTargetedIDAttribute();
         $entityDetail->nameIdFormat = $entity->getNameIdFormat();
         $entityDetail->organizationNameNl = $entity->getOrganizationNameNl();
         $entityDetail->organizationNameEn = $entity->getOrganizationNameEn();
@@ -568,14 +562,6 @@ class EntityDetail
     public function getScopedAffiliationAttribute()
     {
         return $this->scopedAffiliationAttribute;
-    }
-
-    /**
-     * @return Attribute
-     */
-    public function getEduPersonTargetedIDAttribute()
-    {
-        return $this->eduPersonTargetedIDAttribute;
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -105,7 +105,6 @@ entity:
         prefered_language: Preferred language attribute
         personal_code: Personal code attribute
         scoped_affiliation: Scoped affiliation attribute
-        edu_person_targetted_id: Edu person targeted ID attribute
       oidc:
         title: Attributes
         html: <strong>information about the attribute fields</strong>
@@ -123,7 +122,6 @@ entity:
         prefered_language: Preferred language attribute
         personal_code: Personal code attribute
         scoped_affiliation: Scoped affiliation attribute
-        edu_person_targetted_id: Edu person targeted ID attribute
       oidcng:
         title: Attributes
         html: <strong>information about the attribute fields</strong>
@@ -141,7 +139,6 @@ entity:
         prefered_language: Preferred language attribute
         personal_code: Personal code attribute
         scoped_affiliation: Scoped affiliation attribute
-        edu_person_targetted_id: Edu person targeted ID attribute
 entity.list.title: Entities of service '%serviceName%'
 entity.list.title_no_service_selected: No service selected
 entity.list.empty: There are no entities configured
@@ -408,7 +405,6 @@ entity.edit.information.oidcng.uidAttribute: Text should be set in web translati
 entity.edit.information.oidcng.preferredLanguageAttribute: Text should be set in web translations
 entity.edit.information.oidcng.personalCodeAttribute: Text should be set in web translations
 entity.edit.information.oidcng.scopedAffiliationAttribute: Text should be set in web translations
-entity.edit.information.oidcng.eduPersonTargetedIDAttribute: Text should be set in web translations
 entity.edit.information.comments: Text should be set in web translations
 entity.edit.information.nameIdFormat: Text should be set in web translations
 entity.edit.information.subjectType: Text should be set in web translations

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detail.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detail.html.twig
@@ -88,7 +88,6 @@
         {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.prefered_language')|trans, value: entity.preferredLanguageAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.preferredLanguageAttribute'} %}
         {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.personal_code')|trans, value: entity.personalCodeAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.personalCodeAttribute'} %}
         {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.scoped_affiliation')|trans, value: entity.scopedAffiliationAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.scopedAffiliationAttribute'} %}
-        {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.edu_person_targetted_id')|trans, value: entity.eduPersonTargetedIDAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.eduPersonTargetedIDAttribute'} %}
 
     </div>
 


### PR DESCRIPTION
When opening an oidccng entity, the ARP attributes are listed at the
bottom of the view. Here we also rendered the EPTI (edu person targetted
ID) used to transport the NameId. This is an internal attribute that
should not be displayed to the end user.

https://www.pivotaltracker.com/story/show/169916839