### PR TITLE
Use `oauth20_rs` Manage entity scheme for resource servers

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Constants.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Constants.php
@@ -37,7 +37,7 @@ class Constants
 
     const TYPE_SAML = 'saml20';
     const TYPE_OPENID_CONNECT_TNG = 'oidcng';
-    const TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER = 'oidcng_rs';
+    const TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER = 'oauth20_rs';
 
     const OIDC_SECRET_LENGTH = 20;
 

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Protocol.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Protocol.php
@@ -27,28 +27,24 @@ class Protocol
 
     const OIDC10_RP = 'oidc10_rp';
 
+    const OAUTH20_RS = 'oauth20_rs';
+
     private static $protocolMapping = [
         self::SAML20_SP => Constants::TYPE_SAML,
-        self::OIDC10_RP => Constants::TYPE_OPENID_CONNECT_TNG
+        self::OIDC10_RP => Constants::TYPE_OPENID_CONNECT_TNG,
+        self::OAUTH20_RS => Constants::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER
     ];
 
     private $protocol;
 
     /**
-     * @param array $data
      * @param string $manageProtocol
      * @return Protocol
      * @SuppressWarnings(PHPMD.UndefinedVariable) - protocolMapping is defined, md does not seem to resolve correctly
      */
-    public static function fromApiResponse(array $data, $manageProtocol)
+    public static function fromApiResponse($manageProtocol)
     {
         $protocol = self::$protocolMapping[$manageProtocol];
-
-        $isResourceServer = isset($data['data']['metaDataFields']['isResourceServer']) && $data['data']['metaDataFields']['isResourceServer'];
-        if ($protocol === Constants::TYPE_OPENID_CONNECT_TNG && $isResourceServer) {
-            $protocol = Constants::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER;
-        }
-
         return new self($protocol);
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/ManageEntity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/ManageEntity.php
@@ -88,17 +88,13 @@ class ManageEntity
         $attributeList = AttributeList::fromApiResponse($data);
         $metaData = MetaData::fromApiResponse($data);
         $oidcClient = null;
-        if ($manageProtocol === Protocol::OIDC10_RP) {
-            if (isset($data['data']['metaDataFields']['isResourceServer']) &&
-                $data['data']['metaDataFields']['isResourceServer']
-            ) {
-                $oidcClient = OidcngResourceServerClient::fromApiResponse($data, $manageProtocol);
-            } else {
-                $oidcClient = OidcngClient::fromApiResponse($data, $manageProtocol);
-            }
+        if ($manageProtocol === Protocol::OAUTH20_RS) {
+            $oidcClient = OidcngResourceServerClient::fromApiResponse($data, $manageProtocol);
+        } elseif ($manageProtocol === Protocol::OIDC10_RP) {
+            $oidcClient = OidcngClient::fromApiResponse($data, $manageProtocol);
         }
         $allowedEdentityProviders = AllowedIdentityProviders::fromApiResponse($data);
-        $protocol = Protocol::fromApiResponse($data, $manageProtocol);
+        $protocol = Protocol::fromApiResponse($manageProtocol);
 
         return new self($data['id'], $attributeList, $metaData, $allowedEdentityProviders, $protocol, $oidcClient);
     }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Repository/QueryEntityRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Repository/QueryEntityRepository.php
@@ -29,12 +29,20 @@ interface QueryEntityRepository
      */
     public function findManageIdByEntityId($entityId);
 
+
     /**
      * @param string $manageId
      *
      * @return ManageEntity|null
      */
     public function findByManageId($manageId);
+
+    /**
+     * Use of this method is discouraged, it will try saml, openic and oauth endpoints to find
+     * the entity. If you already know the data type (protocol) of the entity,
+     * please use the findByManageIdAndProtocol instead
+     */
+    public function findByManageIdAndProtocol(string $manageId, string $protocol) :? ManageEntity;
 
     /**
      * @param string $manageId

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
@@ -177,11 +177,6 @@ class EntityCreateController extends Controller
         $form = $this->entityTypeFactory->createCreateForm($type, $service, $targetEnvironment);
         $command = $form->getData();
 
-        // The resource server entity type does not support saving of local drafts
-        if ($type === Constants::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER) {
-            $form->remove('save');
-        }
-
         if ($request->isMethod('post')) {
             $form->handleRequest($request);
         }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -183,7 +183,7 @@ services:
     Surfnet\ServiceProviderDashboard\Application\Metadata\OidcngResourceServerJsonGenerator:
         class: Surfnet\ServiceProviderDashboard\Application\Metadata\OidcngResourceServerJsonGenerator
         tags:
-            - { name: dashboard.json_generator, identifier: oidcng_rs }
+            - { name: dashboard.json_generator, identifier: oauth20_rs }
 
     Surfnet\ServiceProviderDashboard\Legacy\Metadata\Parser:
         arguments:

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -30,7 +30,7 @@ entity:
       oidcng:
         title: Information
         html: <strong>information about this view</strong>
-      oidcng_rs:
+      oauth20_rs:
         title: Information
         html: <strong>information about this view</strong>
     metadata:
@@ -63,7 +63,7 @@ entity:
       oidcng:
         title: Metadata
         html: <strong>information about the metadata fields</strong>
-      oidcng_rs:
+      oauth20_rs:
         title: Metadata
         html: <strong>information about the metadata fields</strong>
     contact:
@@ -83,7 +83,7 @@ entity:
       oidcng:
         title: Contact information
         html: <strong>information about the contact information fields</strong>
-      oidcng_rs:
+      oauth20_rs:
         title: Contact information
         html: <strong>information about the contact information fields</strong>
     attribute:
@@ -251,8 +251,8 @@ should be present.</li>
 <li>A list of the attributes your Service Provider requires to operate.</li>
 </ul>
 "
-entity.edit.info.oidcng_rs.title: Info
-entity.edit.info.oidcng_rs.html: "
+entity.edit.info.oauth20_rs.title: Info
+entity.edit.info.oauth20_rs.html: "
 <p>Documentation about this SP registration form can be found at:
 <a href=\"https://wiki.surfnet.nl/x/isZWAw\">https://wiki.surfnet.nl/x/isZWAw</a>.</p>
 
@@ -272,13 +272,13 @@ entity.edit.metadata.fetch.exception: "Unable to load the metadata from the prov
 entity.edit.metadata.saml20.html: "Please provide the metadata URL of your entity. The URL will be validated and the fields below will be filled in automatically (when available in the metadata). <strong>If the input is not correct please change the settings in your SAML enabled software.</strong> Note that the fields with a * are required and need to be correctly configured. Check the following page for more information: <a href=\"https://wiki.surfnet.nl/x/vclWAw\">https://wiki.surfnet.nl/x/vclWAw</a>."
 entity.edit.metadata.oidc.html: "Please provide the metadata URL of your entity. The URL will be validated and the fields below will be filled in automatically (when available in the metadata). <strong>If the input is not correct please change the settings in your SAML enabled software.</strong> Note that the fields with a * are required and need to be correctly configured. Check the following page for more information: <a href=\"https://wiki.surfnet.nl/x/vclWAw\">https://wiki.surfnet.nl/x/vclWAw</a>."
 entity.edit.metadata.oidcng.html: "Please provide the metadata URL of your entity. The URL will be validated and the fields below will be filled in automatically (when available in the metadata). <strong>If the input is not correct please change the settings in your SAML enabled software.</strong> Note that the fields with a * are required and need to be correctly configured. Check the following page for more information: <a href=\"https://wiki.surfnet.nl/x/vclWAw\">https://wiki.surfnet.nl/x/vclWAw</a>."
-entity.edit.metadata.oidcng_rs.html: "Please provide the metadata URL of your entity. The URL will be validated and the fields below will be filled in automatically (when available in the metadata). <strong>If the input is not correct please change the settings in your SAML enabled software.</strong> Note that the fields with a * are required and need to be correctly configured. Check the following page for more information: <a href=\"https://wiki.surfnet.nl/x/vclWAw\">https://wiki.surfnet.nl/x/vclWAw</a>."
+entity.edit.metadata.oauth20_rs.html: "Please provide the metadata URL of your entity. The URL will be validated and the fields below will be filled in automatically (when available in the metadata). <strong>If the input is not correct please change the settings in your SAML enabled software.</strong> Note that the fields with a * are required and need to be correctly configured. Check the following page for more information: <a href=\"https://wiki.surfnet.nl/x/vclWAw\">https://wiki.surfnet.nl/x/vclWAw</a>."
 entity.edit.metadata.invalid.exception: "An error occurred while importing the metadata."
 entity.edit.metadata.validation-failed: "Warning! Some entries are missing or incorrect. Please review and fix those entries below."
 entity.edit.metadata.saml20.title: Metadata
 entity.edit.metadata.oidc.title: Metadata
 entity.edit.metadata.oidcng.title: Metadata
-entity.edit.metadata.oidcng_rs.title: Metadata
+entity.edit.metadata.oauth20_rs.title: Metadata
 entity.edit.metadata.parse.exception: "The provided metadata is invalid."
 entity.edit.contact_information.title: Contact information
 entity.edit.contact_information.html: "
@@ -320,8 +320,8 @@ entity.edit.attributes.oidcng.html: "
 
 <p><i>Identity Providers will be informed about the attributes your service requests and must agree to the release of these attributes to your entity.</i></p>
 "
-entity.edit.attributes.oidcng_rs.title: Attributes
-entity.edit.attributes.oidcng_rs.html: "
+entity.edit.attributes.oauth20_rs.title: Attributes
+entity.edit.attributes.oauth20_rs.html: "
 <p>When an end-user logs in to your SP, SURFconext sends a SAML-assertion to the SP. The SAML-assertion contains statements about the user, including identity and possibly a number of other attributes (see list below). Select the attributes this service requires to operate. For each attribute you request a <strong>valid reason</strong> must be provided which will be reviewed. Note: <strong>every extra attribute you request could complicate the contractual phase</strong>: just one more reason to not select more attributes than you absolutely need. Also note that SURFconext operates with a minimal disclosure principle. This means that only the absolute necessary (personal) information is transferred to a entity. Check this page for more information: <a href=\"https://wiki.surfnet.nl/x/xcpWAw\">https://wiki.surfnet.nl/x/xcpWAw</a>.</p>
 
 <p>Possibly some boxes have already been checked. This information is reused from the metadata.</p>

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detail.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detail.html.twig
@@ -42,7 +42,7 @@
             {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.access_token_validity'|trans, value: entity.accessTokenValidity, informationPopup: 'entity.edit.information.accessTokenValidity'} %}
         {% endif %}
 
-        {% if entity.protocol == "oidcng_rs" %}
+        {% if entity.protocol == "oauth20_rs" %}
             {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.client_id'|trans, value: entity.entityId, informationPopup: 'entity.edit.information.clientId'} %}
         {% endif %}
 
@@ -75,7 +75,7 @@
 
     </div>
 
-    {% if entity.protocol != "oidcng_rs" %}
+    {% if entity.protocol != "oauth20_rs" %}
 
     <div class="fieldset card">
         <h2>{{ ('entity.detail.attribute.' ~ type ~ '.title')|trans }}</h2>

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Http/HttpClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Http/HttpClient.php
@@ -29,7 +29,6 @@ use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Http\Exception\Unread
 final class HttpClient
 {
     const MODE_TEST = 'test';
-    const MODE_PROD = 'production';
 
     /**
      * @var ClientInterface

--- a/tests/unit/Application/Metadata/OidcngResourceServerJsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/OidcngResourceServerJsonGeneratorTest.php
@@ -72,20 +72,14 @@ class OidcngResourceServerJsonGeneratorTest extends MockeryTestCase
         $this->assertEquals(
             [
                 'data' => [
-                    'type' => 'oidc10-rp',
+                    'type' => 'oauth20_rs',
                     'state' => 'testaccepted',
                     'entityid' => 'entityid',
                     'active' => true,
-                    'allowedEntities' => [],
-                    'allowedall' => true,
                     'revisionnote' => 'revisionnote',
                     'metaDataFields' => [
                         'description:en' => 'description en',
                         'description:nl' => 'description nl',
-                        'grants' => [
-                            'client_credentials',
-                        ],
-                        'isResourceServer' => true,
                         'name:en' => 'name en',
                         'name:nl' => 'name nl',
                         'NameIDFormat' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent', // hardcoded
@@ -103,7 +97,7 @@ class OidcngResourceServerJsonGeneratorTest extends MockeryTestCase
                         'coin:institution_guid' => '543b4e5b-76b5-453f-af1e-5648378bb266',
                     ],
                 ],
-                'type' => 'oidc10_rp',
+                'type' => 'oauth20_rs',
             ],
             $data
         );
@@ -137,20 +131,15 @@ class OidcngResourceServerJsonGeneratorTest extends MockeryTestCase
                         'metaDataFields.OrganizationName:nl' => 'orgnl',
                         'metaDataFields.scopes' => ['openid'],
                         'metaDataFields.secret' => 'test',
-                        'metaDataFields.grants' => [
-                            'client_credentials',
-                        ],
-                        'metaDataFields.isResourceServer' => true,
                         'state' => 'testaccepted',
-                        'allowedEntities' => [],
-                        'allowedall' => true,
                         'metaDataFields.privacy' => 'privacy',
                         'metaDataFields.coin:institution_id' => 'service-institution-id',
                         'metaDataFields.coin:institution_guid' => '543b4e5b-76b5-453f-af1e-5648378bb266',
                         'revisionnote' => 'revisionnote'
                     ),
-                'type' => 'oidc10_rp',
+                'type' => 'oauth20_rs',
                 'id' => 'manageId',
+                'active' => true,
             ),
             $data
         );
@@ -161,7 +150,7 @@ class OidcngResourceServerJsonGeneratorTest extends MockeryTestCase
         ?string $environment = null
     ): ManageEntity {
 
-        $entity = ManageEntity::fromApiResponse(json_decode(file_get_contents(__DIR__ . '/fixture/oidc10_rp_response.json'), true));
+        $entity = ManageEntity::fromApiResponse(json_decode(file_get_contents(__DIR__ . '/fixture/oauth20_rs_response.json'), true));
         $service = new Service();
         $service->setGuid('543b4e5b-76b5-453f-af1e-5648378bb266');
         $service->setInstitutionId('service-institution-id');

--- a/tests/unit/Application/Metadata/fixture/oauth20_rs_response.json
+++ b/tests/unit/Application/Metadata/fixture/oauth20_rs_response.json
@@ -1,0 +1,44 @@
+{
+  "id": "manageId",
+  "type": "oauth20_rs",
+  "data": {
+    "entityid": "entityid",
+    "state": "prodaccepted",
+    "allowedall": true,
+    "arp": {
+      "enabled": true,
+      "attributes": {
+        "urn:mace:dir:attribute-def:uid": [
+          {
+            "value": "*",
+            "source": "idp",
+            "motivation": ""
+          }
+        ]
+      }
+    },
+    "metaDataFields": {
+      "coin:institution_guid" : "96d75330-beed-11e7-8f1a-0800200c9a66",
+      "coin:service_team_id" : "urn:collab:group:test.example.com:test",
+      "contacts:1:contactType" : "support",
+      "contacts:1:emailAddress" : "emailaddress",
+      "contacts:1:givenName" : "givenname",
+      "contacts:1:surName" : "surname",
+      "contacts:1:telephoneNumber" : "telephonenumber",
+      "description:en" : "description en",
+      "description:nl" : "description nl",
+      "name:en" : "name en",
+      "name:nl" : "name nl",
+      "OrganizationName:en": "orgen",
+      "OrganizationDisplayName:en": "orgdisen",
+      "OrganizationURL:en": "http://orgen",
+      "OrganizationName:nl": "orgnl",
+      "OrganizationDisplayName:nl": "orgdisnl",
+      "OrganizationURL:nl": "http://orgnl",
+      "scopes" : [ "openid" ],
+      "secret" : "test"
+    },
+    "type": "oauth20-rs",
+    "revisionnote": "Some revision note"
+  }
+}

--- a/tests/unit/Infrastructure/DashboardBundle/Factory/EntityTypeFactoryTest.php
+++ b/tests/unit/Infrastructure/DashboardBundle/Factory/EntityTypeFactoryTest.php
@@ -193,7 +193,7 @@ class EntityTypeFactoryTest extends MockeryTestCase
         $this->assertInstanceOf(FormType::class, $form);
     }
 
-    public function test_build_create_new_oidcng_rs_form()
+    public function test_build_create_new_oauth20_rs_form()
     {
         $this->formFactory
             ->shouldReceive('create')

--- a/tests/unit/Infrastructure/Manage/Client/fixture/search_result_overwrite_bug/read_response_oauth.json
+++ b/tests/unit/Infrastructure/Manage/Client/fixture/search_result_overwrite_bug/read_response_oauth.json
@@ -1,0 +1,46 @@
+{
+  "id": "710c61af-411d-4bfb-af16-251d9f7b8027",
+  "version": 1,
+  "type": "oauth20_rs",
+  "revision": {
+    "number": 1,
+    "created": 1570441986.983,
+    "parentId": null,
+    "updatedBy": "urn:collab:person:example.com:admin",
+    "terminated": null
+  },
+  "data": {
+    "entityid": "test.oauth20_rs.example.com",
+    "state": "prodaccepted",
+    "metaDataFields": {
+      "name:en": "MijnUu app | Uu",
+      "secret": "$2a$10$DX5wtBQtWT3SkhJVzEeb1uBGOJyBjVNcsOFkoJtABKmd7tYxy9UQy",
+      "scopes": [
+        "openid"
+      ],
+      "NameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+      "contacts:2:givenName": "Test",
+      "contacts:1:surName": "Test",
+      "contacts:2:emailAddress": "test@uu.example.com",
+      "logo:0:width": 200,
+      "contacts:0:emailAddress": "test@uu.example.com",
+      "contacts:0:contactType": "technical",
+      "contacts:2:contactType": "administrative",
+      "contacts:1:contactType": "support",
+      "contacts:1:givenName": "Test",
+      "name:nl": "MijnUu app | Uu",
+      "description:en": "MijnUu app",
+      "coin:service_team_id": "team-UU",
+      "contacts:2:surName": "Test",
+      "description:nl": "MijnUu app",
+      "logo:0:url": "https://static.openconext.nl/media/sp/Uu.png",
+      "contacts:0:givenName": "Test",
+      "contacts:0:surName": "Test",
+      "contacts:1:emailAddress": "test@uu.example.com",
+      "logo:0:height": 160
+    },
+    "type": "oauth20_rs",
+    "revisionnote": "Some revision note",
+    "eid": 53
+  }
+}

--- a/tests/unit/Infrastructure/Manage/Client/fixture/search_result_overwrite_bug/search_oauth.json
+++ b/tests/unit/Infrastructure/Manage/Client/fixture/search_result_overwrite_bug/search_oauth.json
@@ -1,0 +1,15 @@
+[
+  {
+    "_id": "710c61af-411d-4bfb-af16-251d9f7b8028",
+    "version": 1,
+    "type": "oauth20_rs",
+    "data": {
+      "entityid": "test.oauth-rs.example.com",
+      "state": "prodaccepted",
+      "metaDataFields": {
+        "name:en": "Test 8 | UU",
+        "name:nl": "Test 8 | UU"
+      }
+    }
+  }
+]

--- a/tests/unit/Infrastructure/Manage/Client/fixture/search_result_overwrite_bug/search_oidc.json
+++ b/tests/unit/Infrastructure/Manage/Client/fixture/search_result_overwrite_bug/search_oidc.json
@@ -2,6 +2,7 @@
   {
     "_id": "710c61af-411d-4bfb-af16-251d9f7b8027",
     "version": 1,
+    "type": "oidc10_rp",
     "data": {
       "entityid": "test.oidcng.example.com",
       "state": "prodaccepted",
@@ -14,6 +15,7 @@
   {
     "_id": "810c61af-411d-4bfb-af16-251d9f7b8027",
     "version": 1,
+    "type": "oidc10_rp",
     "data": {
       "entityid": "test2.oidcng.example.com",
       "state": "prodaccepted",
@@ -26,6 +28,7 @@
   {
     "_id": "910c61af-411d-4bfb-af16-251d9f7b8027",
     "version": 1,
+    "type": "oidc10_rp",
     "data": {
       "entityid": "test3.oidcng.example.com",
       "state": "prodaccepted",

--- a/tests/unit/Infrastructure/Manage/Client/fixture/search_result_overwrite_bug/search_saml.json
+++ b/tests/unit/Infrastructure/Manage/Client/fixture/search_result_overwrite_bug/search_saml.json
@@ -2,6 +2,7 @@
   {
     "_id": "1c7b3d8b-7897-4cc1-8521-df4f65b615c5",
     "version": 0,
+    "type": "saml20_sp",
     "data": {
       "entityid": "https://test1.saml.example.com",
       "state": "prodaccepted",
@@ -14,6 +15,7 @@
   {
     "_id": "2c7b3d8b-7897-4cc1-8521-df4f65b615c5",
     "version": 0,
+    "type": "saml20_sp",
     "data": {
       "entityid": "https://test2.saml.example.com",
       "state": "prodaccepted",

--- a/tests/unit/Infrastructure/Manage/Dto/ProtocolTest.php
+++ b/tests/unit/Infrastructure/Manage/Dto/ProtocolTest.php
@@ -29,17 +29,18 @@ class ProtocolTest extends MockeryTestCase
      * @param int $manageProtocol
      * @param string $expectation
      */
-    public function test_protocol_determination(array $manageData, $manageProtocol, $expectation)
+    public function test_protocol_determination($manageProtocol, $expectation)
     {
-        $protocol = Protocol::fromApiResponse($manageData, $manageProtocol);
+        $protocol = Protocol::fromApiResponse($manageProtocol);
         self::assertEquals($expectation, $protocol->getProtocol());
     }
 
     public static function manageData()
     {
         return [
-            [['data' => ['oidcClient-not-set' => null]], Protocol::SAML20_SP, 'saml20'],
-            [['data' => ['oidcClient-not-set' => 1]], Protocol::OIDC10_RP, 'oidcng'],
+            [Protocol::SAML20_SP, 'saml20'],
+            [Protocol::OIDC10_RP, 'oidcng'],
+            [Protocol::OAUTH20_RS, 'oauth20_rs'],
         ];
     }
 }

--- a/tests/webtests/EntityCreateOidcngResourceServerTest.php
+++ b/tests/webtests/EntityCreateOidcngResourceServerTest.php
@@ -36,7 +36,7 @@ class EntityCreateOidcngResourceServerTest extends WebTestCase
 
     public function test_it_renders_the_form()
     {
-        $crawler = $this->client->request('GET', "/entity/create/2/oidcng_rs/test");
+        $crawler = $this->client->request('GET', "/entity/create/2/oauth20_rs/test");
         $form = $crawler->filter('.page-container')
             ->selectButton('Publish')
             ->form();
@@ -52,7 +52,7 @@ class EntityCreateOidcngResourceServerTest extends WebTestCase
 
     public function test_it_can_cancel_out_of_the_form()
     {
-        $crawler = $this->client->request('GET', "/entity/create/2/oidcng_rs/test");
+        $crawler = $this->client->request('GET', "/entity/create/2/oauth20_rs/test");
         $form = $crawler
             ->selectButton('Cancel')
             ->form();
@@ -76,7 +76,7 @@ class EntityCreateOidcngResourceServerTest extends WebTestCase
 
     public function test_it_can_not_save_the_form_drafts_are_disabled()
     {
-        $crawler = $this->client->request('GET', "/entity/create/2/oidcng_rs/test");
+        $crawler = $this->client->request('GET', "/entity/create/2/oauth20_rs/test");
 
         // There is a publish button instead
         $buttonNodes = $crawler->filter('button#dashboard_bundle_entity_type_publishButton');
@@ -92,7 +92,7 @@ class EntityCreateOidcngResourceServerTest extends WebTestCase
         $this->testPublicationClient->registerPublishResponse('https://entity-id', '{"id":"f1e394b2-08b1-4882-8b32-43876c15c743"}');
         $formData = $this->buildValidFormData();
 
-        $crawler = $this->client->request('GET', "/entity/create/2/oidcng_rs/test");
+        $crawler = $this->client->request('GET', "/entity/create/2/oauth20_rs/test");
 
         $form = $crawler
             ->selectButton('Publish')
@@ -133,7 +133,7 @@ class EntityCreateOidcngResourceServerTest extends WebTestCase
         );
 
         $formData = $this->buildValidFormData();
-        $crawler = $this->client->request('GET', "/entity/create/2/oidcng_rs/test");
+        $crawler = $this->client->request('GET', "/entity/create/2/oauth20_rs/test");
 
         $form = $crawler
             ->selectButton('Publish')
@@ -155,7 +155,7 @@ class EntityCreateOidcngResourceServerTest extends WebTestCase
         // SURFnet is not allowed to create production entities.
         $this->switchToService('SURFnet');
 
-        $this->client->request('GET', "/entity/create/1/oidcng_rs/production");
+        $this->client->request('GET', "/entity/create/1/oauth20_rs/production");
 
         $this->assertEquals(403, $this->client->getResponse()->getStatusCode());
     }

--- a/tests/webtests/Manage/Client/FakeQueryClient.php
+++ b/tests/webtests/Manage/Client/FakeQueryClient.php
@@ -97,4 +97,9 @@ class FakeQueryClient implements QueryEntityRepository
             }
         }
     }
+
+    public function findByManageIdAndProtocol(string $manageId, string $protocol) :? ManageEntity
+    {
+        return $this->findByManageId($manageId);
+    }
 }


### PR DESCRIPTION
This updates SPDashboard to work with the new Manage enitty type: oauth20_rs. The previous piggy back strategy to register these entities on the oidc10_rp type is no longer required. More info in the story: https://www.pivotaltracker.com/story/show/176961821

Only the last commit of this PR needs to be reviewed. Before merging. This PR must be rebased onto develop. To functionally test this. The new Docker Dev env should be used. This should be as simple as running `docker-compose up`.