### PR TITLE
Repair ParsleyJs by pinning JQ versions installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "url-parse": "^1.4.7"
   },
   "resolutions": {
-    "jquery": "3.5.0",
+    "jquery": "3.5.1",
     "braces": "^2.3.1",
     "yargs-parser": "^13.1.2",
     "lodash": "^4.17"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6205,7 +6205,7 @@ jest-worker@^26.6.2:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jest@^23.6.2:
+jest@^26.6.3:
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/jest/-/jest-26.6.3.tgz#40e8fdbe48f00dfa1f0ce8121ca74b88ac9148ef"
   integrity sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
@@ -6224,12 +6224,7 @@ jquery.mousewheel@^3.1.9:
   resolved "https://registry.yarnpkg.com/jquery.mousewheel/-/jquery.mousewheel-3.1.9.tgz#b1e162f1df8aaf6c24fbf923d3d6c58c52d9553e"
   integrity sha1-seFi8d+Kr2wk+/kj09bFjFLZVT4=
 
-jquery@3.5.0, jquery@>=1.8.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
-  integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
-
-jquery@^3.4.0:
+jquery@3.5.1, jquery@>=1.8.0, jquery@^3.4.0:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
   integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==


### PR DESCRIPTION
Multiple JQ versions means trouble in the land of JS. Webpack does not
know which to use. And are used in conjunction, causing the one to have
a certain library and the oterh version not.

Pinning to the newest JQuery version seemed to fix the issue.

https://www.pivotaltracker.com/story/show/176979397