### PR TITLE
Manage organization names

### DIFF
--- a/app/DoctrineMigrations/Version20210211124755.php
+++ b/app/DoctrineMigrations/Version20210211124755.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20210211124755 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE service ADD organization_name_nl VARCHAR(255) NOT NULL, ADD organization_name_en VARCHAR(255) NOT NULL, ADD organization_display_name_nl VARCHAR(255) DEFAULT NULL, ADD organization_display_name_en VARCHAR(255) DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE service DROP organization_name_nl, DROP organization_name_en, DROP organization_display_name_nl, DROP organization_display_name_en');
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveEntityCommandInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveEntityCommandInterface.php
@@ -49,11 +49,7 @@ interface SaveEntityCommandInterface extends Command
     public function getAdministrativeContact(): ?Contact;
     public function getSupportContact(): ?Contact;
 
-    public function getOrganizationNameEn(): ?string;
-    public function getOrganizationDisplayNameEn(): ?string;
     public function getOrganizationUrlEn(): ?string;
-    public function getOrganizationNameNl(): ?string;
-    public function getOrganizationDisplayNameNl(): ?string;
     public function getOrganizationUrlNl(): ?string;
 
     public function getApplicationUrl(): ?string;

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
@@ -338,26 +338,6 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
     /**
      * @var string
      */
-    private $organizationNameNl;
-
-    /**
-     * @var string
-     */
-    private $organizationNameEn;
-
-    /**
-     * @var string
-     */
-    private $organizationDisplayNameNl;
-
-    /**
-     * @var string
-     */
-    private $organizationDisplayNameEn;
-
-    /**
-     * @var string
-     */
     private $organizationUrlNl;
 
     /**
@@ -904,58 +884,6 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
     public function setComments($comments)
     {
         $this->comments = $comments;
-    }
-
-    public function getOrganizationNameNl(): ?string
-    {
-        return $this->organizationNameNl;
-    }
-
-    /**
-     * @param string $organizationNameNl
-     */
-    public function setOrganizationNameNl($organizationNameNl)
-    {
-        $this->organizationNameNl = $organizationNameNl;
-    }
-
-    public function getOrganizationNameEn(): ?string
-    {
-        return $this->organizationNameEn;
-    }
-
-    /**
-     * @param string $organizationNameEn
-     */
-    public function setOrganizationNameEn($organizationNameEn)
-    {
-        $this->organizationNameEn = $organizationNameEn;
-    }
-
-    public function getOrganizationDisplayNameNl(): ?string
-    {
-        return $this->organizationDisplayNameNl;
-    }
-
-    /**
-     * @param string $organizationDisplayNameNl
-     */
-    public function setOrganizationDisplayNameNl($organizationDisplayNameNl)
-    {
-        $this->organizationDisplayNameNl = $organizationDisplayNameNl;
-    }
-
-    public function getOrganizationDisplayNameEn(): ?string
-    {
-        return $this->organizationDisplayNameEn;
-    }
-
-    /**
-     * @param string $organizationDisplayNameEn
-     */
-    public function setOrganizationDisplayNameEn($organizationDisplayNameEn)
-    {
-        $this->organizationDisplayNameEn = $organizationDisplayNameEn;
     }
 
     public function getOrganizationUrlNl(): ?string

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngResourceServerEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngResourceServerEntityCommand.php
@@ -141,26 +141,6 @@ class SaveOidcngResourceServerEntityCommand implements SaveEntityCommandInterfac
     /**
      * @var string
      */
-    private $organizationNameNl;
-
-    /**
-     * @var string
-     */
-    private $organizationNameEn;
-
-    /**
-     * @var string
-     */
-    private $organizationDisplayNameNl;
-
-    /**
-     * @var string
-     */
-    private $organizationDisplayNameEn;
-
-    /**
-     * @var string
-     */
     private $organizationUrlNl;
 
     /**
@@ -405,70 +385,6 @@ class SaveOidcngResourceServerEntityCommand implements SaveEntityCommandInterfac
     public function setComments($comments)
     {
         $this->comments = $comments;
-    }
-
-    /**
-     * @return string
-     */
-    public function getOrganizationNameNl(): ?string
-    {
-        return $this->organizationNameNl;
-    }
-
-    /**
-     * @param string $organizationNameNl
-     */
-    public function setOrganizationNameNl($organizationNameNl)
-    {
-        $this->organizationNameNl = $organizationNameNl;
-    }
-
-    /**
-     * @return string
-     */
-    public function getOrganizationNameEn(): ?string
-    {
-        return $this->organizationNameEn;
-    }
-
-    /**
-     * @param string $organizationNameEn
-     */
-    public function setOrganizationNameEn($organizationNameEn)
-    {
-        $this->organizationNameEn = $organizationNameEn;
-    }
-
-    /**
-     * @return string
-     */
-    public function getOrganizationDisplayNameNl(): ?string
-    {
-        return $this->organizationDisplayNameNl;
-    }
-
-    /**
-     * @param string $organizationDisplayNameNl
-     */
-    public function setOrganizationDisplayNameNl($organizationDisplayNameNl)
-    {
-        $this->organizationDisplayNameNl = $organizationDisplayNameNl;
-    }
-
-    /**
-     * @return string
-     */
-    public function getOrganizationDisplayNameEn(): ?string
-    {
-        return $this->organizationDisplayNameEn;
-    }
-
-    /**
-     * @param string $organizationDisplayNameEn
-     */
-    public function setOrganizationDisplayNameEn($organizationDisplayNameEn)
-    {
-        $this->organizationDisplayNameEn = $organizationDisplayNameEn;
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveSamlEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveSamlEntityCommand.php
@@ -329,26 +329,6 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
     /**
      * @var string
      */
-    private $organizationNameNl;
-
-    /**
-     * @var string
-     */
-    private $organizationNameEn;
-
-    /**
-     * @var string
-     */
-    private $organizationDisplayNameNl;
-
-    /**
-     * @var string
-     */
-    private $organizationDisplayNameEn;
-
-    /**
-     * @var string
-     */
     private $organizationUrlNl;
 
     /**
@@ -933,70 +913,6 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
     public function hasNameIdFormat()
     {
         return !empty($this->nameIdFormat);
-    }
-
-    /**
-     * @return string
-     */
-    public function getOrganizationNameNl(): ?string
-    {
-        return $this->organizationNameNl;
-    }
-
-    /**
-     * @param string $organizationNameNl
-     */
-    public function setOrganizationNameNl($organizationNameNl)
-    {
-        $this->organizationNameNl = $organizationNameNl;
-    }
-
-    /**
-     * @return string
-     */
-    public function getOrganizationNameEn(): ?string
-    {
-        return $this->organizationNameEn;
-    }
-
-    /**
-     * @param string $organizationNameEn
-     */
-    public function setOrganizationNameEn($organizationNameEn)
-    {
-        $this->organizationNameEn = $organizationNameEn;
-    }
-
-    /**
-     * @return string
-     */
-    public function getOrganizationDisplayNameNl(): ?string
-    {
-        return $this->organizationDisplayNameNl;
-    }
-
-    /**
-     * @param string $organizationDisplayNameNl
-     */
-    public function setOrganizationDisplayNameNl($organizationDisplayNameNl)
-    {
-        $this->organizationDisplayNameNl = $organizationDisplayNameNl;
-    }
-
-    /**
-     * @return string
-     */
-    public function getOrganizationDisplayNameEn(): ?string
-    {
-        return $this->organizationDisplayNameEn;
-    }
-
-    /**
-     * @param string $organizationDisplayNameEn
-     */
-    public function setOrganizationDisplayNameEn($organizationDisplayNameEn)
-    {
-        $this->organizationDisplayNameEn = $organizationDisplayNameEn;
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/CreateServiceCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/CreateServiceCommand.php
@@ -22,6 +22,9 @@ use Surfnet\ServiceProviderDashboard\Application\Command\Command;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Symfony\Component\Validator\Constraints as Assert;
 
+/**
+ * @SuppressWarnings(PHPMD.TooManyFields)
+ */
 class CreateServiceCommand implements Command
 {
     /**
@@ -78,6 +81,30 @@ class CreateServiceCommand implements Command
      * @var string
      */
     private $surfconextRepresentativeApproved = Service::SURFCONEXT_APPROVED_NO;
+
+    /**
+     * @var string
+     * @Assert\NotBlank
+     */
+    private $organizationNameNl;
+
+    /**
+     * @var string
+     * @Assert\NotBlank
+     */
+    private $organizationNameEn;
+
+    /**
+     * @var string
+     * @Assert\NotBlank
+     */
+    private $organizationDisplayNameNl;
+
+    /**
+     * @var string
+     * @Assert\NotBlank
+     */
+    private $organizationDisplayNameEn;
 
     /**
      * @param string $guid
@@ -246,5 +273,69 @@ class CreateServiceCommand implements Command
     public function getInstitutionId()
     {
         return $this->institutionId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationDisplayNameNl(): ?string
+    {
+        return $this->organizationDisplayNameNl;
+    }
+
+    /**
+     * @param string $organizationDisplayNameNl
+     */
+    public function setOrganizationDisplayNameNl(string $organizationDisplayNameNl): void
+    {
+        $this->organizationDisplayNameNl = $organizationDisplayNameNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationDisplayNameEn(): ?string
+    {
+        return $this->organizationDisplayNameEn;
+    }
+
+    /**
+     * @param string $organizationDisplayNameEn
+     */
+    public function setOrganizationDisplayNameEn(string $organizationDisplayNameEn): void
+    {
+        $this->organizationDisplayNameEn = $organizationDisplayNameEn;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationNameNl(): ?string
+    {
+        return $this->organizationNameNl;
+    }
+
+    /**
+     * @param string $organizationNameNl
+     */
+    public function setOrganizationNameNl(string $organizationNameNl): void
+    {
+        $this->organizationNameNl = $organizationNameNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationNameEn(): ?string
+    {
+        return $this->organizationNameEn;
+    }
+
+    /**
+     * @param string $organizationNameEn
+     */
+    public function setOrganizationNameEn(string $organizationNameEn): void
+    {
+        $this->organizationNameEn = $organizationNameEn;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/EditServiceCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/EditServiceCommand.php
@@ -21,6 +21,9 @@ namespace Surfnet\ServiceProviderDashboard\Application\Command\Service;
 use Surfnet\ServiceProviderDashboard\Application\Command\Command;
 use Symfony\Component\Validator\Constraints as Assert;
 
+/**
+ * @SuppressWarnings(PHPMD.TooManyFields)
+ */
 class EditServiceCommand implements Command
 {
     /**
@@ -89,6 +92,30 @@ class EditServiceCommand implements Command
     private $institutionId;
 
     /**
+     * @var string
+     * @Assert\NotBlank
+     */
+    private $organizationNameNl;
+
+    /**
+     * @var string
+     * @Assert\NotBlank
+     */
+    private $organizationNameEn;
+
+    /**
+     * @var string
+     * @Assert\NotBlank
+     */
+    private $organizationDisplayNameNl;
+
+    /**
+     * @var string
+     * @Assert\NotBlank
+     */
+    private $organizationDisplayNameEn;
+
+    /**
      * @SuppressWarnings(PHPMD.ExcessiveParameterList) - Could be decomposed, but for now makes no sense.
      *
      * @param int $id
@@ -103,6 +130,10 @@ class EditServiceCommand implements Command
      * @param string $surfconextRepresentativeApproved
      * @param string $privacyQuestionsAnswered
      * @param string $institutionId
+     * @param string $organizationNameNl
+     * @param string $organizationNameEn
+     * @param string $organizationDisplayNameNl
+     * @param string $organizationDisplayNameEn
      */
     public function __construct(
         $id,
@@ -116,7 +147,11 @@ class EditServiceCommand implements Command
         $contractSigned,
         $surfconextRepresentativeApproved,
         $privacyQuestionsAnswered,
-        $institutionId
+        $institutionId,
+        $organizationNameNl,
+        $organizationNameEn,
+        $organizationDisplayNameNl,
+        $organizationDisplayNameEn
     ) {
         $this->id = $id;
         $this->guid = $guid;
@@ -130,6 +165,10 @@ class EditServiceCommand implements Command
         $this->surfconextRepresentativeApproved = $surfconextRepresentativeApproved;
         $this->privacyQuestionsAnswered = $privacyQuestionsAnswered;
         $this->institutionId = $institutionId;
+        $this->organizationNameEn = $organizationNameEn;
+        $this->organizationNameNl = $organizationNameNl;
+        $this->organizationDisplayNameEn = $organizationDisplayNameEn;
+        $this->organizationDisplayNameNl = $organizationDisplayNameNl;
     }
 
     /**
@@ -322,5 +361,69 @@ class EditServiceCommand implements Command
     public function getInstitutionId()
     {
         return $this->institutionId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationDisplayNameNl(): ?string
+    {
+        return $this->organizationDisplayNameNl;
+    }
+
+    /**
+     * @param string $organizationDisplayNameNl
+     */
+    public function setOrganizationDisplayNameNl(string $organizationDisplayNameNl): void
+    {
+        $this->organizationDisplayNameNl = $organizationDisplayNameNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationDisplayNameEn(): ?string
+    {
+        return $this->organizationDisplayNameEn;
+    }
+
+    /**
+     * @param string $organizationDisplayNameEn
+     */
+    public function setOrganizationDisplayNameEn(string $organizationDisplayNameEn): void
+    {
+        $this->organizationDisplayNameEn = $organizationDisplayNameEn;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationNameNl(): ?string
+    {
+        return $this->organizationNameNl;
+    }
+
+    /**
+     * @param string $organizationNameNl
+     */
+    public function setOrganizationNameNl(string $organizationNameNl): void
+    {
+        $this->organizationNameNl = $organizationNameNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationNameEn(): ?string
+    {
+        return $this->organizationNameEn;
+    }
+
+    /**
+     * @param string $organizationNameEn
+     */
+    public function setOrganizationNameEn(string $organizationNameEn): void
+    {
+        $this->organizationNameEn = $organizationNameEn;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandler.php
@@ -133,10 +133,13 @@ class SaveOidcngEntityCommandHandler implements CommandHandler
         $entity->setPersonalCodeAttribute($command->getPersonalCodeAttribute());
         $entity->setScopedAffiliationAttribute($command->getScopedAffiliationAttribute());
         $entity->setComments($command->getComments());
-        $entity->setOrganizationNameNl($command->getOrganizationNameNl());
-        $entity->setOrganizationNameEn($command->getOrganizationNameEn());
-        $entity->setOrganizationDisplayNameNl($command->getOrganizationDisplayNameNl());
-        $entity->setOrganizationDisplayNameEn($command->getOrganizationDisplayNameEn());
+
+        // OrganizationName and OrganizationDisplayName are tracked on the Service
+        $entity->setOrganizationNameNl($entity->getService()->getOrganizationNameNl());
+        $entity->setOrganizationNameEn($entity->getService()->getOrganizationNameEn());
+        $entity->setOrganizationDisplayNameNl($entity->getService()->getOrganizationDisplayNameNl());
+        $entity->setOrganizationDisplayNameEn($entity->getService()->getOrganizationDisplayNameEn());
+
         $entity->setOrganizationUrlNl($command->getOrganizationUrlNl());
         $entity->setOrganizationUrlEn($command->getOrganizationUrlEn());
         $entity->setOidcngResourceServers(new ResourceServerCollection($command->getOidcngResourceServers()));

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcngResourceServerEntityCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveOidcngResourceServerEntityCommandHandler.php
@@ -102,10 +102,11 @@ class SaveOidcngResourceServerEntityCommandHandler implements CommandHandler
         $entity->setTechnicalContact($command->getTechnicalContact());
         $entity->setSupportContact($command->getSupportContact());
 
-        $entity->setOrganizationNameNl($command->getOrganizationNameNl());
-        $entity->setOrganizationNameEn($command->getOrganizationNameEn());
-        $entity->setOrganizationDisplayNameNl($command->getOrganizationDisplayNameNl());
-        $entity->setOrganizationDisplayNameEn($command->getOrganizationDisplayNameEn());
+        // OrganizationName and OrganizationDisplayName are tracked on the Service
+        $entity->setOrganizationNameNl($entity->getService()->getOrganizationNameNl());
+        $entity->setOrganizationNameEn($entity->getService()->getOrganizationNameEn());
+        $entity->setOrganizationDisplayNameNl($entity->getService()->getOrganizationDisplayNameNl());
+        $entity->setOrganizationDisplayNameEn($entity->getService()->getOrganizationDisplayNameEn());
         $entity->setOrganizationUrlNl($command->getOrganizationUrlNl());
         $entity->setOrganizationUrlEn($command->getOrganizationUrlEn());
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveSamlEntityCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/SaveSamlEntityCommandHandler.php
@@ -118,10 +118,11 @@ class SaveSamlEntityCommandHandler implements CommandHandler
             $entity->setNameIdFormat(Constants::NAME_ID_FORMAT_TRANSIENT);
         }
 
-        $entity->setOrganizationNameNl($command->getOrganizationNameNl());
-        $entity->setOrganizationNameEn($command->getOrganizationNameEn());
-        $entity->setOrganizationDisplayNameNl($command->getOrganizationDisplayNameNl());
-        $entity->setOrganizationDisplayNameEn($command->getOrganizationDisplayNameEn());
+        // OrganizationName and OrganizationDisplayName are tracked on the Service
+        $entity->setOrganizationNameNl($entity->getService()->getOrganizationNameNl());
+        $entity->setOrganizationNameEn($entity->getService()->getOrganizationNameEn());
+        $entity->setOrganizationDisplayNameNl($entity->getService()->getOrganizationDisplayNameNl());
+        $entity->setOrganizationDisplayNameEn($entity->getService()->getOrganizationDisplayNameEn());
         $entity->setOrganizationUrlNl($command->getOrganizationUrlNl());
         $entity->setOrganizationUrlEn($command->getOrganizationUrlEn());
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/CreateServiceCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/CreateServiceCommandHandler.php
@@ -56,6 +56,10 @@ class CreateServiceCommandHandler implements CommandHandler
         $service->setIntakeStatus($command->getIntakeStatus());
         $service->setSurfconextRepresentativeApproved($command->getSurfconextRepresentativeApproved());
         $service->setInstitutionId($command->getInstitutionId());
+        $service->setOrganizationNameEn($command->getOrganizationNameEn());
+        $service->setOrganizationNameNl($command->getOrganizationNameNl());
+        $service->setOrganizationDisplayNameEn($command->getOrganizationDisplayNameEn());
+        $service->setOrganizationDisplayNameNl($command->getOrganizationDisplayNameNl());
 
         $this->serviceRepository->isUnique($service);
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/EditServiceCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/EditServiceCommandHandler.php
@@ -64,6 +64,10 @@ class EditServiceCommandHandler implements CommandHandler
         $service->setSurfconextRepresentativeApproved($command->getSurfconextRepresentativeApproved());
 
         $service->setInstitutionId($command->getInstitutionId());
+        $service->setOrganizationNameEn($command->getOrganizationNameEn());
+        $service->setOrganizationNameNl($command->getOrganizationNameNl());
+        $service->setOrganizationDisplayNameEn($command->getOrganizationDisplayNameEn());
+        $service->setOrganizationDisplayNameNl($command->getOrganizationDisplayNameNl());
 
         $this->serviceRepository->isUnique($service);
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityMergeService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityMergeService.php
@@ -197,11 +197,11 @@ class EntityMergeService
     private function buildOrganizationFromCommand(SaveEntityCommandInterface $command): Organization
     {
         return new Organization(
-            $command->getOrganizationNameEn(),
-            $command->getOrganizationDisplayNameEn(),
+            $command->getService()->getOrganizationNameEn(),
+            $command->getService()->getOrganizationDisplayNameEn(),
             $command->getOrganizationUrlEn(),
-            $command->getOrganizationNameNl(),
-            $command->getOrganizationDisplayNameNl(),
+            $command->getService()->getOrganizationNameNl(),
+            $command->getService()->getOrganizationDisplayNameNl(),
             $command->getOrganizationUrlNl()
         );
     }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
@@ -382,7 +382,7 @@ class Service
     /**
      * @return string
      */
-    public function getOrganizationDisplayNameNl(): string
+    public function getOrganizationDisplayNameNl(): ?string
     {
         return $this->organizationDisplayNameNl;
     }
@@ -398,7 +398,7 @@ class Service
     /**
      * @return string
      */
-    public function getOrganizationDisplayNameEn(): string
+    public function getOrganizationDisplayNameEn(): ?string
     {
         return $this->organizationDisplayNameEn;
     }
@@ -413,7 +413,7 @@ class Service
     /**
      * @return string
      */
-    public function getOrganizationNameNl(): string
+    public function getOrganizationNameNl(): ?string
     {
         return $this->organizationNameNl;
     }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
@@ -146,6 +146,34 @@ class Service
      */
     private $institutionId;
 
+    /**
+     * @var string
+     *
+     * @ORM\Column(length=255, nullable=false)
+     */
+    private $organizationDisplayNameNl;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(length=255, nullable=false)
+     */
+    private $organizationDisplayNameEn;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(length=255, nullable=false)
+     */
+    private $organizationNameNl;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(length=255, nullable=false)
+     */
+    private $organizationNameEn;
+
     public function __construct()
     {
         $this->contacts = new ArrayCollection();
@@ -349,5 +377,68 @@ class Service
     public function setInstitutionId($institutionId)
     {
         $this->institutionId = $institutionId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationDisplayNameNl(): string
+    {
+        return $this->organizationDisplayNameNl;
+    }
+
+    /**
+     * @param string $organizationDisplayNameNl
+     */
+    public function setOrganizationDisplayNameNl(string $organizationDisplayNameNl): void
+    {
+        $this->organizationDisplayNameNl = $organizationDisplayNameNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationDisplayNameEn(): string
+    {
+        return $this->organizationDisplayNameEn;
+    }
+
+    /**
+     * @param string $organizationDisplayNameEn
+     */
+    public function setOrganizationDisplayNameEn(string $organizationDisplayNameEn): void
+    {
+        $this->organizationDisplayNameEn = $organizationDisplayNameEn;
+    }
+    /**
+     * @return string
+     */
+    public function getOrganizationNameNl(): string
+    {
+        return $this->organizationNameNl;
+    }
+
+    /**
+     * @param string $organizationNameNl
+     */
+    public function setOrganizationNameNl(string $organizationNameNl): void
+    {
+        $this->organizationNameNl = $organizationNameNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrganizationNameEn(): string
+    {
+        return $this->organizationNameEn;
+    }
+
+    /**
+     * @param string $organizationNameEn
+     */
+    public function setOrganizationNameEn(string $organizationNameEn): void
+    {
+        $this->organizationNameEn = $organizationNameEn;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -199,7 +199,11 @@ class ServiceController extends Controller
             $service->getContractSigned(),
             $service->getSurfconextRepresentativeApproved(),
             $this->serviceStatusService->hasPrivacyQuestions($service),
-            $service->getInstitutionId()
+            $service->getInstitutionId(),
+            $service->getOrganizationNameNl(),
+            $service->getOrganizationNameEn(),
+            $service->getOrganizationDisplayNameNl(),
+            $service->getOrganizationDisplayNameEn()
         );
 
         $form = $this->createForm(EditServiceType::class, $command);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DataFixtures/ORM/WebTestFixtures.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DataFixtures/ORM/WebTestFixtures.php
@@ -58,7 +58,10 @@ class WebTestFixtures extends Fixture
         $service->setGuid(Uuid::uuid4());
         $service->setInstitutionId(Uuid::uuid4());
         $service->setGuid(Uuid::uuid4());
-
+        $service->setOrganizationDisplayNameEn($name);
+        $service->setOrganizationDisplayNameNl($name);
+        $service->setOrganizationNameEn($name);
+        $service->setOrganizationNameNl($name);
         return $service;
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
@@ -486,10 +486,6 @@ class OidcngEntityType extends AbstractType
             ->add('status', HiddenType::class)
             ->add('manageId', HiddenType::class)
             ->add('environment', HiddenType::class)
-            ->add('organizationNameNl', HiddenType::class)
-            ->add('organizationNameEn', HiddenType::class)
-            ->add('organizationDisplayNameNl', HiddenType::class)
-            ->add('organizationDisplayNameEn', HiddenType::class)
             ->add('organizationUrlNl', HiddenType::class)
             ->add('organizationUrlEn', HiddenType::class)
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngResourceServerEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngResourceServerEntityType.php
@@ -168,10 +168,6 @@ class OidcngResourceServerEntityType extends AbstractType
             ->add('status', HiddenType::class)
             ->add('manageId', HiddenType::class)
             ->add('environment', HiddenType::class)
-            ->add('organizationNameNl', HiddenType::class)
-            ->add('organizationNameEn', HiddenType::class)
-            ->add('organizationDisplayNameNl', HiddenType::class)
-            ->add('organizationDisplayNameEn', HiddenType::class)
             ->add('organizationUrlNl', HiddenType::class)
             ->add('organizationUrlEn', HiddenType::class)
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
@@ -425,10 +425,6 @@ class SamlEntityType extends AbstractType
             ->add('status', HiddenType::class)
             ->add('manageId', HiddenType::class)
             ->add('environment', HiddenType::class)
-            ->add('organizationNameNl', HiddenType::class)
-            ->add('organizationNameEn', HiddenType::class)
-            ->add('organizationDisplayNameNl', HiddenType::class)
-            ->add('organizationDisplayNameEn', HiddenType::class)
             ->add('organizationUrlNl', HiddenType::class)
             ->add('organizationUrlEn', HiddenType::class)
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Service/ServiceType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Service/ServiceType.php
@@ -47,6 +47,38 @@ class ServiceType extends AbstractType
                 )
                     ->add('name')
                     ->add(
+                        'organizationNameNl',
+                        TextType::class,
+                        [
+                            'required' => true,
+                            'label' => 'service.form.label.organization_name_nl',
+                        ]
+                    )
+                    ->add(
+                        'organizationNameEn',
+                        TextType::class,
+                        [
+                            'required' => true,
+                            'label' => 'service.form.label.organization_name_en',
+                        ]
+                    )
+                    ->add(
+                        'organizationDisplayNameNl',
+                        TextType::class,
+                        [
+                            'required' => true,
+                            'label' => 'service.form.label.organization_display_name_nl',
+                        ]
+                    )
+                    ->add(
+                        'organizationDisplayNameEn',
+                        TextType::class,
+                        [
+                            'required' => true,
+                            'label' => 'service.form.label.organization_display_name_en',
+                        ]
+                    )
+                    ->add(
                         'institutionId',
                         TextType::class,
                         [

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -486,6 +486,10 @@ service.delete.confirmation: "You are about to delete '%name%'. Are you sure?"
 service.delete.entity_list_text: "With this, you are also deleting the following entities:"
 service.form.general.title: General
 service.form.status.title: Service status
+service.form.label.organization_display_name_en: Organization display name English
+service.form.label.organization_name_nl: Organization name Dutch
+service.form.label.organization_name_en: Organization name English
+service.form.label.organization_display_name_nl: Organization display name Dutch
 service.form.label.connection_status: Connection status
 service.form.label.connection_status_not_requested: Not requested
 service.form.label.connection_status_requested: Requested

--- a/tests/integration/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/SaveOidcngEntityCommandHandlerTest.php
@@ -55,6 +55,8 @@ class SaveOidcngEntityCommandHandlerTest extends MockeryTestCase
     public function test_it_can_handle_saving_of_a_save_command()
     {
         $service = m::mock(Service::class);
+        $service->shouldReceive('getOrganizationNameEn', 'getOrganizationNameNl', 'getOrganizationDisplayNameEn', 'getOrganizationDisplayNameNl')
+            ->andReturn('Organization Name');
 
         $command = SaveOidcngEntityCommand::forCreateAction($service);
         $command->setEntityId('test_entity');

--- a/tests/integration/Application/CommandHandler/Entity/SaveOidcngResourceServerEntityCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/SaveOidcngResourceServerEntityCommandHandlerTest.php
@@ -53,7 +53,8 @@ class SaveOidcngResourceServerEntityCommandHandlerTest extends MockeryTestCase
     public function test_it_can_handle_saving_of_a_save_command()
     {
         $service = m::mock(Service::class);
-
+        $service->shouldReceive('getOrganizationNameEn', 'getOrganizationNameNl', 'getOrganizationDisplayNameEn', 'getOrganizationDisplayNameNl')
+            ->andReturn('Organization Name');
         $command = SaveOidcngResourceServerEntityCommand::forCreateAction($service);
         $command->setEntityId('test_entity');
         $command->setNameEn('Test Entity');

--- a/tests/integration/Application/CommandHandler/Service/CreateServiceCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Service/CreateServiceCommandHandlerTest.php
@@ -58,6 +58,10 @@ class CreateServiceCommandHandlerTest extends MockeryTestCase
         $service->setIntakeStatus('yes');
         $service->setSurfconextRepresentativeApproved('yes');
         $service->setContractSigned('yes');
+        $service->setOrganizationDisplayNameEn('Organization Display Name EN');
+        $service->setOrganizationDisplayNameNl('Organization Display Name NL');
+        $service->setOrganizationNameEn('Organization Name EN');
+        $service->setOrganizationNameNl('Organization Name NL');
 
         $command = new CreateServiceCommand();
         $command->setName($service->getName());
@@ -65,7 +69,10 @@ class CreateServiceCommandHandlerTest extends MockeryTestCase
         $command->setGuid($service->getGuid());
         $command->setPrivacyQuestionsEnabled($service->isPrivacyQuestionsEnabled());
         $command->setProductionEntitiesEnabled($service->isProductionEntitiesEnabled());
-
+        $command->setOrganizationDisplayNameEn($service->getOrganizationDisplayNameEn());
+        $command->setOrganizationDisplayNameNl($service->getOrganizationDisplayNameNl());
+        $command->setOrganizationNameEn($service->getOrganizationNameEn());
+        $command->setOrganizationNameNl($service->getOrganizationNameNl());
         $command->setServiceType($service->getServiceType());
         $command->setIntakeStatus($service->getIntakeStatus());
         $command->setSurfconextRepresentativeApproved($service->getSurfconextRepresentativeApproved());
@@ -96,6 +103,10 @@ class CreateServiceCommandHandlerTest extends MockeryTestCase
         $command->setIntakeStatus('yes');
         $command->setSurfconextRepresentativeApproved('yes');
         $command->setContractSigned('yes');
+        $command->setOrganizationDisplayNameEn('Organization name');
+        $command->setOrganizationDisplayNameNl('Organization name');
+        $command->setOrganizationNameEn('Organization name');
+        $command->setOrganizationNameNl('Organization name');
 
         $this->repository
             ->shouldReceive('isUnique')

--- a/tests/integration/Application/CommandHandler/Service/EditServiceCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Service/EditServiceCommandHandlerTest.php
@@ -59,7 +59,11 @@ class EditServiceCommandHandlerTest extends MockeryTestCase
             'no',
             'no',
             true,
-            '123'
+            '123',
+            'Foobar Inc',
+            'Foobar Inc',
+            'Foobar Inc',
+            'Foobar Inc'
         );
         $command->setName('Foobar');
         $command->setTeamName('team-foobar');
@@ -119,7 +123,11 @@ class EditServiceCommandHandlerTest extends MockeryTestCase
             'no',
             'no',
             true,
-            '123'
+            '123',
+            'Foobar Inc',
+            'Foobar Inc',
+            'Foobar Inc',
+            'Foobar Inc'
         );
 
         $this->repository->shouldReceive('findById')->andReturn(null)->once();
@@ -146,7 +154,11 @@ class EditServiceCommandHandlerTest extends MockeryTestCase
             'no',
             'no',
             true,
-            '123'
+            '123',
+            'Foobar Inc',
+            'Foobar Inc',
+            'Foobar Inc',
+            'Foobar Inc'
         );
 
         $mockEntity = m::mock(Service::class)->makePartial();

--- a/tests/unit/Application/Service/EntityMergeServiceTest.php
+++ b/tests/unit/Application/Service/EntityMergeServiceTest.php
@@ -49,6 +49,8 @@ class EntityMergeServiceTest extends TestCase
     public function test_it_can_merge_saml_save_command_data_into_an_empty_manage_entity()
     {
         $service = m::mock(Service::class);
+        $service->shouldReceive('getOrganizationNameEn', 'getOrganizationNameNl', 'getOrganizationDisplayNameEn', 'getOrganizationDisplayNameNl')
+            ->andReturn('Organization Name');
         $manageEntity = $this->service->mergeEntityCommand($this->buildSamlCommand($service), null);
 
         self::assertNull($manageEntity->getId());
@@ -67,11 +69,15 @@ class EntityMergeServiceTest extends TestCase
     public function test_it_can_merge_saml_save_command_data_into_a_manage_entity()
     {
         $manageEntity = $this->buildManageEntity();
+        $service = m::mock(Service::class);
+        $service->shouldReceive('getOrganizationNameEn', 'getOrganizationNameNl', 'getOrganizationDisplayNameEn', 'getOrganizationDisplayNameNl')
+            ->andReturn('Organization Name');
+        $manageEntity->setService($service);
         // The point of this tests is not to verify all data was correctly merged (see seperate unit tests for that)
         self::assertEquals('https://monitorstands.example.com', $manageEntity->getMetaData()->getEntityId());
         self::assertEquals('SURFconext', $manageEntity->getMetaData()->getContacts()->findAdministrativeContact()->getGivenName());
         $mergedManageEntity = $this->service->mergeEntityCommand(
-            $this->buildSamlCommand(m::mock(Service::class)),
+            $this->buildSamlCommand($service),
             $manageEntity
         );
         // Verify merging was performed by randomly test one value that should have been updated. And one that should have been nulled

--- a/tests/webtests/EditServiceTest.php
+++ b/tests/webtests/EditServiceTest.php
@@ -38,6 +38,10 @@ class EditServiceTest extends WebTestCase
                     'guid' => 'f1af6b9e-2546-4593-a57f-6ca34d2561e9',
                     'name' => 'The A Team',
                     'teamName' => 'team-a',
+                    'organizationDisplayNameNl' => 'team-a',
+                    'organizationDisplayNameEn' => 'team-a',
+                    'organizationNameNl' => 'team-a',
+                    'organizationNameEn' => 'team-a',
                 ]
             ]
         ];

--- a/tests/webtests/ServiceCreateTest.php
+++ b/tests/webtests/ServiceCreateTest.php
@@ -41,6 +41,10 @@ class ServiceCreateTest extends WebTestCase
                     'institutionId' => 'b8a1fa6f-bffd-xxyz-874a-b9f4fdf92942',
                     'name' => 'The A Team',
                     'teamName' => 'team-a',
+                    'organizationDisplayNameNl' => 'team-a',
+                    'organizationDisplayNameEn' => 'team-a',
+                    'organizationNameNl' => 'team-a',
+                    'organizationNameEn' => 'team-a',
                 ]
             ]
         ];
@@ -69,6 +73,10 @@ class ServiceCreateTest extends WebTestCase
                     'institutionId' => 'b8a1fa6f-bffd-xxyz-874a-b9f4fdf92942',
                     'name' => 'The A Team',
                     'teamName' => 'team-a',
+                    'organizationDisplayNameNl' => 'team-a',
+                    'organizationDisplayNameEn' => 'team-a',
+                    'organizationNameNl' => 'team-a',
+                    'organizationNameEn' => 'team-a',
                 ]
             ]
         ];
@@ -102,6 +110,10 @@ class ServiceCreateTest extends WebTestCase
                     'institutionId' => 'b8a1fa6f-bffd-xxyz-874a-b9f4fdf92942',
                     'name' => 'The A Team',
                     'teamName' => 'team-a',
+                    'organizationDisplayNameNl' => 'team-a',
+                    'organizationDisplayNameEn' => 'team-a',
+                    'organizationNameNl' => 'team-a',
+                    'organizationNameEn' => 'team-a',
                 ]
             ]
         ];
@@ -131,6 +143,10 @@ class ServiceCreateTest extends WebTestCase
                     'institutionId' => 'b8a1fa6f-bffd-xxyz-874a-b9f4fdf92942',
                     'name' => 'The A Team',
                     'teamName' => 'urn:collab:org:surf.nl',
+                    'organizationDisplayNameNl' => 'team-a',
+                    'organizationDisplayNameEn' => 'team-a',
+                    'organizationNameNl' => 'team-a',
+                    'organizationNameEn' => 'team-a',
                 ]
             ]
         ];
@@ -162,6 +178,10 @@ class ServiceCreateTest extends WebTestCase
                     'institutionId' => 'b8a1fa6f-bffd-xxyz-874a-b9f4fdf92942',
                     'name' => 'The A Team',
                     'teamName' => 'team-a',
+                    'organizationDisplayNameNl' => 'team-a',
+                    'organizationDisplayNameEn' => 'team-a',
+                    'organizationNameNl' => 'team-a',
+                    'organizationNameEn' => 'team-a',
                 ]
             ]
         ];


### PR DESCRIPTION
The organization display, and the regular organization names are now manageble via the Service create and edit forms.

Whenever an entity of the service is saved, the current values of the service's org names are transported to the manage entity.

@quartje is investigating if the Organization URL should also be made configurable in the Service create/edit views. If that task is to be performed. That should land in a new PR, this PR can be used as a template for the tasks that need to be performed.

**Warning**: A database migration is required to test this feature
**See**: https://www.pivotaltracker.com/story/show/175513094