### PR TITLE
Finish Service changes started in #362

### DIFF
--- a/app/DoctrineMigrations/Version20200623063105.php
+++ b/app/DoctrineMigrations/Version20200623063105.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20200623063105 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE service DROP institution_guid, CHANGE institution_id institution_id VARCHAR(255) DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE service ADD institution_guid VARCHAR(255) NOT NULL COLLATE utf8_unicode_ci, CHANGE institution_id institution_id VARCHAR(255) NOT NULL COLLATE utf8_unicode_ci');
+    }
+}

--- a/app/js/components/mock/service_create_form.html
+++ b/app/js/components/mock/service_create_form.html
@@ -15,11 +15,6 @@
                     <input type="text" id="dashboard_bundle_service_type_general_institutionId"
                            name="dashboard_bundle_service_type[general][institutionId]"
                            class="institution-id-container"/></div>
-                <div class="form-row"><label for="dashboard_bundle_service_type_general_institutionGuid"
-                                             class="required">Institution GUID</label>
-                    <p class="parsley-errors"></p>
-                    <input type="text" id="dashboard_bundle_service_type_general_institutionGuid"
-                           name="dashboard_bundle_service_type[general][institutionGuid]" required="required"/></div>
                 <div class="form-row"><label for="dashboard_bundle_service_type_general_teamName" class="required">team
                     identifier</label>
                     <p class="parsley-errors"></p>

--- a/app/js/components/mock/service_edit_form.html
+++ b/app/js/components/mock/service_edit_form.html
@@ -17,12 +17,6 @@
                     <input type="text" id="dashboard_bundle_edit_service_type_general_institutionId"
                            name="dashboard_bundle_edit_service_type[general][institutionId]"
                            class="institution-id-container" value="inst-id"/></div>
-                <div class="form-row"><label for="dashboard_bundle_edit_service_type_general_institutionGuid"
-                                             class="required">Institution GUID</label>
-                    <p class="parsley-errors"></p>
-                    <input type="text" id="dashboard_bundle_edit_service_type_general_institutionGuid"
-                           name="dashboard_bundle_edit_service_type[general][institutionGuid]" required="required"
-                           value="ac17228a-fdf7-11e8-8eb2-f2801f1b9fd1"/></div>
                 <div class="form-row"><label for="dashboard_bundle_edit_service_type_general_teamName" class="required">team
                     identifier</label>
                     <p class="parsley-errors"></p>

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/CreateServiceCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/CreateServiceCommand.php
@@ -48,12 +48,6 @@ class CreateServiceCommand implements Command
     private $institutionId;
 
     /**
-     * @var string
-     * @Assert\NotBlank
-     */
-    private $institutionGuid;
-
-    /**
      * @var bool
      */
     private $productionEntitiesEnabled = false;
@@ -179,14 +173,6 @@ class CreateServiceCommand implements Command
     }
 
     /**
-     * @param string $institutionGuid
-     */
-    public function setInstitutionGuid($institutionGuid)
-    {
-        $this->institutionGuid = $institutionGuid;
-    }
-
-    /**
      * @return string
      */
     public function getGuid()
@@ -281,13 +267,5 @@ class CreateServiceCommand implements Command
     public function getInstitutionId()
     {
         return $this->institutionId;
-    }
-
-    /**
-     * @return string
-     */
-    public function getInstitutionGuid()
-    {
-        return $this->institutionGuid;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/EditServiceCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/EditServiceCommand.php
@@ -94,12 +94,6 @@ class EditServiceCommand implements Command
     private $institutionId;
 
     /**
-     * @var string
-     * @Assert\NotBlank
-     */
-    private $institutionGuid;
-
-    /**
      * @SuppressWarnings(PHPMD.ExcessiveParameterList) - Could be decomposed, but for now makes no sense.
      *
      * @param int $id
@@ -114,7 +108,6 @@ class EditServiceCommand implements Command
      * @param string $contractSigned
      * @param string $surfconextRepresentativeApproved
      * @param string $privacyQuestionsAnswered
-     * @param string $institutionGuid
      * @param string $institutionId
      */
     public function __construct(
@@ -130,7 +123,6 @@ class EditServiceCommand implements Command
         $contractSigned,
         $surfconextRepresentativeApproved,
         $privacyQuestionsAnswered,
-        $institutionGuid,
         $institutionId
     ) {
         $this->id = $id;
@@ -145,7 +137,6 @@ class EditServiceCommand implements Command
         $this->contractSigned = $contractSigned;
         $this->surfconextRepresentativeApproved = $surfconextRepresentativeApproved;
         $this->privacyQuestionsAnswered = $privacyQuestionsAnswered;
-        $this->institutionGuid = $institutionGuid;
         $this->institutionId = $institutionId;
     }
 
@@ -254,14 +245,6 @@ class EditServiceCommand implements Command
     }
 
     /**
-     * @param string $institutionGuid
-     */
-    public function setInstitutionGuid($institutionGuid)
-    {
-        $this->institutionGuid = $institutionGuid;
-    }
-
-    /**
      * @return string
      */
     public function getId()
@@ -363,13 +346,5 @@ class EditServiceCommand implements Command
     public function getInstitutionId()
     {
         return $this->institutionId;
-    }
-
-    /**
-     * @return string
-     */
-    public function getInstitutionGuid()
-    {
-        return $this->institutionGuid;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/CreateServiceCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/CreateServiceCommandHandler.php
@@ -55,7 +55,6 @@ class CreateServiceCommandHandler implements CommandHandler
         $service->setContractSigned($command->getContractSigned());
         $service->setIntakeStatus($command->getIntakeStatus());
         $service->setSurfconextRepresentativeApproved($command->getSurfconextRepresentativeApproved());
-        $service->setInstitutionGuid($command->getInstitutionGuid());
         $service->setInstitutionId($command->getInstitutionId());
 
         $this->serviceRepository->isUnique($service);

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/EditServiceCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/EditServiceCommandHandler.php
@@ -64,7 +64,6 @@ class EditServiceCommandHandler implements CommandHandler
         $service->setIntakeStatus($command->getIntakeStatus());
         $service->setSurfconextRepresentativeApproved($command->getSurfconextRepresentativeApproved());
 
-        $service->setInstitutionGuid($command->getInstitutionGuid());
         $service->setInstitutionId($command->getInstitutionId());
 
         $this->serviceRepository->isUnique($service);

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
@@ -234,6 +234,14 @@ class JsonGenerator implements GeneratorInterface
             $this->spDashboardMetadataGenerator->build($entity)
         );
 
+        $service = $entity->getService();
+        if ($service->getInstitutionId() != '') {
+            $metadata['coin:institution_id'] = $service->getInstitutionId();
+        }
+        if ($service->getGuid() != '') {
+            $metadata['coin:institution_guid'] = $service->getGuid();
+        }
+
         if ($entity->getProtocol() == Entity::TYPE_SAML) {
             $metadata['AssertionConsumerService:0:Binding'] = $entity->getAcsBinding();
             $metadata['AssertionConsumerService:0:Location'] = $entity->getAcsLocation();

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
@@ -214,6 +214,14 @@ class OidcngJsonGenerator implements GeneratorInterface
             $this->spDashboardMetadataGenerator->build($entity)
         );
 
+        $service = $entity->getService();
+        if ($service->getInstitutionId() != '') {
+            $metadata['coin:institution_id'] = $service->getInstitutionId();
+        }
+        if ($service->getGuid() != '') {
+            $metadata['coin:institution_guid'] = $service->getGuid();
+        }
+
         $metadata['NameIDFormat'] = $entity->getNameIdFormat();
 
         // If the entity exists in Manage, use the scopes configured there.

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
@@ -183,6 +183,14 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
             $this->spDashboardMetadataGenerator->build($entity)
         );
 
+        $service = $entity->getService();
+        if ($service->getInstitutionId() != '') {
+            $metadata['coin:institution_id'] = $service->getInstitutionId();
+        }
+        if ($service->getGuid() != '') {
+            $metadata['coin:institution_guid'] = $service->getGuid();
+        }
+
         $metadata['NameIDFormat'] = $entity->getNameIdFormat();
 
         // Will become configurable some time in the future.

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
@@ -160,13 +160,6 @@ class Service
      */
     private $institutionId;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(length=255, nullable=true)
-     */
-    private $institutionGuid;
-
     public function __construct()
     {
         $this->contacts = new ArrayCollection();
@@ -398,11 +391,6 @@ class Service
         $this->surfconextRepresentativeApproved = $surfconextRepresentativeApproved;
     }
 
-    public function getInstitutionGuid()
-    {
-        return $this->institutionGuid;
-    }
-
     public function getInstitutionId()
     {
         return $this->institutionId;
@@ -414,13 +402,5 @@ class Service
     public function setInstitutionId($institutionId)
     {
         $this->institutionId = $institutionId;
-    }
-
-    /**
-     * @param string $institutionGuid
-     */
-    public function setInstitutionGuid($institutionGuid)
-    {
-        $this->institutionGuid = $institutionGuid;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -200,7 +200,6 @@ class ServiceController extends Controller
             $service->getContractSigned(),
             $service->getSurfconextRepresentativeApproved(),
             $this->serviceStatusService->hasPrivacyQuestions($service),
-            $service->getInstitutionGuid(),
             $service->getInstitutionId()
         );
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DataFixtures/ORM/WebTestFixtures.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DataFixtures/ORM/WebTestFixtures.php
@@ -66,7 +66,7 @@ class WebTestFixtures extends Fixture
         $service->setTeamName($teamName);
         $service->setGuid(Uuid::uuid4());
         $service->setInstitutionId(Uuid::uuid4());
-        $service->setInstitutionGuid(Uuid::uuid4());
+        $service->setGuid(Uuid::uuid4());
 
         return $service;
     }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Service/ServiceType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Service/ServiceType.php
@@ -55,14 +55,6 @@ class ServiceType extends AbstractType
                             'attr' => ['class' => 'institution-id-container']
                         ]
                     )
-                    ->add(
-                        'institutionGuid',
-                        TextType::class,
-                        [
-                            'required' => true,
-                            'label' => 'service.form.label.institution_guid'
-                        ]
-                    )
                     ->add('teamName', null, ['label' => 'team identifier'])
                     ->add(
                         'productionEntitiesEnabled',

--- a/tests/integration/Application/CommandHandler/Service/CreateServiceCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Service/CreateServiceCommandHandlerTest.php
@@ -71,7 +71,6 @@ class CreateServiceCommandHandlerTest extends MockeryTestCase
         $command->setSurfconextRepresentativeApproved($service->getSurfconextRepresentativeApproved());
         $command->setContractSigned($service->getContractSigned());
         $command->setInstitutionId($service->getInstitutionId());
-        $command->setInstitutionGuid($service->getInstitutionGuid());
 
         $this->repository->shouldReceive('save')->with(IsEqual::equalTo($service))->once();
         $this->repository->shouldReceive('isUnique')->andReturn(true)->once();

--- a/tests/integration/Application/CommandHandler/Service/EditServiceCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Service/EditServiceCommandHandlerTest.php
@@ -60,7 +60,6 @@ class EditServiceCommandHandlerTest extends MockeryTestCase
             'no',
             'no',
             true,
-            '22dd879c-ee2f-11db-8314-0800200c9a66',
             '123'
         );
         $command->setName('Foobar');
@@ -91,8 +90,6 @@ class EditServiceCommandHandlerTest extends MockeryTestCase
                 $this->assertEquals('no', $arg->getSurfconextRepresentativeApproved());
                 $this->assertEquals('not-applicable', $arg->getIntakeStatus());
                 $this->assertEquals('123', $arg->getInstitutionId());
-                $this->assertEquals('22dd879c-ee2f-11db-8314-0800200c9a66', $arg->getInstitutionGuid());
-
                 return true;
             }))
             ->once();
@@ -125,7 +122,6 @@ class EditServiceCommandHandlerTest extends MockeryTestCase
             'no',
             'no',
             true,
-            '22dd879c-ee2f-11db-8314-0800200c9a66',
             '123'
         );
 
@@ -154,7 +150,6 @@ class EditServiceCommandHandlerTest extends MockeryTestCase
             'no',
             'no',
             true,
-            '22dd879c-ee2f-11db-8314-0800200c9a66',
             '123'
         );
 

--- a/tests/unit/Application/Metadata/JsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/JsonGeneratorTest.php
@@ -27,6 +27,7 @@ use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\PrivacyQ
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\SpDashboardMetadataGenerator;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\IdentityProvider;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Dto\ManageEntity;
@@ -337,6 +338,8 @@ class JsonGeneratorTest extends MockeryTestCase
                             'NameIDFormat' => 'nameidformat',
                             'coin:signature_method' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
                             'certData' => 'certdata',
+                            'coin:institution_id' => 'service-institution-id',
+                            'coin:institution_guid' => '543b4e5b-76b5-453f-af1e-5648378bb266'
                         ),
                     'metadataurl' => 'http://metadata',
                     'revisionnote' => 'revisionnote',
@@ -392,6 +395,8 @@ class JsonGeneratorTest extends MockeryTestCase
                     'revisionnote' => 'revisionnote',
                     'allowedEntities' => [],
                     'allowedall' => true,
+                    'metaDataFields.coin:institution_id' => 'service-institution-id',
+                    'metaDataFields.coin:institution_guid' => '543b4e5b-76b5-453f-af1e-5648378bb266'
                 ),
             'type' => 'saml20_sp',
             'id' => 'manageId',
@@ -448,6 +453,8 @@ class JsonGeneratorTest extends MockeryTestCase
                             'sp' => 'sp',
                             'coin:oidc_client' => '1',
                             'coin:signature_method' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+                            'coin:institution_id' => 'service-institution-id',
+                            'coin:institution_guid' => '543b4e5b-76b5-453f-af1e-5648378bb266'
                         ),
                     'oidcClient' =>
                         array (
@@ -515,6 +522,8 @@ class JsonGeneratorTest extends MockeryTestCase
                     'allowedEntities' => [],
                     'allowedall' => true,
                     'metaDataFields.coin:signature_method' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+                    'metaDataFields.coin:institution_id' => 'service-institution-id',
+                    'metaDataFields.coin:institution_guid' => '543b4e5b-76b5-453f-af1e-5648378bb266'
                 ),
             'type' => 'saml20_sp',
             'id' => 'manageId',
@@ -736,6 +745,8 @@ class JsonGeneratorTest extends MockeryTestCase
                             'AssertionConsumerService:0:Location' => 'http://acs',
                             'NameIDFormat' => 'nameidformat',
                             'coin:signature_method' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+                            'coin:institution_id' => 'service-institution-id',
+                            'coin:institution_guid' => '543b4e5b-76b5-453f-af1e-5648378bb266'
                         ),
                     'metadataurl' => 'http://metadata',
                     'revisionnote' => 'revisionnote',
@@ -795,6 +806,11 @@ CERT
         $contact->setPhone('telephonenumber');
 
         $entity->setSupportContact($contact);
+
+        $service = new Service();
+        $service->setGuid('543b4e5b-76b5-453f-af1e-5648378bb266');
+        $service->setInstitutionId('service-institution-id');
+        $entity->setService($service);
 
         if (!is_null($idpAllowAll)) {
             $entity->setIdpAllowAll($idpAllowAll);
@@ -859,6 +875,12 @@ CERT
         $contact->setPhone('telephonenumber');
 
         $entity->setSupportContact($contact);
+
+        $service = new Service();
+        $service->setGuid('543b4e5b-76b5-453f-af1e-5648378bb266');
+        $service->setInstitutionId('service-institution-id');
+        $entity->setService($service);
+
         $entity = MetadataConversionDto::fromEntity($entity);
         return $entity;
     }

--- a/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
@@ -27,6 +27,7 @@ use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\SpDashbo
 use Surfnet\ServiceProviderDashboard\Application\Metadata\OidcngJsonGenerator;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\IdentityProvider;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
 
@@ -118,6 +119,8 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
                         ],
                         'secret' => 'test',
                         'scopes' => ['openid'],
+                        'coin:institution_id' => 'service-institution-id',
+                        'coin:institution_guid' => '543b4e5b-76b5-453f-af1e-5648378bb266'
                     ],
                     'revisionnote' => 'revisionnote',
                 ],
@@ -186,6 +189,8 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
                         'allowedEntities' => [],
                         'allowedResourceServers' => [],
                         'allowedall' => true,
+                        'metaDataFields.coin:institution_id' => 'service-institution-id',
+                        'metaDataFields.coin:institution_guid' => '543b4e5b-76b5-453f-af1e-5648378bb266'
                     ),
                 'type' => 'oidc10_rp',
                 'id' => 'manageId',
@@ -383,6 +388,11 @@ CERT
         if (!is_null($certificate)) {
             $entity->setCertificate($certificate);
         }
+
+        $service = new Service();
+        $service->setGuid('543b4e5b-76b5-453f-af1e-5648378bb266');
+        $service->setInstitutionId('service-institution-id');
+        $entity->setService($service);
 
         return MetadataConversionDto::fromEntity($entity);
     }

--- a/tests/unit/Application/Metadata/OidcngResourceServerJsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/OidcngResourceServerJsonGeneratorTest.php
@@ -26,6 +26,7 @@ use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\PrivacyQ
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\SpDashboardMetadataGenerator;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\OidcngResourceServerJsonGenerator;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
 
 class OidcngResourceServerJsonGeneratorTest extends MockeryTestCase
@@ -100,7 +101,9 @@ class OidcngResourceServerJsonGeneratorTest extends MockeryTestCase
                         'OrganizationURL:nl' => 'http://orgnl',
                         'scopes' => ['openid'],
                         'privacy' => 'privacy',
-                        'secret' => 'test'
+                        'secret' => 'test',
+                        'coin:institution_id' => 'service-institution-id',
+                        'coin:institution_guid' => '543b4e5b-76b5-453f-af1e-5648378bb266'
                     ],
                 ],
                 'type' => 'oidc10_rp',
@@ -148,7 +151,9 @@ class OidcngResourceServerJsonGeneratorTest extends MockeryTestCase
                         'state' => 'testaccepted',
                         'allowedEntities' => [],
                         'allowedall' => true,
-                        'metaDataFields.privacy' => 'privacy'
+                        'metaDataFields.privacy' => 'privacy',
+                        'metaDataFields.coin:institution_id' => 'service-institution-id',
+                        'metaDataFields.coin:institution_guid' => '543b4e5b-76b5-453f-af1e-5648378bb266'
                     ),
                 'type' => 'oidc10_rp',
                 'id' => 'manageId',
@@ -198,6 +203,11 @@ CERT
         $entity->setSupportContact($contact);
         $entity->setClientSecret('test');
         $entity->shouldReceive('isAllowedAll')->andReturn(true);
+
+        $service = new Service();
+        $service->setGuid('543b4e5b-76b5-453f-af1e-5648378bb266');
+        $service->setInstitutionId('service-institution-id');
+        $entity->setService($service);
 
         return MetadataConversionDto::fromEntity($entity);
     }

--- a/tests/webtests/ServiceCreateTest.php
+++ b/tests/webtests/ServiceCreateTest.php
@@ -39,7 +39,6 @@ class ServiceCreateTest extends WebTestCase
                 'general' => [
                     'guid' => 'a8a1fa6f-bffd-xxyz-874a-b9f4fdf92942',
                     'institutionId' => 'b8a1fa6f-bffd-xxyz-874a-b9f4fdf92942',
-                    'institutionGuid' => 'a8a1fa6f-bffd-xxyz-874a-b9f4fdf92942',
                     'name' => 'The A Team',
                     'teamName' => 'team-a',
                 ]
@@ -68,7 +67,6 @@ class ServiceCreateTest extends WebTestCase
                 'general' => [
                     'guid' => '',
                     'institutionId' => 'b8a1fa6f-bffd-xxyz-874a-b9f4fdf92942',
-                    'institutionGuid' => 'a8a1fa6f-bffd-xxyz-874a-b9f4fdf92942',
                     'name' => 'The A Team',
                     'teamName' => 'team-a',
                 ]
@@ -102,7 +100,6 @@ class ServiceCreateTest extends WebTestCase
                 'general' => [
                     'guid' => '1234abcd-146e-e711-80e8-005056956c1e',
                     'institutionId' => 'b8a1fa6f-bffd-xxyz-874a-b9f4fdf92942',
-                    'institutionGuid' => 'a8a1fa6f-bffd-xxyz-874a-b9f4fdf92942',
                     'name' => 'The A Team',
                     'teamName' => 'team-a',
                 ]
@@ -132,7 +129,6 @@ class ServiceCreateTest extends WebTestCase
                 'general' => [
                     'guid' => Uuid::uuid4(),
                     'institutionId' => 'b8a1fa6f-bffd-xxyz-874a-b9f4fdf92942',
-                    'institutionGuid' => 'a8a1fa6f-bffd-xxyz-874a-b9f4fdf92942',
                     'name' => 'The A Team',
                     'teamName' => 'urn:collab:org:surf.nl',
                 ]
@@ -164,7 +160,6 @@ class ServiceCreateTest extends WebTestCase
                 'general' => [
                     'guid' => 'b9aaa8c4-3376-4e9d-b828-afa38cf29986',
                     'institutionId' => 'b8a1fa6f-bffd-xxyz-874a-b9f4fdf92942',
-                    'institutionGuid' => 'a8a1fa6f-bffd-xxyz-874a-b9f4fdf92942',
                     'name' => 'The A Team',
                     'teamName' => 'team-a',
                 ]


### PR DESCRIPTION
First commit: The institution guid field is removed. This is redundant as the CRM ID is actually the Institution GUID. The story merely stated which manage fields should be filled with the form values already present (in this case the coin:institution_id with the crm id)

Second commit: The insittution fields are saved to Manage.

See: https://www.pivotaltracker.com/story/show/163754504/comments/215468187
See: https://github.com/SURFnet/sp-dashboard/pull/362