### PR TITLE
Add composer to Ansible for installation

### DIFF
--- a/ansible/roles/spdashboard/tasks/spdashboardvm.yml
+++ b/ansible/roles/spdashboard/tasks/spdashboardvm.yml
@@ -6,6 +6,7 @@
       - gcc-c++
       - sqlite-devel
       - ant
+      - composer
     state: present
 
 - name: Install Mailcatcher


### PR DESCRIPTION
This is needed because this is removed from Deploy to
be always installed.