### PR TITLE
Docker: Add php-fpm override config

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,4 +40,6 @@ RUN apk add --no-cache libxml2-dev \
     chown -R www-data /var/www/html/var/sessions && \
     rm -rf /var/www/html/var/cache/prod/
 
+COPY ./docker/conf/zz-docker.conf /usr/local/etc/php-fpm.d
+
 CMD ["/usr/local/sbin/php-fpm" , "-F"]

--- a/docker/conf/zz-docker.conf
+++ b/docker/conf/zz-docker.conf
@@ -1,0 +1,6 @@
+[global]
+daemonize = no
+
+[www]
+listen = 9000
+php_value[session.cookie_secure] = True

--- a/docker/conf/zz-docker.conf
+++ b/docker/conf/zz-docker.conf
@@ -3,4 +3,12 @@ daemonize = no
 
 [www]
 listen = 9000
-php_value[session.cookie_secure] = True
+php_value[session.cookie_secure] = On
+php_value[session.cookie_httponly = ] = On
+php_value[session.hash_function = ] = 1
+php_value[session.hash_bits_per_character = ] = 6
+php_value[enable_dl] = Off
+php_value[display_errors] = Off
+php_value[expose_php] = Off
+php_value[file_uploads] = Off
+php_value[short_open_tag] = Off


### PR DESCRIPTION
The zz-docker.conf in the local directory overwrites the default file as
supplied in the Docker image. This allows us to set the secure flag on
the session cookie, and set other php ini settings if needed