### PR TITLE
Stop matching the Jira status to the entity status

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -309,7 +309,6 @@ services:
             - '@surfnet.manage.configuration.production'
             - '@router'
             - '@logger'
-            - '%jira_issue_type_publication_request%'
             - '%jira_issue_type%'
 
     Surfnet\ServiceProviderDashboard\Application\Service\LoadEntityService:


### PR DESCRIPTION
This is no longer required as the actual entity status is reflected on
the manage entity. Using Jira for this purpose leads to incorrect entity
status in SPD