### PR TITLE
Register required php extensions in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "type": "project",
     "autoload": {
         "psr-4": {
-           "Surfnet\\": "src/Surfnet"
+            "Surfnet\\": "src/Surfnet"
         },
         "classmap": [
             "app/AppKernel.php",
@@ -23,7 +23,13 @@
     },
     "require": {
         "php": "7.2.*",
+        "ext-curl": "*",
+        "ext-gd": "*",
         "ext-json": "*",
+        "ext-mbstring": "*",
+        "ext-mysqli": "*",
+        "ext-soap": "*",
+        "ext-xml": "*",
         "doctrine/dbal": "~2.5.12",
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/doctrine-cache-bundle": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b799e08a648982b2c679c98ce7d8fa49",
+    "content-hash": "3951c8247f3f9afb2b776caa3c01d31d",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -7501,7 +7501,13 @@
     "prefer-lowest": false,
     "platform": {
         "php": "7.2.*",
-        "ext-json": "*"
+        "ext-curl": "*",
+        "ext-gd": "*",
+        "ext-json": "*",
+        "ext-mbstring": "*",
+        "ext-mysqli": "*",
+        "ext-soap": "*",
+        "ext-xml": "*"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
During @quartje's Docker adventures he noted that the required php extensions are not explicitly required in the Composer config. 

This PR adds the required extensions to composer.json

https://www.pivotaltracker.com/story/show/173356684