### PR TITLE
Enable and fix Url validation

### DIFF
--- a/app/js/components/validation.js
+++ b/app/js/components/validation.js
@@ -109,18 +109,18 @@ if (form.length) {
 // Add a stricter url validator, fields validated with urlstrict are
 // allowed to be empty, or a URL with protocol.
 window.Parsley.addValidator('urlstrict', function (value, requirement) {
-    let helper = new ValidatorHelper();
+    const helper = new ValidatorHelper();
     return helper.validateEmpty(value) || helper.validateUrl(value);
 }, 32).addMessage('en', 'urlstrict', 'This value should be a valid URL.');
 
 // Add URI validator (must be URN or URL), fields validated with urn
 // must be empty or be a valid URN  or URL (with protocol).
 window.Parsley.addValidator('uri', function (value, requirement) {
-    let helper = new ValidatorHelper();
+    const helper = new ValidatorHelper();
     return helper.validateEmpty(value) || helper.validateUrl(value) || helper.validateUrn(value)
 }, 32).addMessage('en', 'uri', 'This value should be a valid URL or URN.');
 
-window.Parsley.addValidator('redirecturis-set', {
+window.Parsley.addValidator('redirecturis_set', {
     validateString: function(value, requirement, instance) {
         let count  = 0;
         instance.$element.closest('.collection-widget').find('input').each(function (idx, value) {
@@ -128,21 +128,22 @@ window.Parsley.addValidator('redirecturis-set', {
                 count++;
             }
         });
-        let helper = new ValidatorHelper();
-
-        return (helper.validateUrl(value) || helper.validateLoopback(value)) && count > 0
+        return count > 0
     },
     messages: {
         en: 'At least one redirecturi must be set.',
     }
 }, 32);
 
-window.Parsley.addValidator('redirecturis-valid', {
-    validateString: function(value, requirement, instance) {
-        let items = instance.$element.closest('.collection-widget').find('input');
-        console.log(items, value);
-        let helper = new ValidatorHelper();
-        return helper.validateUrl(value) || helper.validateLoopback(value) || helper.validateReverseDns(value)
+window.Parsley.addValidator('redirecturis_valid', {
+    validateString: function(value) {
+        // Allos empty string (substitute for validatie-if-empty validation)
+        if (value === '') {
+            return true;
+        }
+        const helper = new ValidatorHelper();
+        const result = helper.validateUrl(value.trim()) || helper.validateLoopback(value.trim());
+        return result;
     },
     messages: {
         en: 'Invalid redirect URI provided.',

--- a/app/js/components/validation.js
+++ b/app/js/components/validation.js
@@ -137,13 +137,12 @@ window.Parsley.addValidator('redirecturis_set', {
 
 window.Parsley.addValidator('redirecturis_valid', {
     validateString: function(value) {
-        // Allos empty string (substitute for validatie-if-empty validation)
+        // Allow empty string (substitute for validatie-if-empty validation)
         if (value === '') {
             return true;
         }
         const helper = new ValidatorHelper();
-        const result = helper.validateUrl(value.trim()) || helper.validateLoopback(value.trim());
-        return result;
+        return helper.validateUrl(value.trim()) || helper.validateLoopback(value.trim());
     },
     messages: {
         en: 'Invalid redirect URI provided.',

--- a/app/js/components/validator_helper.test.ts
+++ b/app/js/components/validator_helper.test.ts
@@ -32,6 +32,8 @@ describe('validation functions', () => {
       'httpd:/invalid-protocol.com',
       'https://localhost',
       'https://185.258.148.45',
+      'localhost',
+      '123.123.123.123',
       'git://www.sp-dashboard.com/with/path',
       'ftp://www.sp-dashboard.com/with/path',
       'sftp://www.sp-dashboard.com/with/path',
@@ -94,6 +96,8 @@ describe('validation functions', () => {
       'httpd://localhost',
       'https://local-host/foo/bar',
       'http://local',
+      'localhost',
+      '127.0.0.1',
     ];
     const helper = new ValidatorHelper();
 
@@ -103,6 +107,31 @@ describe('validation functions', () => {
 
     for (const illegal of illegalUrls) {
       expect(helper.validateLoopback(illegal)).toBeFalsy();
+    }
+  });
+
+  it('should correctly flip urls', () => {
+    const expectancies = [
+      { url: 'com.example.foobar://whatever', flipped: 'whatever://foobar.example.com' },
+      { url: 'com.github://https/client', flipped: 'https://github.com/client' },
+      { url: 'https://foobar.example.com', flipped: 'foobar.example.com://https' },
+      { url: 'https://foobar.example.com/foo/bar', flipped: 'foobar.example.com://https/foo/bar' },
+      { url: 'http://11.22.33.44', flipped: '11.22.33.44://http' },
+    ];
+    const helper = new ValidatorHelper();
+    for (const expectation of expectancies) {
+      const flipped = helper.flipProtocol(expectation.url);
+      expect(flipped).toBe(expectation.flipped);
+    }
+  });
+
+  it('flip protocol should only processes valid urls', () => {
+    const invalidUrls = [
+      'localhost',
+    ];
+    const helper = new ValidatorHelper();
+    for (const invalid of invalidUrls) {
+      expect(() => helper.flipProtocol(invalid)).toThrow('Invalid URL');
     }
   });
 });

--- a/app/js/components/validator_helper.test.ts
+++ b/app/js/components/validator_helper.test.ts
@@ -124,14 +124,4 @@ describe('validation functions', () => {
       expect(flipped).toBe(expectation.flipped);
     }
   });
-
-  it('flip protocol should only processes valid urls', () => {
-    const invalidUrls = [
-      'localhost',
-    ];
-    const helper = new ValidatorHelper();
-    for (const invalid of invalidUrls) {
-      expect(() => helper.flipProtocol(invalid)).toThrow('Invalid URL');
-    }
-  });
 });

--- a/app/js/components/validator_helper.ts
+++ b/app/js/components/validator_helper.ts
@@ -1,3 +1,6 @@
+// tslint:disable-next-line:no-var-requires
+const Url = require('url-parse');
+
 export class ValidatorHelper {
 
   public validateEmpty(value: string): boolean {
@@ -64,20 +67,15 @@ export class ValidatorHelper {
    * This helper method is designed to turn a reverse redirect url into a validatable regular url
    */
   public flipProtocol(value: string): string {
-    const url = new URL(value.trim());
+    const url = new Url(value.trim());
     // The hostname is provided in reverse as per https://tools.ietf.org/html/rfc8252#section-7.1
     const originalHost = url.protocol.replace(':', '');
     const reversedHost = originalHost.split('.').reverse().join('.');
     // Store the protocol (stored in the host), removing the port if present.
-    let originalProtocol = (url.host.includes(url.port)) ? url.host.replace(`:${url.port}`, '') : url.host;
-    if (originalProtocol === '') {
-      originalProtocol = url.pathname.replace('//', '');
-    }
-    const protocolRegex = new RegExp(`^${this.escapeRegExp(originalHost)}`, 'gi');
-    const hostRegex = new RegExp(`${this.escapeRegExp(originalProtocol)}`, 'gi');
-    let parsedUrl = value.replace(hostRegex, reversedHost);
-    parsedUrl = parsedUrl.replace(protocolRegex, originalProtocol);
-    return parsedUrl;
+    const originalProtocol = (url.host.includes(url.port)) ? url.host.replace(`:${url.port}`, '') : url.host;
+    url.host = reversedHost;
+    url.protocol = originalProtocol;
+    return url.toString();
   }
 
   private invalidProtocol(input: string, isReverseUrl: boolean = false): boolean {
@@ -111,9 +109,5 @@ export class ValidatorHelper {
       return true;
     }
     return false;
-  }
-
-  private escapeRegExp(regex: string) {
-    return regex.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "jquery.mousewheel": "^3.1.9",
     "parsleyjs": "^2.8.1",
     "select2": "^4.0.3",
-    "tippy.js": "^2.0.2"
+    "tippy.js": "^2.0.2",
+    "url-parse": "^1.4.7"
   },
   "resolutions": {
     "jquery": "3.5.0",

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
@@ -110,10 +110,9 @@ class OidcngEntityType extends AbstractType
                     'entry_type' => TextType::class,
                     'entry_options' => [
                         'attr' => [
-                            'data-parsley-redirecturis-set' => null,
-                            'data-parsley-redirecturis-valid' => null,
+                            'data-parsley-redirecturis_set' => 'true',
+                            'data-parsley-redirecturis_valid' => 'true',
                             'data-parsley-trigger' => 'blur',
-                            'data-parsley-validate-if-empty' => null,
                         ],
                     ],
                     'attr' => [

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/ValidRedirectUrlValidator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/ValidRedirectUrlValidator.php
@@ -22,6 +22,7 @@ use Exception;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngEntityCommand;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\UrlValidator;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 class ValidRedirectUrlValidator extends UrlValidator
 {
@@ -32,6 +33,8 @@ class ValidRedirectUrlValidator extends UrlValidator
      */
     public function validate($value, Constraint $constraint)
     {
+        // This validator is used on a collection of Redirect URLs, Its possible violations are already present.
+        $numberOfViolations = $this->context->getViolations()->count();
         /**
          * @var SaveOidcngEntityCommand $entityCommand
          */
@@ -46,17 +49,16 @@ class ValidRedirectUrlValidator extends UrlValidator
 
         // Test if we have Url violations, if so re validate the url with the reverse redirect URL rules
         $violations = $this->context->getViolations();
-        if ($violations->count() > 0) {
+        if ($violations->count() > $numberOfViolations) {
             $parts = parse_url($value);
             if (!isset($parts['host'])) {
                 return;
             }
 
             $clientId = $entityCommand->getClientId();
-            // Remove all violations, we'll run the validator again with the reverse hostname.
-            foreach ($violations as $index => $violation) {
-                $violations->remove($index);
-            }
+            // Remove the violations that where added just now, we'll run the validator again with the reverse hostname.
+            $this->dropLastAddedErrors($violations, $numberOfViolations);
+
             $storedHost = $parts['host'];
             $parts['host'] = $this->reverseHostname($parts['scheme']);
             if (!substr_count($clientId, $parts['host']) > 0) {
@@ -97,5 +99,28 @@ class ValidRedirectUrlValidator extends UrlValidator
     private function reverseHostname($hostname)
     {
         return implode('.', array_reverse(explode('.', $hostname)));
+    }
+
+    private function dropLastAddedErrors(
+        ConstraintViolationListInterface $violations,
+        int $numberOfViolationsBeforeExecution
+    ) {
+        // Convert the violations to an array for easier manipulation
+        $violationsArray = $violations->getIterator()->getArrayCopy();
+        $numberOfViolations = $violations->count();
+        // Now empty the current list of violations
+        foreach ($violations as $index => $violation) {
+            $violations->offsetUnset($index);
+        }
+
+        // Remove the last errors from the array copy
+        for ($i=1; $i<=($numberOfViolations - $numberOfViolationsBeforeExecution); $i++) {
+            array_pop($violationsArray);
+        }
+
+        // Set the array copy values as the list of violations
+        foreach ($violationsArray as $index => $violation) {
+            $violations->set($index, $violation);
+        }
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/ValidRedirectUrlValidator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/ValidRedirectUrlValidator.php
@@ -47,9 +47,13 @@ class ValidRedirectUrlValidator extends UrlValidator
         // Test if we have Url violations, if so re validate the url with the reverse redirect URL rules
         $violations = $this->context->getViolations();
         if ($violations->count() > 0) {
+            $parts = parse_url($value);
+            if (!isset($parts['host'])) {
+                return;
+            }
+
             $clientId = $entityCommand->getClientId();
             $violations->remove(0);
-            $parts = parse_url($value);
             $storedHost = $parts['host'];
             $parts['host'] = $this->reverseHostname($parts['scheme']);
             if (!substr_count($clientId, $parts['host']) > 0) {

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/ValidRedirectUrlValidator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/ValidRedirectUrlValidator.php
@@ -53,7 +53,10 @@ class ValidRedirectUrlValidator extends UrlValidator
             }
 
             $clientId = $entityCommand->getClientId();
-            $violations->remove(0);
+            // Remove all violations, we'll run the validator again with the reverse hostname.
+            foreach ($violations as $index => $violation) {
+                $violations->remove($index);
+            }
             $storedHost = $parts['host'];
             $parts['host'] = $this->reverseHostname($parts['scheme']);
             if (!substr_count($clientId, $parts['host']) > 0) {

--- a/tests/integration/Infrastructure/DashboardBundle/Validator/Constraints/ValidRedirectUrlValidatorTest.php
+++ b/tests/integration/Infrastructure/DashboardBundle/Validator/Constraints/ValidRedirectUrlValidatorTest.php
@@ -60,6 +60,20 @@ class ValidRedirectUrlValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
+    /**
+     * @dataProvider invalidRedirectUrlsGenerator
+     */
+    public function test_invalid_redirect_url($url)
+    {
+        $constraint = new ValidRedirectUrl();
+        $command = m::mock(SaveOidcngEntityCommand::class);
+        $command->makePartial();
+        $command->shouldReceive('getClientId')->andReturn('https://example.com');
+        $this->mockFormData($command);
+
+        $this->validator->validate($url, $constraint);
+        $this->assertTrue($this->context->getViolations()->count() > 0);
+    }
 
     /**
      * @dataProvider invalidReverseRedirectUrlsGenerator
@@ -102,5 +116,10 @@ class ValidRedirectUrlValidatorTest extends ConstraintValidatorTestCase
     {
         yield ['https://example.com/', 'com.example.test://https'];
         yield ['https://example.com/', 'com.example.test://custom'];
+    }
+
+    public static function invalidRedirectUrlsGenerator()
+    {
+        yield ['123.123.123.123'];
     }
 }

--- a/tests/integration/Infrastructure/DashboardBundle/Validator/Constraints/ValidRedirectUrlValidatorTest.php
+++ b/tests/integration/Infrastructure/DashboardBundle/Validator/Constraints/ValidRedirectUrlValidatorTest.php
@@ -93,6 +93,38 @@ class ValidRedirectUrlValidatorTest extends ConstraintValidatorTestCase
         );
     }
 
+    public function test_reverse_redirect_url_validation_sequence()
+    {
+        $clientId = 'https://www.example.com/foob/bar';
+        $validReverseUrl = 'com.example.www://https/foob/bar';
+        $invalidReverseUrl = 'com.example.test://https';
+
+        // test sequence
+        $constraint = new ValidRedirectUrl();
+        $command = m::mock(SaveOidcngEntityCommand::class);
+        $command->makePartial();
+        $command->shouldReceive('getClientId')->andReturn($clientId);
+        $this->mockFormData($command);
+
+        $this->validator->validate($validReverseUrl, $constraint);
+        $this->validator->validate($invalidReverseUrl, $constraint);
+
+        $this->assertEquals(1, $this->context->getViolations()->count());
+
+        // test sequence but now other way around
+        $constraint = new ValidRedirectUrl();
+        $command = m::mock(SaveOidcngEntityCommand::class);
+        $command->makePartial();
+        $command->shouldReceive('getClientId')->andReturn($clientId);
+        $this->mockFormData($command);
+
+        $this->validator->validate($invalidReverseUrl, $constraint);
+        $this->validator->validate($validReverseUrl, $constraint);
+
+        $this->assertEquals(1, $this->context->getViolations()->count());
+    }
+
+
     private function mockFormData(SaveEntityCommandInterface $data)
     {
         $form = $this->createMock('Symfony\Component\Form\FormInterface');

--- a/tests/integration/Infrastructure/DashboardBundle/Validator/Constraints/ValidRedirectUrlValidatorTest.php
+++ b/tests/integration/Infrastructure/DashboardBundle/Validator/Constraints/ValidRedirectUrlValidatorTest.php
@@ -110,6 +110,7 @@ class ValidRedirectUrlValidatorTest extends ConstraintValidatorTestCase
         yield ['https://www.example.com/foob/bar', 'com.example.www://https/foo/bar'];
         yield ['https://www.example.com/foob/bar', 'com.example.www://https/foo/bar#fraction'];
         yield ['https://www.example.com/foob/bar', 'com.example.www://https/foo/bar?myQuery=param#fraction'];
+        yield ['https://spdashboard.dev.support.surfconext.nl', 'nl.surfconext.support.dev.spdashboard://https/my/path'];
     }
 
     public static function invalidReverseRedirectUrlsGenerator()

--- a/yarn.lock
+++ b/yarn.lock
@@ -9274,7 +9274,7 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-url-parse@^1.4.3:
+url-parse@^1.4.3, url-parse@^1.4.7:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
   integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==


### PR DESCRIPTION
The Jest test behaves differently to the browser when it comes to the `flipProtocol` method. The URL parser is able to correctly parse on the Jest test, but fails to do so in a Firefox browser.

@pablothedude any thoughts on this?

For example, try this redirect url `spdashboard.dev.support.surfconext.nl://https/my/path`

**Edit**
@pablothedude suggested to use `parse-url` library. And that fixed the problem with ease.

See:
`https://www.pivotaltracker.com/story/show/172833472`