### PR TITLE
Docker: Add content security policy to the docker httpd config

### DIFF
--- a/docker/httpd/conf/000-default.conf
+++ b/docker/httpd/conf/000-default.conf
@@ -9,6 +9,14 @@ SetEnv HTTPS on
   RewriteEngine On
   RewriteCond %{REQUEST_FILENAME} !-f 
   RewriteRule ^(.*)$ app.php/$1 [QSA,L]
+<IfModule mod_headers.c>
+        <If "%{THE_REQUEST} =~ /translations/">
+            Header always unset X-Content-Security-Policy
+            Header always unset Content-Security-Policy
+            Header always set Content-Security-Policy "default-src 'self'; block-all-mixed-content; font-src 'self' netdna.bootstrapcdn.com; object-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' ajax.googleapis.com; style-src 'self' netdna.bootstrapcdn.com 'unsafe-inline'; upgrade-insecure-requests; report-uri /csp/report"
+        </If>
+</IfModule>
+
 <FilesMatch \.php$>
   SetHandler "proxy:fcgi://spdashboard_php-fpm:9000"
 </FilesMatch>


### PR DESCRIPTION
With this change, the translations work again