### PR TITLE
Do not overwrite source & value if set in Manage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.5.4
+**Feature**
+* Do not overwrite the source & value from an attribute if set in Manage #356
+* Push metadata to production after secret reset #355
+
 ## 2.5.3
 **Bugfix**
 * Remove excessive OIDCng RS ARP attribute translations #349

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
@@ -64,6 +64,14 @@ class ArpGenerator implements MetadataGenerator
                 if ($attr->hasMotivation()) {
                     $attributes[$urn][0]['motivation'] = $attr->getMotivation();
                 }
+
+                if ($entity->isManageEntity() && $entity->getArpAttributes()->findByUrn($urn)) {
+                    $manageAttribute = $entity->getArpAttributes()->findByUrn($urn);
+                    // If the source is set in Manage, do not overwrite the source with idp
+                    $attributes[$urn][0]['source'] = $manageAttribute->getSource();
+                    // If the filter value is set in Manage, do not overwrite it with '*' again
+                    $attributes[$urn][0]['value'] = $manageAttribute->getValue();
+                }
             }
         }
 


### PR DESCRIPTION
The source and value parts of ARP attributes where overidden to their
defaults even when set in Manage.

See: https://www.pivotaltracker.com/story/show/173030675