### PR TITLE
Remove memberOf as managed attribute

### DIFF
--- a/app/Resources/metadata/attributes.json
+++ b/app/Resources/metadata/attributes.json
@@ -148,15 +148,5 @@
       "urn:mace:dir:attribute-def:eduPersonTargetedID",
       "urn:oid:1.3.6.1.4.1.5923.1.1.1.10"
     ]
-  },
-  {
-    "id": "isMemberOf",
-    "getterName": "",
-    "setterName": "",
-    "friendlyName": "isMemberOf",
-    "urns": [
-      "urn:mace:dir:attribute-def:isMemberOf",
-      "urn:oid:1.3.6.1.4.1.5923.1.5.1.1"
-    ]
   }
 ]

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
@@ -45,11 +45,6 @@ class ArpGenerator implements MetadataGenerator
         foreach ($this->repository->findAll() as $definition) {
             $getterName = $definition->getterName;
 
-            // Skip attributes we know about but don't have registered.
-            if (!method_exists($entity, $getterName)) {
-                continue;
-            }
-
             $attr = $entity->$getterName();
 
             if ($attr instanceof Attribute && $attr->isRequested()) {

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity.php
@@ -596,15 +596,11 @@ class Entity
                 continue;
             }
 
-            $setter = $attributeDefinition->setterName;
-            if (empty($setter)) {
-                continue;
-            }
-
             $attribute = new Attribute();
             $attribute->setRequested(true);
             $attribute->setMotivation($manageAttribute->getMotivation());
 
+            $setter = $attributeDefinition->setterName;
             $entity->{$setter}($attribute);
         }
     }

--- a/tests/unit/Legacy/Repository/AttributesMetadataRepositoryTest.php
+++ b/tests/unit/Legacy/Repository/AttributesMetadataRepositoryTest.php
@@ -51,14 +51,13 @@ class AttributesMetadataRepositoryTest extends MockeryTestCase
           "uid",
           "principleName",
           "preferredLanguage",
-          "isMemberOf",
           "personalCode",
           "eduPersonTargetedID",
         ];
 
         $attributes = $this->repository->findAll();
 
-        $this->assertCount(16, $attributes);
+        $this->assertCount(15, $attributes);
         foreach ($attributes as $attribute) {
             $this->assertContains($attribute->id, $expectedAttributes);
         }
@@ -106,5 +105,31 @@ class AttributesMetadataRepositoryTest extends MockeryTestCase
         foreach ($attributes as $attribute) {
             $this->assertContains($attribute->id, $expectedAttributes);
         }
+    }
+
+    public function test_it_has_all_metadata_attribute_urns()
+    {
+        $expectedAttributes = [
+            'urn:mace:dir:attribute-def:displayName',
+            'urn:mace:dir:attribute-def:eduPersonAffiliation',
+            'urn:mace:dir:attribute-def:eduPersonScopedAffiliation',
+            'urn:mace:dir:attribute-def:mail',
+            'urn:mace:dir:attribute-def:cn',
+            'urn:mace:terena.org:attribute-def:schacHomeOrganization',
+            'urn:mace:terena.org:attribute-def:schacHomeOrganizationType',
+            'urn:mace:dir:attribute-def:sn',
+            'urn:mace:dir:attribute-def:givenName',
+            'urn:mace:dir:attribute-def:eduPersonEntitlement',
+            'urn:mace:dir:attribute-def:uid',
+            'urn:mace:dir:attribute-def:eduPersonPrincipalName',
+            'urn:mace:dir:attribute-def:preferredLanguage',
+            'urn:schac:attribute-def:schacPersonalUniqueCode',
+            'urn:mace:dir:attribute-def:eduPersonTargetedID',
+        ];
+
+        $urns = $this->repository->findAllAttributeUrns();
+
+        $this->assertCount(15, $urns);
+        $this->assertEquals($expectedAttributes, $urns);
     }
 }


### PR DESCRIPTION
The memberOf attribute was defined as attribute but didn't seem to be
managed by SPD. So when pushing the attribute to Manage it was replaced
with an empty value. So therefore the attribute was removed and a
couple of checks for mapping values to getters/setters could be
removed to make the code more explicit and thus better readable.

https://www.pivotaltracker.com/n/projects/1400064/stories/173508616