### PR TITLE
Remove remaining OIDC crud

### DIFF
--- a/tests/unit/Application/Metadata/JsonGeneratorStrategyTest.php
+++ b/tests/unit/Application/Metadata/JsonGeneratorStrategyTest.php
@@ -63,7 +63,6 @@ class JsonGeneratorStrategyTest extends MockeryTestCase
 
         $this->strategy = new JsonGeneratorStrategy();
         $this->strategy->addStrategy('saml', $this->generator1);
-        $this->strategy->addStrategy('oidc', $this->generator2);
         $this->strategy->addStrategy('oidcng', $this->generator3);
     }
 
@@ -72,9 +71,6 @@ class JsonGeneratorStrategyTest extends MockeryTestCase
         $entity = m::mock(ManageEntity::class);
 
         $entity->shouldReceive('getProtocol->getProtocol')->andReturn('saml');
-        $this->strategy->generateForNewEntity($entity, 'prodaccepted');
-
-        $entity->shouldReceive('getProtocol->getProtocol')->andReturn('oidc');
         $this->strategy->generateForNewEntity($entity, 'prodaccepted');
 
         $entity->shouldReceive('getProtocol->getProtocol')->andReturn('oidcng');
@@ -86,9 +82,6 @@ class JsonGeneratorStrategyTest extends MockeryTestCase
         $entity = m::mock(ManageEntity::class);
 
         $entity->shouldReceive('getProtocol->getProtocol')->andReturn('saml');
-        $this->strategy->generateForExistingEntity($entity, 'prodaccepted');
-
-        $entity->shouldReceive('getProtocol->getProtocol')->andReturn('oidc');
         $this->strategy->generateForExistingEntity($entity, 'prodaccepted');
 
         $entity->shouldReceive('getProtocol->getProtocol')->andReturn('oidcng');

--- a/tests/unit/Application/ViewObject/EntityTest.php
+++ b/tests/unit/Application/ViewObject/EntityTest.php
@@ -94,7 +94,7 @@ class EntityTest extends MockeryTestCase
             $state,
             $env,
             $protocol,
-            $protocol === 'oidc' ? true : false,
+            false,
             $router
         );
     }

--- a/tests/unit/Domain/Entity/Entity/ProtocolTest.php
+++ b/tests/unit/Domain/Entity/Entity/ProtocolTest.php
@@ -45,11 +45,6 @@ class ProtocolTest extends TestCase
             new Protocol('saml20'),
         ];
         yield [
-            new Protocol('oidc'),
-            new Protocol('oidcng'),
-            new Protocol('oidcng')
-        ];
-        yield [
             new Protocol('saml20'),
             new Protocol(null),
             new Protocol(null),


### PR DESCRIPTION
Some test oidc remaining support was removed. In a previous commit the
OIDC client id generator was removed. This can be seen as part of the
task mentioned below.

https://www.pivotaltracker.com/story/show/175139821