### PR TITLE
Inject Jira ticket types in EntityService

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
@@ -73,12 +73,16 @@ class EntityService implements EntityServiceInterface
     private $prodManageConfig;
 
     /**
-     * @param EntityQueryRepositoryProvider $entityQueryRepositoryProvider
-     * @param TicketServiceInterface $ticketService
-     * @param Config $testConfig
-     * @param Config $productionConfig
-     * @param RouterInterface $router
-     * @param LoggerInterface $logger
+     * @var string
+     */
+    private $publishStatus;
+
+    /**
+     * @var string
+     */
+    private $removalStatus;
+
+    /**
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -87,7 +91,9 @@ class EntityService implements EntityServiceInterface
         Config $testConfig,
         Config $productionConfig,
         RouterInterface $router,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        string $publishStatus,
+        string $removalStatus
     ) {
         $this->queryRepositoryProvider = $entityQueryRepositoryProvider;
         $this->ticketService = $ticketService;
@@ -95,6 +101,8 @@ class EntityService implements EntityServiceInterface
         $this->logger = $logger;
         $this->testManageConfig = $testConfig;
         $this->prodManageConfig = $productionConfig;
+        $this->publishStatus = $publishStatus;
+        $this->removalStatus = $removalStatus;
     }
 
     public function createEntityUuid()
@@ -297,10 +305,10 @@ class EntityService implements EntityServiceInterface
 
                     if ($issue) {
                         switch ($issue->getIssueType()) {
-                            case 'spd-request-production-entity':
+                            case $this->publishStatus:
                                 $entity->updateStatus(Constants::STATE_PUBLICATION_REQUESTED);
                                 break;
-                            case 'spd-delete-production-entity':
+                            case $this->removalStatus:
                                 $entity->updateStatus(Constants::STATE_REMOVAL_REQUESTED);
                                 break;
                         }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -311,6 +311,8 @@ services:
             - '@surfnet.manage.configuration.production'
             - '@router'
             - '@logger'
+            - '%jira_issue_type_publication_request%'
+            - '%jira_issue_type%'
 
     Surfnet\ServiceProviderDashboard\Application\Service\LoadEntityService:
         arguments:


### PR DESCRIPTION
In order to test for the correct (configured) ticket type in the entity
service, we need the configured types in the service. Previously these
where hardcoded. But this did not work in an evn where the configuration
was set differently..

See: https://www.pivotaltracker.com/story/show/175288951