### PR TITLE
Ensure copy ClientId is editable

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
@@ -348,18 +348,23 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      */
     private $resourceServers = [];
 
+    /** @var bool */
+    private $isCopy;
+
     public function __construct()
     {
     }
 
     /**
      * @param Service $service
+     * @param bool $isCopy
      * @return SaveOidcngEntityCommand
      */
-    public static function forCreateAction(Service $service)
+    public static function forCreateAction(Service $service, bool $isCopy = false)
     {
         $command = new self();
         $command->service = $service;
+        $command->isCopy = $isCopy;
         return $command;
     }
 
@@ -382,6 +387,22 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
     public function getService(): Service
     {
         return $this->service;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isCopy()
+    {
+        return $this->isCopy;
+    }
+
+    /**
+     * @param bool $isCopy
+     */
+    public function setIsCopy(bool $isCopy)
+    {
+        $this->isCopy = $isCopy;
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngResourceServerEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngResourceServerEntityCommand.php
@@ -143,18 +143,23 @@ class SaveOidcngResourceServerEntityCommand implements SaveEntityCommandInterfac
      */
     private $manageId;
 
+    /** @var bool */
+    private $isCopy;
+
     public function __construct()
     {
     }
 
     /**
      * @param Service $service
+     * @param bool $isCopy
      * @return SaveOidcngResourceServerEntityCommand
      */
-    public static function forCreateAction(Service $service)
+    public static function forCreateAction(Service $service, bool $isCopy = false): SaveOidcngResourceServerEntityCommand
     {
         $command = new self();
         $command->service = $service;
+        $command->isCopy = $isCopy;
 
         return $command;
     }
@@ -178,6 +183,22 @@ class SaveOidcngResourceServerEntityCommand implements SaveEntityCommandInterfac
     public function getService(): Service
     {
         return $this->service;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isCopy()
+    {
+        return $this->isCopy;
+    }
+
+    /**
+     * @param bool $isCopy
+     */
+    public function setIsCopy(bool $isCopy)
+    {
+        $this->isCopy = $isCopy;
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
@@ -264,7 +264,7 @@ class EntityCreateController extends Controller
         $entity->setEnvironment($targetEnvironment);
 
         // load entity into form
-        $form = $this->entityTypeFactory->createEditForm($entity, $service, $targetEnvironment);
+        $form = $this->entityTypeFactory->createEditForm($entity, $service, $targetEnvironment, true);
         $command = $form->getData();
 
         // A copy can never be saved as draft: changes are published directly to manage.

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Factory/EntityTypeFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Factory/EntityTypeFactory.php
@@ -65,13 +65,17 @@ class EntityTypeFactory
             case ($type === Constants::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER):
                 $command = SaveOidcngResourceServerEntityCommand::forCreateAction($service);
                 $command->setEnvironment($environment);
-                return $this->formFactory->create(OidcngResourceServerEntityType::class, $command, $this->buildOptions($environment));
+                return $this->formFactory->create(
+                    OidcngResourceServerEntityType::class,
+                    $command,
+                    $this->buildOptions($environment)
+                );
         }
 
         throw new InvalidArgumentException("invalid form type requested: " . $type);
     }
 
-    public function createEditForm(ManageEntity $entity, Service $service, string $environment)
+    public function createEditForm(ManageEntity $entity, Service $service, string $environment, $isCopy = false)
     {
         switch ($entity->getProtocol()->getProtocol()) {
             case (Constants::TYPE_SAML):
@@ -79,13 +83,23 @@ class EntityTypeFactory
                 $command->setService($service);
                 return $this->formFactory->create(SamlEntityType::class, $command, $this->buildOptions($environment));
             case (Constants::TYPE_OPENID_CONNECT_TNG):
-                $command = $this->saveCommandFactory->buildOidcngCommandByManageEntity($entity, $environment);
+                $command = $this->saveCommandFactory->buildOidcngCommandByManageEntity($entity, $environment, $isCopy);
                 $command->setService($service);
                 return $this->formFactory->create(OidcngEntityType::class, $command, $this->buildOptions($environment));
             case (Constants::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER):
-                $command = $this->saveCommandFactory->buildOidcngRsCommandByManageEntity($entity, $environment);
+                $command = $this
+                    ->saveCommandFactory
+                    ->buildOidcngRsCommandByManageEntity(
+                        $entity,
+                        $environment,
+                        $isCopy
+                    );
                 $command->setService($service);
-                return $this->formFactory->create(OidcngResourceServerEntityType::class, $command, $this->buildOptions($environment));
+                return $this->formFactory->create(
+                    OidcngResourceServerEntityType::class,
+                    $command,
+                    $this->buildOptions($environment)
+                );
         }
 
         throw new InvalidArgumentException("invalid form type requested");

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
@@ -78,8 +78,9 @@ class OidcngEntityType extends AbstractType
 
         /** @var SaveOidcngEntityCommand $command */
         $command = $options['data'];
-        $manageId = $options['data']->getManageId();
-        if (!empty($manageId)) {
+        $copy = $command->isCopy();
+        $manageId = $command->getManageId();
+        if (!empty($manageId) && !$copy) {
             $metadata->remove('clientId');
             $metadata
                 ->add(

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Factory/SaveCommandFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Factory/SaveCommandFactory.php
@@ -57,8 +57,10 @@ class SaveCommandFactory implements SaveCommandFactoryInterface
         $this->playGroundUriProd = $oidcPlaygroundUriProd;
     }
 
-    public function buildSamlCommandByManageEntity(ManageEntity $manageEntity, string $environment): SaveSamlEntityCommand
-    {
+    public function buildSamlCommandByManageEntity(
+        ManageEntity $manageEntity,
+        string $environment
+    ): SaveSamlEntityCommand {
         $command = new SaveSamlEntityCommand();
         $metaData = $manageEntity->getMetaData();
         $coins = $manageEntity->getMetaData()->getCoin();
@@ -94,7 +96,7 @@ class SaveCommandFactory implements SaveCommandFactoryInterface
         return $command;
     }
 
-    public function buildOidcngCommandByManageEntity(ManageEntity $manageEntity, string $environment): SaveOidcngEntityCommand
+    public function buildOidcngCommandByManageEntity(ManageEntity $manageEntity, string $environment, bool $isCopy = false): SaveOidcngEntityCommand
     {
         $command = new SaveOidcngEntityCommand();
         $metaData = $manageEntity->getMetaData();
@@ -109,6 +111,7 @@ class SaveCommandFactory implements SaveCommandFactoryInterface
         $command->setAdministrativeContact(Contact::from($metaData->getContacts()->findAdministrativeContact()));
         $command->setTechnicalContact(Contact::from($metaData->getContacts()->findTechnicalContact()));
         $command->setSupportContact(Contact::from($metaData->getContacts()->findSupportContact()));
+        $command->setIsCopy($isCopy);
 
         // Organization data
         $command->setNameNl($metaData->getNameNl());
@@ -148,8 +151,11 @@ class SaveCommandFactory implements SaveCommandFactoryInterface
         return $command;
     }
 
-    public function buildOidcngRsCommandByManageEntity(ManageEntity $manageEntity, string $environment): SaveOidcngResourceServerEntityCommand
-    {
+    public function buildOidcngRsCommandByManageEntity(
+        ManageEntity $manageEntity,
+        string $environment,
+        bool $isCopy = false
+    ): SaveOidcngResourceServerEntityCommand {
         $command = new SaveOidcngResourceServerEntityCommand();
         $metaData = $manageEntity->getMetaData();
 
@@ -158,6 +164,7 @@ class SaveCommandFactory implements SaveCommandFactoryInterface
         $command->setStatus($manageEntity->getStatus());
         $command->setEnvironment($environment);
         $command->setEntityId($metaData->getEntityId());
+        $command->setIsCopy($isCopy);
 
         $command->setSecret($manageEntity->getOidcClient()->getClientSecret());
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Factory/SaveCommandFactoryInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Factory/SaveCommandFactoryInterface.php
@@ -25,9 +25,20 @@ use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 
 interface SaveCommandFactoryInterface
 {
-    public function buildSamlCommandByManageEntity(ManageEntity $manageEntity, string $environment): SaveSamlEntityCommand;
+    public function buildSamlCommandByManageEntity(
+        ManageEntity $manageEntity,
+        string $environment
+    ): SaveSamlEntityCommand;
 
-    public function buildOidcngCommandByManageEntity(ManageEntity $manageEntity, string $environment): SaveOidcngEntityCommand;
+    public function buildOidcngCommandByManageEntity(
+        ManageEntity $manageEntity,
+        string $environment,
+        bool $isCopy = false
+    ): SaveOidcngEntityCommand;
 
-    public function buildOidcngRsCommandByManageEntity(ManageEntity $manageEntity, string $environment): SaveOidcngResourceServerEntityCommand;
+    public function buildOidcngRsCommandByManageEntity(
+        ManageEntity $manageEntity,
+        string $environment,
+        bool $isCopy = false
+    ): SaveOidcngResourceServerEntityCommand;
 }


### PR DESCRIPTION
Prior to this change, when copying a oicdng or oicdng-rs entity, the id was not editable.

This change adds a check to see whether or not the edit form is due to a copy action.  If it is a copy action, the id field is editable.  Else it is not.

See the story in pivotal for more info: https://www.pivotaltracker.com/story/show/165599582