### PR TITLE
Merge manage attributes only

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
@@ -78,10 +78,12 @@ class ArpGenerator implements MetadataGenerator
 
     private function addManageOnlyAttributes(array &$attributes, MetadataConversionDto $entity)
     {
+        $managedAttributeUrns = $this->repository->findAllAttributeUrns();
+
         if ($entity->isManageEntity()) {
             // Also add the attributes that are not managed in the SPD entity, but have been configured in Manage
             foreach ($entity->getArpAttributes()->getAttributes() as $manageAttribute) {
-                if (!array_key_exists($manageAttribute->getName(), $attributes)) {
+                if (!array_key_exists($manageAttribute->getName(), $attributes) && !in_array($manageAttribute->getName(), $managedAttributeUrns)) {
                     $attributes[$manageAttribute->getName()] = [
                         [
                             'source' => $manageAttribute->getSource(),

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Repository/AttributesMetadataRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Repository/AttributesMetadataRepository.php
@@ -25,4 +25,6 @@ interface AttributesMetadataRepository
     public function findAllPrivacyQuestionsAttributes();
 
     public function findAllSpDashboardAttributes();
+
+    public function findAllAttributeUrns();
 }

--- a/src/Surfnet/ServiceProviderDashboard/Legacy/Repository/AttributesMetadataRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Legacy/Repository/AttributesMetadataRepository.php
@@ -62,4 +62,16 @@ class AttributesMetadataRepository implements AttributesMetadataRepositoryInterf
             file_get_contents($this->rootDir . '/metadata/sp_dashboard.json')
         );
     }
+
+    /**
+     * @return string[]
+     */
+    public function findAllAttributeUrns()
+    {
+        $names = [];
+        foreach ($this->findAll() as $definition) {
+            $names[] = reset($definition->urns);
+        }
+        return $names;
+    }
 }


### PR DESCRIPTION
When removing SP-Dashboard attributes they were merged back
with the values known in Manage. This prevented the removal of
attributes in SP-Dashboard.

https://www.pivotaltracker.com/n/projects/1400064/stories/173508616