### PR TITLE
Push metadata on production secret reset

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/PushMetadataCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/PushMetadataCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Copyright 2020 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Command\Entity;
+
+use Surfnet\ServiceProviderDashboard\Application\Command\Command;
+
+class PushMetadataCommand implements Command
+{
+    private $targetEnvironment;
+
+    public function __construct($environment)
+    {
+        $this->targetEnvironment = $environment;
+    }
+
+    public function targetEnvironment()
+    {
+        return $this->targetEnvironment;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityTestCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityTestCommandHandler.php
@@ -27,7 +27,6 @@ use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityRepository;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\PublishEntityRepository;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\PublishMetadataException;
-use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\PushMetadataException;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 
 class PublishEntityTestCommandHandler implements CommandHandler
@@ -86,9 +85,6 @@ class PublishEntityTestCommandHandler implements CommandHandler
             $publishResponse = $this->publishClient->publish($entity);
 
             if (array_key_exists('id', $publishResponse)) {
-                $this->logger->info(sprintf('Pushing entity "%s" to engineblock', $entity->getNameNl()));
-                $this->publishClient->pushMetadata();
-
                 if ($this->isNewResourceServer($entity)) {
                     $this->flashBag->add('wysiwyg', 'entity.list.oidcng_connection.info.html');
                 }
@@ -102,9 +98,6 @@ class PublishEntityTestCommandHandler implements CommandHandler
                 )
             );
             $this->flashBag->add('error', 'entity.edit.error.publish');
-        } catch (PushMetadataException $e) {
-            $this->logger->error(sprintf('Pushing to Engineblock failed with message: "%s"', $e->getMessage()));
-            $this->flashBag->add('error', 'entity.edit.error.push');
         }
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PushMetadataCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PushMetadataCommandHandler.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Copyright 2020 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity;
+
+use Psr\Log\LoggerInterface;
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PushMetadataCommand;
+use Surfnet\ServiceProviderDashboard\Application\CommandHandler\CommandHandler;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\PushMetadataException;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Service\ManagePublishService;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+
+class PushMetadataCommandHandler implements CommandHandler
+{
+    /**
+     * @var ManagePublishService
+     */
+    private $publishService;
+
+    /**
+     * @var FlashBagInterface
+     */
+    private $flashBag;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        ManagePublishService $publishService,
+        FlashBagInterface $flashBag,
+        LoggerInterface $logger
+    ) {
+        $this->publishService = $publishService;
+        $this->flashBag = $flashBag;
+        $this->logger = $logger;
+    }
+
+    public function handle(PushMetadataCommand $command)
+    {
+        $this->logger->info(
+            sprintf(
+                'Pushing metadata to EngineBlock using the %s environment.',
+                $command->targetEnvironment()
+            )
+        );
+
+        try {
+            $this->publishService->pushMetadata($command->targetEnvironment());
+        } catch (PushMetadataException $e) {
+            $this->logger->error(sprintf('Pushing to EngineBlock failed with message: "%s"', $e->getMessage()));
+            $this->flashBag->add('error', 'entity.edit.error.push');
+        }
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/UpdateEntityAclCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/UpdateEntityAclCommandHandler.php
@@ -27,7 +27,6 @@ use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\PublishEntityRepository;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\ServiceRepository;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\PublishMetadataException;
-use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\PushMetadataException;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 
 class UpdateEntityAclCommandHandler implements CommandHandler
@@ -86,12 +85,7 @@ class UpdateEntityAclCommandHandler implements CommandHandler
         $entity->setIdpWhitelist($command->getSelected());
 
         try {
-            $publishResponse = $this->publishClient->publish($entity);
-
-            if (array_key_exists('id', $publishResponse)) {
-                $this->logger->info(sprintf('Pushing entity "%s" to engineblock', $entity->getNameNl()));
-                $this->publishClient->pushMetadata();
-            }
+            $this->publishClient->publish($entity);
         } catch (PublishMetadataException $e) {
             $this->logger->error(
                 sprintf(
@@ -101,9 +95,6 @@ class UpdateEntityAclCommandHandler implements CommandHandler
                 )
             );
             $this->flashBag->add('error', 'entity.edit.error.publish');
-        } catch (PushMetadataException $e) {
-            $this->logger->error(sprintf('Pushing to Engineblock failed with message: "%s"', $e->getMessage()));
-            $this->flashBag->add('error', 'entity.edit.error.push');
         }
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityAclController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityAclController.php
@@ -22,6 +22,7 @@ use League\Tactician\CommandBus;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PushMetadataCommand;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\UpdateEntityAclCommand;
 use Surfnet\ServiceProviderDashboard\Application\Service\EntityAclService;
 use Surfnet\ServiceProviderDashboard\Application\Service\EntityService;
@@ -92,6 +93,7 @@ class EntityAclController extends Controller
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
             $this->commandBus->handle($command);
+            $this->commandBus->handle(new PushMetadataCommand($entity->getEnvironment()));
         }
         $viewObject = EntityDetail::fromEntity($entity);
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityControllerTrait.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityControllerTrait.php
@@ -24,6 +24,7 @@ use Surfnet\ServiceProviderDashboard\Application\Command\Entity\DeleteDraftEntit
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\LoadMetadataCommand;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityProductionCommand;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityTestCommand;
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PushMetadataCommand;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveSamlEntityCommand;
 use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
 use Surfnet\ServiceProviderDashboard\Application\Service\LoadEntityService;
@@ -160,6 +161,9 @@ trait EntityControllerTrait
 
         try {
             $this->commandBus->handle($publishEntityCommand);
+            if ($entity->getEnvironment() === Entity::ENVIRONMENT_TEST) {
+                $this->commandBus->handle(new PushMetadataCommand(Entity::ENVIRONMENT_TEST));
+            }
         } catch (Exception $e) {
             $flashBag->add('error', 'entity.edit.error.publish');
         }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityControllerTrait.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityControllerTrait.php
@@ -161,14 +161,15 @@ trait EntityControllerTrait
 
         try {
             $this->commandBus->handle($publishEntityCommand);
-            if ($entity->getEnvironment() === Entity::ENVIRONMENT_TEST) {
-                $this->commandBus->handle(new PushMetadataCommand(Entity::ENVIRONMENT_TEST));
-            }
         } catch (Exception $e) {
             $flashBag->add('error', 'entity.edit.error.publish');
         }
 
         if (!$flashBag->has('error')) {
+            if ($entity->getEnvironment() === Entity::ENVIRONMENT_TEST) {
+                $this->commandBus->handle(new PushMetadataCommand(Entity::ENVIRONMENT_TEST));
+            }
+
             // A clone is saved in session temporarily, to be able to report which entity was removed on the reporting
             // page we will be redirecting to in a moment.
             $this->get('session')->set('published.entity.clone', clone $entity);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -383,7 +383,7 @@ services:
         - '@surfnet.manage.http.http_client.prod_environment'
 
     surfnet.manage.query_service:
-        class: Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Service\MangeQueryService
+        class: Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Service\ManageQueryService
         arguments:
             - '@Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient'
             - '@surfnet.manage.client.query_client.prod_environment'

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -128,6 +128,16 @@ services:
         tags:
             - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityProductionCommand }
 
+    surfnet.dashboard.command_handler.push_metadata:
+        class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\PushMetadataCommandHandler
+        arguments:
+            - '@surfnet.manage.publish_service'
+            - '@session.flash_bag'
+            - '@logger'
+        public: true
+        tags:
+            - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Entity\PushMetadataCommand }
+
     surfnet.dashboard.command_handler.update_entity_acl:
         class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\UpdateEntityAclCommandHandler
         arguments:

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -378,6 +378,12 @@ services:
             - '@Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient'
             - '@surfnet.manage.client.query_client.prod_environment'
 
+    surfnet.manage.publish_service:
+        class: Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Service\ManagePublishService
+        arguments:
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\PublishEntityClient'
+            - '@surfnet.manage.client.publish_client.prod_environment'
+
     Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Http\HttpClient:
         arguments:
             - '@surfnet.manage.http.guzzle.test_environment'

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/UniqueEntityIdValidator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/UniqueEntityIdValidator.php
@@ -24,14 +24,14 @@ use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngEntity
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngResourceServerEntityCommand;
 use Surfnet\ServiceProviderDashboard\Application\Parser\OidcngClientIdParser;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityRepository as DoctrineRepository;
-use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Service\MangeQueryService;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Service\ManageQueryService;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
 class UniqueEntityIdValidator extends ConstraintValidator
 {
     /**
-     * @var MangeQueryService
+     * @var ManageQueryService
      */
     private $queryService;
 
@@ -44,7 +44,7 @@ class UniqueEntityIdValidator extends ConstraintValidator
      * @param DoctrineRepository $doctrineRepository
      */
     public function __construct(
-        MangeQueryService $queryService,
+        ManageQueryService $queryService,
         DoctrineRepository $doctrineRepository
     ) {
         $this->queryService = $queryService;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Service/ManagePublishService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Service/ManagePublishService.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Copyright 2020 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Service;
+
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\PublishEntityClient;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\InvalidArgumentException;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\PublishMetadataException;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\PushMetadataException;
+
+class ManagePublishService
+{
+    private $validEnvironments = ['test', 'production'];
+
+    /**
+     * @var PublishEntityClient
+     */
+    private $testClient;
+
+    /**
+     * @var PublishEntityClient
+     */
+    private $productionClient;
+
+    public function __construct(PublishEntityClient $test, PublishEntityClient $production)
+    {
+        $this->testClient = $test;
+        $this->productionClient = $production;
+    }
+
+    /**
+     * @param string $environment
+     * @param Entity $entity
+     * @throws InvalidArgumentException
+     * @throws PublishMetadataException
+     */
+    public function publish($environment, Entity $entity)
+    {
+        $this->getClient($environment)->publish($entity);
+    }
+
+    /**
+     * @param $environment
+     * @throws InvalidArgumentException
+     * @throws PushMetadataException
+     */
+    public function pushMetadata($environment)
+    {
+        $this->getClient($environment)->pushMetadata();
+    }
+
+    private function getClient($environment)
+    {
+        if (!in_array($environment, $this->validEnvironments)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Please set the publication mode to one of these environments (%s)',
+                    implode(', ', $this->validEnvironments)
+                )
+            );
+        }
+        if ($environment === 'test') {
+            return $this->testClient;
+        }
+        return $this->productionClient;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Service/ManageQueryService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Service/ManageQueryService.php
@@ -21,7 +21,7 @@ namespace Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Service;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\InvalidArgumentException;
 
-class MangeQueryService
+class ManageQueryService
 {
     private $validEnvironments = ['test', 'production'];
 

--- a/tests/integration/Application/CommandHandler/Entity/PublishEntityTestCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/PublishEntityTestCommandHandlerTest.php
@@ -103,89 +103,27 @@ class PublishEntityTestCommandHandlerTest extends MockeryTestCase
 
         $this->logger
             ->shouldReceive('info')
-            ->times(2);
-
-        $this->client
-            ->shouldReceive('publish')
-            ->once()
-            ->with($entity)
-            ->andReturn([
-                'id' => 123,
-            ]);
-
-        $manageEntity = m::mock(ManageEntity::class);
-        $manageEntity
-            ->shouldReceive('getAllowedIdentityProviders->getAllowedIdentityProviders')
-            ->andReturn([]);
-        $manageEntity
-            ->shouldReceive('getAllowedIdentityProviders->isAllowAll')
-            ->andReturn(true);
-
-        $this->manageClient
-            ->shouldReceive('findByManageId')
-            ->andReturn($manageEntity);
-
-        $this->client
-            ->shouldReceive('pushMetadata')
-            ->once();
-
-        $command = new PublishEntityTestCommand('d6f394b2-08b1-4882-8b32-81688c15c489');
-        $this->commandHandler->handle($command);
-    }
-
-    public function test_it_handles_failing_push()
-    {
-        $entity = m::mock(Entity::class);
-        $entity
-            ->shouldReceive('getNameNl')
-            ->andReturn('Test Entity Name')
-            ->shouldReceive('getManageId')
-            ->shouldReceive('getProtocol')
-            ->shouldReceive('setIdpAllowAll')
-            ->shouldReceive('setIdpWhitelistRaw')
-            ->andReturn(Entity::TYPE_SAML);
-
-        $this->repository
-            ->shouldReceive('findById')
-            ->with('d6f394b2-08b1-4882-8b32-81688c15c489')
-            ->andReturn($entity);
-
-        $manageEntity = m::mock(ManageEntity::class);
-        $manageEntity
-            ->shouldReceive('getAllowedIdentityProviders->getAllowedIdentityProviders')
-            ->andReturn([]);
-        $manageEntity
-            ->shouldReceive('getAllowedIdentityProviders->isAllowAll')
-            ->andReturn(true);
-
-        $this->manageClient
-            ->shouldReceive('findByManageId')
-            ->andReturn($manageEntity);
-
-        $this->logger
-            ->shouldReceive('info')
-            ->times(2);
-
-        $this->client
-            ->shouldReceive('publish')
-            ->once()
-            ->with($entity)
-            ->andReturn([
-                'id' => 123,
-            ]);
-
-        $this->client
-            ->shouldReceive('pushMetadata')
-            ->once()
-            ->andThrow(PushMetadataException::class);
-
-        $this->logger
-            ->shouldReceive('error')
             ->times(1);
 
-        $this->flashBag
-            ->shouldReceive('add')
-            ->with('error', 'entity.edit.error.push');
+        $this->client
+            ->shouldReceive('publish')
+            ->once()
+            ->with($entity)
+            ->andReturn([
+                'id' => 123,
+            ]);
+
+        $manageEntity = m::mock(ManageEntity::class);
+        $manageEntity
+            ->shouldReceive('getAllowedIdentityProviders->getAllowedIdentityProviders')
+            ->andReturn([]);
+        $manageEntity
+            ->shouldReceive('getAllowedIdentityProviders->isAllowAll')
+            ->andReturn(true);
+
+        $this->manageClient
+            ->shouldReceive('findByManageId')
+            ->andReturn($manageEntity);
 
         $command = new PublishEntityTestCommand('d6f394b2-08b1-4882-8b32-81688c15c489');
         $this->commandHandler->handle($command);

--- a/tests/integration/Application/CommandHandler/Entity/PushMetadataCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/PushMetadataCommandHandlerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Copyright 2020 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Integration\Application\CommandHandler\Entity;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Psr\Log\LoggerInterface;
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PushMetadataCommand;
+use Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\PushMetadataCommandHandler;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\PushMetadataException;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Service\ManagePublishService;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+
+class PushMetadataCommandHandlerTest extends MockeryTestCase
+{
+    /**
+     * @var m\MockInterface&ManagePublishService
+     */
+    private $publishService;
+
+    /**
+     * @var m\MockInterface&LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var m\MockInterface&FlashBagInterface
+     */
+    private $flashBag;
+
+    /**
+     * @var PushMetadataCommandHandler
+     */
+    private $commandHandler;
+
+    public function setUp()
+    {
+        $this->publishService = m::mock(ManagePublishService::class);
+        $this->logger = m::mock(LoggerInterface::class);
+        $this->flashBag = m::mock(FlashBagInterface::class);
+
+        $this->commandHandler = new PushMetadataCommandHandler(
+            $this->publishService,
+            $this->flashBag,
+            $this->logger
+        );
+    }
+
+    public function test_pushing_entities()
+    {
+        $this->publishService->shouldReceive('pushMetadata');
+        $this->logger->shouldReceive('info')->with('Pushing metadata to EngineBlock using the test environment.');
+        $this->commandHandler->handle(new PushMetadataCommand('test'));
+    }
+
+    public function test_failed_push()
+    {
+        $e = new PushMetadataException('Foobar');
+        $this->publishService
+            ->shouldReceive('pushMetadata')
+            ->andThrow($e);
+
+        $this->logger->shouldReceive('info')->with('Pushing metadata to EngineBlock using the production environment.');
+        $this->logger->shouldReceive('error')->with('Pushing to EngineBlock failed with message: "Foobar"');
+        $this->flashBag->shouldReceive('add')->with('error', 'entity.edit.error.push');
+        $this->commandHandler->handle(new PushMetadataCommand('production'));
+    }
+}

--- a/tests/integration/Infrastructure/DashboardBundle/Validator/Constraints/UniqueEntityIdValidatorTest.php
+++ b/tests/integration/Infrastructure/DashboardBundle/Validator/Constraints/UniqueEntityIdValidatorTest.php
@@ -26,7 +26,7 @@ use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveSamlEntityCo
 use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityRepository;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\UniqueEntityId;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\UniqueEntityIdValidator;
-use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Service\MangeQueryService;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Service\ManageQueryService;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class UniqueEntityIdValidatorTest extends ConstraintValidatorTestCase
@@ -38,7 +38,7 @@ class UniqueEntityIdValidatorTest extends ConstraintValidatorTestCase
     private $repository;
 
     /**
-     * @var m\MockInterface&MangeQueryService
+     * @var m\MockInterface&ManageQueryService
      */
     private $queryService;
 
@@ -52,7 +52,7 @@ class UniqueEntityIdValidatorTest extends ConstraintValidatorTestCase
     {
         $this->repository = m::mock(EntityRepository::class);
 
-        $this->queryService = m::mock(MangeQueryService::class);
+        $this->queryService = m::mock(ManageQueryService::class);
 
         return new UniqueEntityIdValidator(
             $this->queryService,

--- a/tests/unit/Infrastructure/Manage/Service/ManagePublishServiceTest.php
+++ b/tests/unit/Infrastructure/Manage/Service/ManagePublishServiceTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Copyright 2020 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\Manage\Service;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery\Mock;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\PublishEntityClient;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\InvalidArgumentException;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Service\ManagePublishService;
+
+class ManagePublishServiceTest extends MockeryTestCase
+{
+    private $publishService;
+    /**
+     * @var Mock&PublishEntityClient
+     */
+    private $testClient;
+    /**
+     * @var Mock&PublishEntityClient
+     */
+    private $productionClient;
+
+    protected function setUp(): void
+    {
+        $this->testClient = m::mock(PublishEntityClient::class);
+        $this->productionClient = m::mock(PublishEntityClient::class);
+        $this->publishService = new ManagePublishService($this->testClient, $this->productionClient);
+    }
+
+    public function test_calling_publish_on_test_client()
+    {
+        $entity = m::mock(Entity::class);
+        $this->testClient
+            ->shouldReceive('publish')
+            ->with($entity)
+            ->once();
+
+        $this->publishService
+            ->publish('test', $entity);
+    }
+
+    public function test_calling_push_to_production()
+    {
+        $this->productionClient
+            ->shouldReceive('pushMetadata')
+            ->once();
+
+        $this->publishService
+            ->pushMetadata('production');
+    }
+
+    public function test_unknown_environment()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Please set the publication mode to one of these environments (test, production)');
+        $this->publishService->pushMetadata('ahkh-morpork');
+    }
+}

--- a/tests/unit/Infrastructure/Manage/Service/ManageQueryServiceTest.php
+++ b/tests/unit/Infrastructure/Manage/Service/ManageQueryServiceTest.php
@@ -23,7 +23,7 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Mock;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\InvalidArgumentException;
-use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Service\MangeQueryService;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Service\ManageQueryService;
 
 class ManageQueryServiceTest extends MockeryTestCase
 {
@@ -41,7 +41,7 @@ class ManageQueryServiceTest extends MockeryTestCase
     {
         $this->testClient = m::mock(QueryClient::class);
         $this->productionClient = m::mock(QueryClient::class);
-        $this->queryService = new MangeQueryService($this->testClient, $this->productionClient);
+        $this->queryService = new ManageQueryService($this->testClient, $this->productionClient);
     }
 
     public function test_calling_find_method_on_service_on_test_client()


### PR DESCRIPTION
This PR issues a metadata push after a production OIDC client secret reset action.

In order to make this possible I extracted the push logic from the existing publication command handlers. So some refactoring was required to get this task done. The first 5 commits cover the refactoring. And the final commit actually performs the metadata push after the secret reset.

__Warning:__
When functional testing this you will not actually be able to push the metadata from Manage prod to EngineBlock and the OIDCng proxy. The push will fail in Manage halfway. Metadata will have been pushed to Engine, but not to the not existing OIDC server. 

To fix your EngineBlock config after this task run:

`ANSIBLE_TAGS=vm_only_provision_manage_eb vagrant provision`

https://www.pivotaltracker.com/story/show/173009970