### PR TITLE
Ensure presence of InputId on new entity form

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
@@ -74,7 +74,7 @@ class EntityCreateController extends Controller
     /**
      * @Method({"GET", "POST"})
      * @Route(
-     *     "/entity/create/type/{serviceId}/{targetEnvironment}",
+     *     "/entity/create/type/{serviceId}/{targetEnvironment}/{inputId}",
      *     defaults={
      *          "targetEnvironment" = "test",
      *     },

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityType/type.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityType/type.html.twig
@@ -9,7 +9,7 @@
     <div class="wysiwyg">{{ 'entity.type.description.html'|trans|wysiwyg }}</div>
 
     <div class="row entity-type">
-        {{ form_start(form, {'action': path('entity_type', {'serviceId': serviceId, 'targetEnvironment': environment})}) }}
+        {{ form_start(form, {'action': path('entity_type', {'serviceId': serviceId, 'targetEnvironment': environment, 'inputId': inputId})}) }}
         {{ form_widget(form) }}
 
         <div class="button-row">


### PR DESCRIPTION
This id ensures we know which of the services was selected to create a new
entity fom.

https://www.pivotaltracker.com/story/show/176976523