### PR TITLE
Deprovision the oidcng playtround uris

### DIFF
--- a/ansible/roles/spdashboard/templates/parameters.yml.j2
+++ b/ansible/roles/spdashboard/templates/parameters.yml.j2
@@ -53,5 +53,3 @@ parameters:
     jira_test_mode_storage_path: {{ spdashboard_test_mode_path }}
     playground_uri_test: {{ spdashboard_playground_uri_test }}
     playground_uri_prod: {{ spdashboard_playground_uri_prod }}
-    oidcng_playground_uri_test: {{ spdashboard_oidcng_playground_uri_test }}
-    oidcng_playground_uri_prod: {{ spdashboard_oidcng_playground_uri_prod }}

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -84,6 +84,3 @@ parameters:
     # Playground uri's for OIDC entities
     playground_uri_test: https://test.dev.playground.surfconext.nl
     playground_uri_prod: https://prod.dev.playground.surfconext.nl
-    # Playground uri's for OIDC TNG entities
-    oidcng_playground_uri_test: 'https://test.dev.playground.surfconext.nl'
-    oidcng_playground_uri_prod: 'https://prod.dev.playground.surfconext.nl'

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
@@ -63,25 +63,6 @@ class EntityService implements EntityServiceInterface
     private $logger;
 
     /**
-     * @var string
-     */
-    private $oidcPlaygroundUriTest;
-
-    /**
-     * @var string
-     */
-    private $oidcPlaygroundUriProd;
-    /**
-     * @var string
-     */
-    private $oidcngPlaygroundUriTest;
-
-    /**
-     * @var string
-     */
-    private $oidcngPlaygroundUriProd;
-
-    /**
      * @var Config
      */
     private $testManageConfig;
@@ -98,10 +79,6 @@ class EntityService implements EntityServiceInterface
      * @param Config $productionConfig
      * @param RouterInterface $router
      * @param LoggerInterface $logger
-     * @param string $oidcPlaygroundUriTest
-     * @param string $oidcPlaygroundUriProd
-     * @param string $oidcngPlaygroundUriTest
-     * @param string $oidcngPlaygroundUriProd
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -110,25 +87,12 @@ class EntityService implements EntityServiceInterface
         Config $testConfig,
         Config $productionConfig,
         RouterInterface $router,
-        LoggerInterface $logger,
-        $oidcPlaygroundUriTest,
-        $oidcPlaygroundUriProd,
-        $oidcngPlaygroundUriTest,
-        $oidcngPlaygroundUriProd
+        LoggerInterface $logger
     ) {
-        Assert::stringNotEmpty($oidcPlaygroundUriTest, 'Please set "playground_uri_test" in parameters.yml');
-        Assert::stringNotEmpty($oidcPlaygroundUriProd, 'Please set "playground_uri_prod" in parameters.yml');
-        Assert::stringNotEmpty($oidcngPlaygroundUriTest, 'Please set "oidcng_playground_uri_test" in parameters.yml');
-        Assert::stringNotEmpty($oidcngPlaygroundUriProd, 'Please set "oidcng_playground_uri_prod" in parameters.yml');
-
         $this->queryRepositoryProvider = $entityQueryRepositoryProvider;
         $this->ticketService = $ticketService;
         $this->router = $router;
         $this->logger = $logger;
-        $this->oidcPlaygroundUriTest = $oidcPlaygroundUriTest;
-        $this->oidcPlaygroundUriProd = $oidcPlaygroundUriProd;
-        $this->oidcngPlaygroundUriTest = $oidcngPlaygroundUriTest;
-        $this->oidcngPlaygroundUriProd = $oidcngPlaygroundUriProd;
         $this->testManageConfig = $testConfig;
         $this->prodManageConfig = $productionConfig;
     }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -197,8 +197,8 @@ services:
         tags:
             - { name: dashboard.json_generator, identifier: oidcng }
         arguments:
-            $oidcPlaygroundUriTest: '%oidcng_playground_uri_test%'
-            $oidcPlaygroundUriProd: '%oidcng_playground_uri_prod%'
+            $oidcPlaygroundUriTest: '%playground_uri_test%'
+            $oidcPlaygroundUriProd: '%playground_uri_prod%'
 
     Surfnet\ServiceProviderDashboard\Application\Metadata\OidcngResourceServerJsonGenerator:
         class: Surfnet\ServiceProviderDashboard\Application\Metadata\OidcngResourceServerJsonGenerator
@@ -311,10 +311,6 @@ services:
             - '@surfnet.manage.configuration.production'
             - '@router'
             - '@logger'
-            - '%playground_uri_test%'
-            - '%playground_uri_prod%'
-            - '%oidcng_playground_uri_test%'
-            - '%oidcng_playground_uri_prod%'
 
     Surfnet\ServiceProviderDashboard\Application\Service\LoadEntityService:
         arguments:


### PR DESCRIPTION
The distinction between the oidc and oidcng entites was removed once we dropped oidc (old style) support. Keeping the one most descriptive (without the NG suffix) was most logical.

https://www.pivotaltracker.com/story/show/175288814