### PR TITLE
Increase CSP strictness

### DIFF
--- a/ansible/roles/spdashboard/templates/spdashboard.conf.j2
+++ b/ansible/roles/spdashboard/templates/spdashboard.conf.j2
@@ -21,6 +21,14 @@ Listen {{ apache_app_listen_address.spdashboard }}:{{ loadbalancing.spdashboard.
         RewriteRule ^(.*)$ {{ front_controller }} [QSA,L]
     </Directory>
 
+    <IfModule mod_headers.c>
+        <If "%{THE_REQUEST} =~ /translations/">
+            Header always unset X-Content-Security-Policy
+            Header always unset Content-Security-Policy
+            Header always set Content-Security-Policy "default-src 'self'; block-all-mixed-content; font-src 'self' netdna.bootstrapcdn.com; object-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' ajax.googleapis.com; style-src 'self' netdna.bootstrapcdn.com 'unsafe-inline'; upgrade-insecure-requests; report-uri /csp/report"
+        </If>
+    </IfModule>
+
 {% if apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -73,14 +73,11 @@ nelmio_security:
                 - 'none'
             style-src:
                 - 'self'
-                - 'netdna.bootstrapcdn.com'
                 - 'unsafe-inline'
             script-src:
                 - 'self'
-                - 'ajax.googleapis.com'
             font-src:
                 - 'self'
-                - 'netdna.bootstrapcdn.com'
             block-all-mixed-content: true # defaults to false, blocks HTTP content over HTTPS transport
             upgrade-insecure-requests: true # defaults to false, upgrades HTTP requests to HTTPS transport
     content_type:

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -73,7 +73,6 @@ nelmio_security:
                 - 'none'
             style-src:
                 - 'self'
-                - 'unsafe-inline'
             script-src:
                 - 'self'
             font-src:

--- a/app/js/components/service_status.ts
+++ b/app/js/components/service_status.ts
@@ -136,6 +136,8 @@ export class ServiceStatus {
       tooltipEl.style.top = `${position.top + window.pageYOffset + tooltipModel.caretY}px`;
     };
 
+    Chart.platform.disableCSSInjection = true;
+
     const options: Chart.ChartConfiguration = {
       type: 'doughnut',
       data: {

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -133,16 +133,6 @@ services:
         tags:
             - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Entity\PushMetadataCommand }
 
-    surfnet.dashboard.command_handler.push_metadata:
-        class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\PushMetadataCommandHandler
-        arguments:
-            - '@surfnet.manage.publish_service'
-            - '@session.flash_bag'
-            - '@logger'
-        public: true
-        tags:
-            - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Entity\PushMetadataCommand }
-
     surfnet.dashboard.command_handler.update_entity_acl:
         class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\UpdateEntityAclCommandHandler
         arguments:

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -407,7 +407,6 @@ entity.edit.information.oidcng.uidAttribute: Text should be set in web translati
 entity.edit.information.oidcng.preferredLanguageAttribute: Text should be set in web translations
 entity.edit.information.oidcng.personalCodeAttribute: Text should be set in web translations
 entity.edit.information.oidcng.scopedAffiliationAttribute: Text should be set in web translations
-entity.edit.information.oidcng.eduPersonTargetedIDAttribute: Text should be set in web translations
 entity.edit.information.comments: Text should be set in web translations
 entity.edit.information.nameIdFormat: Text should be set in web translations
 entity.edit.information.subjectType: Text should be set in web translations


### PR DESCRIPTION
Remove unwanted CSP settings that where explicitly added for the translations section of SPD. They are now overloaded in the Apache config. As Nelmio does not provide a means to override CSP config per page/path.

To get this into an existing dev-env. Please update the contents of your `/etc/httpd/conf.d/spdashboard.conf` with the contents of the Jinja template found in this PR.

https://www.pivotaltracker.com/story/show/173371989