### PR TITLE
Remove default scope from Oidcng RP entities

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
@@ -202,12 +202,9 @@ class OidcngJsonGenerator implements GeneratorInterface
         $metadata['NameIDFormat'] = $entity->getMetaData()->getNameIdFormat();
 
         // If the entity exists in Manage, use the scopes configured there.
-        if ($entity->isManageEntity()) {
+        if ($entity->isManageEntity() && $entity->getOidcClient()->getScope()) {
             // This prevents overwriting the scopes attribute. See: https://www.pivotaltracker.com/story/show/170868465
             $metadata['scopes'] = $entity->getOidcClient()->getScope();
-        } else {
-            // Will become configurable some time in the future.
-            $metadata['scopes'] = ['openid'];
         }
 
         $this->setExcludeFromPush($metadata, $entity);

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcngClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcngClient.php
@@ -62,7 +62,7 @@ class OidcngClient implements OidcClientInterface
         $clientId = self::getStringOrEmpty($data['data'], 'entityid');
         $clientSecret = self::getStringOrEmpty($data['data']['metaDataFields'], 'secret');
         $redirectUris = self::getStringOrEmpty($data['data']['metaDataFields'], 'redirectUrls');
-        $scope = self::getStringOrEmpty($data['data']['metaDataFields'], 'scopes');
+        $scope = self::getStringOrNull($data['data']['metaDataFields'], 'scopes');
 
         $grantType = isset($data['data']['metaDataFields']['grants'])
             ? reset($data['data']['metaDataFields']['grants']) : '';
@@ -76,7 +76,7 @@ class OidcngClient implements OidcClientInterface
         Assert::string($clientSecret);
         Assert::isArray($redirectUris);
         Assert::string($grantType);
-        Assert::isArray($scope);
+        Assert::nullOrIsArray($scope);
         Assert::boolean($isPublicClient);
         Assert::numeric($accessTokenValidity);
         Assert::isArray($resourceServers);
@@ -101,7 +101,7 @@ class OidcngClient implements OidcClientInterface
         string $clientSecret,
         array $redirectUris,
         string $grantType,
-        array $scope,
+        ?array $scope,
         bool $isPublicClient,
         int $accessTokenValidity,
         array $resourceServers
@@ -124,6 +124,16 @@ class OidcngClient implements OidcClientInterface
     private static function getStringOrEmpty(array $data, $key)
     {
         return isset($data[$key]) ? $data[$key] : '';
+    }
+
+    /**
+     * @param array $data
+     * @param $key
+     * @return string|null
+     */
+    private static function getStringOrNull(array $data, $key)
+    {
+        return isset($data[$key]) ? $data[$key] : null;
     }
 
     /**

--- a/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
@@ -116,7 +116,6 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
                             'uri3',
                         ],
                         'secret' => 'test',
-                        'scopes' => ['openid'],
                         'coin:institution_id' => 'service-institution-id',
                         'coin:institution_guid' => '543b4e5b-76b5-453f-af1e-5648378bb266'
                     ],
@@ -171,7 +170,6 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
                         'metaDataFields.OrganizationDisplayName:nl' => 'orgdisnl',
                         'metaDataFields.OrganizationURL:nl' => 'http://orgnl',
                         'metaDataFields.privacy' => 'privacy',
-                        'metaDataFields.scopes' => ['openid'],
                         'metaDataFields.secret' => 'test',
                         'metaDataFields.redirectUrls' => [
                             'uri1',

--- a/tests/unit/Application/Metadata/fixture/oidc10_rp_response.json
+++ b/tests/unit/Application/Metadata/fixture/oidc10_rp_response.json
@@ -40,9 +40,6 @@
         "uri2",
         "uri3"
       ],
-      "scopes": [
-        "openid"
-      ],
       "grants": [
         "authorization_code",
         "refresh_token"


### PR DESCRIPTION
Stop setting default scope oidc on RP entities. This is no longer required, as the resource servers are migrating to their own entity type.

https://www.pivotaltracker.com/story/show/176961848

