### PR TITLE
Make form labels normal casing

### DIFF
--- a/app/scss/excludes/forms.scss
+++ b/app/scss/excludes/forms.scss
@@ -7,7 +7,6 @@ h2 {
 }
 
 label {
-  text-transform: uppercase;
   color: $medium-grey;
   display: block;
 

--- a/app/scss/pages/service_edit.scss
+++ b/app/scss/pages/service_edit.scss
@@ -140,7 +140,6 @@ form {
       font-size: 100%;
       margin-bottom: 0;
       padding-bottom: 0;
-      text-transform: uppercase;
     }
   }
 


### PR DESCRIPTION
Previously they where all uppercased. By request, casing was changed to `normal`. 

Buttons and other UI elements are still uppercased. This was not part of the story to address those. Personally I like them uppercased to stand out a bit more.

https://www.pivotaltracker.com/story/show/169284607