### PR TITLE
Prevent use of inline-style as this causes a CSP warning

### DIFF
--- a/app/scss/components/form.scss
+++ b/app/scss/components/form.scss
@@ -30,6 +30,9 @@ form {
     }
   }
 
+  button.hidden {
+    display: none;
+  }
 }
 
 .help-button {

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
@@ -52,7 +52,7 @@ class SamlEntityType extends AbstractType
             // perform. This is to prevent the import action when submitting
             // the form (the import button is now the second button on the
             // form).
-            ->add('default', SubmitType::class, ['attr' => ['style' => 'display: none']])
+            ->add('default', SubmitType::class, ['attr' => ['class' => 'hidden']])
             ->add(
                 $builder->create('metadata', FormType::class, ['inherit_data' => true])
                     ->add(


### PR DESCRIPTION
Using the style attribute is not allowed given the current CSP rules. Without this change the `default` submit button would show on the SAML form. This is required to trigger the default (save) action when pressing enter on the form.

https://www.pivotaltracker.com/story/show/173487094