### PR TITLE
Prevent Jira ticket on prod client secret reset

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/PublishEntityProductionAfterClientResetCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/PublishEntityProductionAfterClientResetCommand.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2017 SURFnet B.V.
+ * Copyright 2020 SURFnet B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ use Surfnet\ServiceProviderDashboard\Application\Command\Command;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Symfony\Component\Validator\Constraints as Assert;
 
-class PublishEntityProductionCommand implements PublishProductionCommandInterface, Command
+class PublishEntityProductionAfterClientResetCommand implements PublishProductionCommandInterface, Command
 {
     /**
      * @var string
@@ -37,12 +37,13 @@ class PublishEntityProductionCommand implements PublishProductionCommandInterfac
     private $applicant;
 
     /**
-     * @param string $id
+     * @param $id
+     * @param Contact $applicant
      */
-    public function __construct($id, Contact $applicatant)
+    public function __construct($id, Contact $applicant)
     {
         $this->id = $id;
-        $this->applicant = $applicatant;
+        $this->applicant = $applicant;
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/PublishProductionCommandInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/PublishProductionCommandInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Copyright 2020 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Command\Entity;
+
+interface PublishProductionCommandInterface
+{
+    public function getId();
+
+    public function getApplicant();
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityControllerTrait.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityControllerTrait.php
@@ -22,6 +22,7 @@ use Exception;
 use League\Tactician\CommandBus;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\DeleteDraftEntityCommand;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\LoadMetadataCommand;
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityProductionAfterClientResetCommand;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityProductionCommand;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityTestCommand;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PushMetadataCommand;
@@ -137,9 +138,10 @@ trait EntityControllerTrait
     /**
      * @param Entity $entity
      * @param FlashBagInterface $flashBag
+     * @param bool $isClientReset
      * @return RedirectResponse|Form
      */
-    private function publishEntity(Entity $entity, FlashBagInterface $flashBag)
+    private function publishEntity(Entity $entity, FlashBagInterface $flashBag, $isClientReset = false)
     {
         if ($entity->isReadOnly()) {
             throw $this->createNotFoundException(
@@ -156,6 +158,12 @@ trait EntityControllerTrait
             case Entity::ENVIRONMENT_PRODUCTION:
                 $applicant = $this->authorizationService->getContact();
                 $publishEntityCommand = new PublishEntityProductionCommand($entity->getId(), $applicant);
+                if ($isClientReset) {
+                    $publishEntityCommand = new PublishEntityProductionAfterClientResetCommand(
+                        $entity->getId(),
+                        $applicant
+                    );
+                }
                 $destination = 'entity_published_production';
                 break;
             default:

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityResetSecretController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityResetSecretController.php
@@ -74,7 +74,7 @@ class EntityResetSecretController extends Controller
 
         // publish the entity
         $entity = $this->entityService->getEntityById($resetOidcSecretCommand->getId());
-        $response = $this->publishEntity($entity, $flashBag);
+        $response = $this->publishEntity($entity, $flashBag, true);
         if ($entity->getEnvironment() === Entity::ENVIRONMENT_PRODUCTION && !$manageEntity->isExcludedFromPush()) {
             // Push metadata (note that we also push to production manage upon client secret resets)
             // https://www.pivotaltracker.com/story/show/173009970

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -121,6 +121,7 @@ services:
         public: true
         tags:
             - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityProductionCommand }
+            - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityProductionAfterClientResetCommand }
 
     surfnet.dashboard.command_handler.push_metadata:
         class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\PushMetadataCommandHandler


### PR DESCRIPTION
When resetting the client secret, no need to create a new publication
request to the service desk Jira. The item probably is already
published. Adding the ticket twice is not expected behaviour.

https://www.pivotaltracker.com/story/show/173220529