### PR TITLE
Allow setting multiple grants

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@ Vagrant.configure(2) do |config|
     v.customize ["modifyvm", :id, "--ioapic", "on"]
     v.customize ["modifyvm", :id, "--memory", "6072"]
   end
-  
+
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "ansible/vagrant.yml"
     ansible.groups = {

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
@@ -94,21 +94,16 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
     private $redirectUrls;
 
     /**
-     * @var array
-     */
-    private $scopes = ['openid'];
-
-    /**
      * @var bool
      */
     private $isPublicClient;
 
     /**
-     * @var string $grantType defaults to OidcGrantType::GRANT_TYPE_AUTHORIZATION_CODE
+     * @var array $grants defaults to OidcGrantType::GRANT_TYPE_AUTHORIZATION_CODE
      *
      * @Assert\NotBlank()
      */
-    private $grantType = OidcGrantType::GRANT_TYPE_AUTHORIZATION_CODE;
+    private $grants = [OidcGrantType::GRANT_TYPE_AUTHORIZATION_CODE];
 
     /**
      * @var int
@@ -940,14 +935,6 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
     }
 
     /**
-     * @return array
-     */
-    public function getScopes()
-    {
-        return $this->scopes;
-    }
-
-    /**
      * @return bool
      */
     public function isPublicClient()
@@ -998,17 +985,17 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
     /**
      * @return OidcGrantType
      */
-    public function getGrantType()
+    public function getGrants()
     {
-        return $this->grantType;
+        return $this->grants;
     }
 
     /**
-     * @param OidcGrantType $grantType
+     * @param OidcGrantType $grants
      */
-    public function setGrantType($grantType)
+    public function setGrants($grants)
     {
-        $this->grantType = $grantType;
+        $this->grants = $grants;
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngResourceServerEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngResourceServerEntityCommand.php
@@ -141,9 +141,10 @@ class SaveOidcngResourceServerEntityCommand implements SaveEntityCommandInterfac
     /** @var bool */
     private $isCopy;
 
-    public function __construct()
-    {
-    }
+    /**
+     * @var string[]
+     */
+    private $scopes = ['oidc'];
 
     /**
      * @param Service $service

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngResourceServerEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngResourceServerEntityCommand.php
@@ -77,11 +77,6 @@ class SaveOidcngResourceServerEntityCommand implements SaveEntityCommandInterfac
     private $secret;
 
     /**
-     * @var array
-     */
-    private $scopes = ['openid'];
-
-    /**
      * @var string
      * @Assert\NotBlank()
      */

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
@@ -49,28 +49,14 @@ class OidcngJsonGenerator implements GeneratorInterface
      */
     private $spDashboardMetadataGenerator;
 
-    /**
-     * @var string
-     */
-    private $oidcPlaygroundUriTest;
-
-    /**
-     * @var string
-     */
-    private $oidcPlaygroundUriProd;
-
     public function __construct(
         ArpGenerator $arpMetadataGenerator,
         PrivacyQuestionsMetadataGenerator $privacyQuestionsMetadataGenerator,
-        SpDashboardMetadataGenerator $spDashboardMetadataGenerator,
-        string $oidcPlaygroundUriTest,
-        string $oidcPlaygroundUriProd
+        SpDashboardMetadataGenerator $spDashboardMetadataGenerator
     ) {
         $this->arpMetadataGenerator = $arpMetadataGenerator;
         $this->privacyQuestionsMetadataGenerator = $privacyQuestionsMetadataGenerator;
         $this->spDashboardMetadataGenerator = $spDashboardMetadataGenerator;
-        $this->oidcPlaygroundUriTest = $oidcPlaygroundUriTest;
-        $this->oidcPlaygroundUriProd = $oidcPlaygroundUriProd;
     }
 
     public function generateForNewEntity(ManageEntity $entity, string $workflowState): array
@@ -199,14 +185,6 @@ class OidcngJsonGenerator implements GeneratorInterface
         }
 
         $metadata['NameIDFormat'] = $entity->getMetaData()->getNameIdFormat();
-
-        // If the entity exists in Manage, use the scopes configured there.
-        if ($entity->isManageEntity() && $entity->getOidcClient()->getScope()) {
-            // This prevents overwriting the scopes attribute. See: https://www.pivotaltracker.com/story/show/170868465
-            $metadata['scopes'] = $entity->getOidcClient()->getScope();
-        } else {
-            $metadata['scopes'] = ['oidc'];
-        }
 
         $this->setExcludeFromPush($metadata, $entity);
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
@@ -204,6 +204,8 @@ class OidcngJsonGenerator implements GeneratorInterface
         if ($entity->isManageEntity() && $entity->getOidcClient()->getScope()) {
             // This prevents overwriting the scopes attribute. See: https://www.pivotaltracker.com/story/show/170868465
             $metadata['scopes'] = $entity->getOidcClient()->getScope();
+        } else {
+            $metadata['scopes'] = ['oidc'];
         }
 
         $this->setExcludeFromPush($metadata, $entity);
@@ -231,7 +233,7 @@ class OidcngJsonGenerator implements GeneratorInterface
             }
             // Reset the redirect URI list in order to get a correct JSON formatting (See #163646662)
             $metadata['redirectUrls'] = $entity->getOidcClient()->getRedirectUris();
-            $metadata['grants'] = [$entity->getOidcClient()->getGrantType()];
+            $metadata['grants'] = $entity->getOidcClient()->getGrants();
             $metadata['accessTokenValidity'] = $entity->getOidcClient()->getAccessTokenValidity();
             $metadata['isPublicClient'] = $entity->getOidcClient()->isPublicClient();
         }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
@@ -163,7 +163,7 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
         // By default, OIDC TNG Resource servers are configured to have persistent subject type (name id format)
         $metadata['NameIDFormat'] = Constants::NAME_ID_FORMAT_PERSISTENT;
         // Scopes 'openid' is hardcoded, but other Manage set values should not be overwritten
-        $metadata['scopes'] = $entity->getOidcClient()->getScope();
+        $metadata['scopes'] = $entity->getOidcClient()->getScopes();
 
         if (!in_array('openid', $metadata['scopes'])) {
             $metadata['scopes'][] ='openid';

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityMergeService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityMergeService.php
@@ -119,7 +119,6 @@ class EntityMergeService
                 $secret->getSecret(),
                 $this->buildRedirectUrls($command),
                 $command->getGrants(),
-                null,
                 $command->isPublicClient(),
                 $command->getAccessTokenValidity(),
                 $command->getOidcngResourceServers()
@@ -129,7 +128,7 @@ class EntityMergeService
             $oidcClient = new OidcngResourceServerClient(
                 $command->getClientId(),
                 $secret->getSecret(),
-                null,
+                [],
                 $command->getScopes()
             );
         }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityMergeService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityMergeService.php
@@ -118,8 +118,8 @@ class EntityMergeService
                 $command->getClientId(),
                 $secret->getSecret(),
                 $this->buildRedirectUrls($command),
-                $command->getGrantType(),
-                $command->getScopes(),
+                $command->getGrants(),
+                null,
                 $command->isPublicClient(),
                 $command->getAccessTokenValidity(),
                 $command->getOidcngResourceServers()

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityDetail.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityDetail.php
@@ -236,9 +236,9 @@ class EntityDetail
     private $redirectUris;
 
     /**
-     * @var string
+     * @var array
      */
-    private $grantType;
+    private $grants;
 
     /**
      * @var bool
@@ -275,7 +275,7 @@ class EntityDetail
         $entityDetail->protocol = $entity->getProtocol()->getProtocol();
 
         if ($entity->getProtocol()->getProtocol() === Constants::TYPE_OPENID_CONNECT_TNG) {
-            $entityDetail->grantType = $entity->getOidcClient()->getGrantType();
+            $entityDetail->grants = $entity->getOidcClient()->getGrants();
             $entityDetail->isPublicClient = $entity->getOidcClient()->isPublicClient();
             $entityDetail->accessTokenValidity = $entity->getOidcClient()->getAccessTokenValidity();
             $entityDetail->redirectUris = $entity->getOidcClient()->getRedirectUris();
@@ -673,12 +673,9 @@ class EntityDetail
         return $this->redirectUris;
     }
 
-    /**
-     * @return string
-     */
-    public function getGrantType()
+    public function getGrants(): array
     {
-        return $this->grantType;
+        return $this->grants;
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcClientInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcClientInterface.php
@@ -44,7 +44,7 @@ interface OidcClientInterface
     /**
      * @return array
      */
-    public function getScope();
+    public function getScopes();
 
     /**
      * @return bool

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcClientInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcClientInterface.php
@@ -39,10 +39,7 @@ interface OidcClientInterface
      */
     public function getRedirectUris();
 
-    /**
-     * @return string
-     */
-    public function getGrantType();
+    public function getGrants(): array;
 
     /**
      * @return array

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcngClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcngClient.php
@@ -22,7 +22,6 @@ use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\SecretInterface;
 use Webmozart\Assert\Assert;
 use function array_diff;
-use function array_intersect;
 use function is_null;
 
 class OidcngClient implements OidcClientInterface
@@ -49,10 +48,6 @@ class OidcngClient implements OidcClientInterface
      */
     private $grants;
     /**
-     * @var array
-     */
-    private $scope;
-    /**
      * @var bool
      */
     private $isPublicClient;
@@ -70,7 +65,6 @@ class OidcngClient implements OidcClientInterface
         $clientId = self::getStringOrEmpty($data['data'], 'entityid');
         $clientSecret = self::getStringOrEmpty($data['data']['metaDataFields'], 'secret');
         $redirectUris = self::getArrayOrEmpty($data['data']['metaDataFields'], 'redirectUrls');
-        $scope = self::getStringOrNull($data['data']['metaDataFields'], 'scopes');
 
         $grantType = isset($data['data']['metaDataFields']['grants'])
             ? $data['data']['metaDataFields']['grants'] : [];
@@ -84,7 +78,6 @@ class OidcngClient implements OidcClientInterface
         Assert::string($clientSecret);
         Assert::isArray($redirectUris);
         Assert::isArray($grantType);
-        Assert::nullOrIsArray($scope);
         Assert::boolean($isPublicClient);
         Assert::numeric($accessTokenValidity);
         Assert::isArray($resourceServers);
@@ -94,7 +87,6 @@ class OidcngClient implements OidcClientInterface
             $clientSecret,
             $redirectUris,
             $grantType,
-            $scope,
             $isPublicClient,
             $accessTokenValidity,
             $resourceServers
@@ -109,7 +101,6 @@ class OidcngClient implements OidcClientInterface
         string $clientSecret,
         array $redirectUris,
         array $grants,
-        ?array $scope,
         bool $isPublicClient,
         int $accessTokenValidity,
         array $resourceServers
@@ -118,7 +109,6 @@ class OidcngClient implements OidcClientInterface
         $this->clientSecret = $clientSecret;
         $this->redirectUris = $redirectUris;
         $this->grants = $grants;
-        $this->scope = $scope;
         $this->isPublicClient = $isPublicClient;
         $this->accessTokenValidity = $accessTokenValidity;
         $this->resourceServers = $resourceServers;
@@ -144,17 +134,7 @@ class OidcngClient implements OidcClientInterface
         return isset($data[$key]) ? $data[$key] : [];
     }
 
-    /**
-     * @param array $data
-     * @param $key
-     * @return string|null
-     */
-    private static function getStringOrNull(array $data, $key)
-    {
-        return isset($data[$key]) ? $data[$key] : null;
-    }
-
-    /**
+     /**
      * @return string
      */
     public function getClientId()
@@ -186,9 +166,9 @@ class OidcngClient implements OidcClientInterface
     /**
      * @return array
      */
-    public function getScope()
+    public function getScopes()
     {
-        return $this->scope;
+        // Not implemented for OIDC RPs as per https://www.pivotaltracker.com/story/show/176961848
     }
 
     /**
@@ -231,7 +211,6 @@ class OidcngClient implements OidcClientInterface
         $this->clientSecret = is_null($client->getClientSecret()) ? null : $client->getClientSecret();
         $this->redirectUris = is_null($client->getRedirectUris()) ? null : $client->getRedirectUris();
         $this->mergeGrants($client->getGrants());
-        $this->scope = is_null($client->getScope()) ? null : $client->getScope();
         $this->isPublicClient = is_null($client->isPublicClient()) ? null : $client->isPublicClient();
         $this->accessTokenValidity = is_null($client->getAccessTokenValidity()) ? null : $client->getAccessTokenValidity();
         $this->resourceServers = is_null($client->getResourceServers()) ? null : $client->getResourceServers();

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcngResourceServerClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcngResourceServerClient.php
@@ -35,7 +35,7 @@ class OidcngResourceServerClient implements OidcClientInterface
     /**
      * @var string
      */
-    private $grantType;
+    private $grants;
     /**
      * @var array
      */
@@ -45,19 +45,19 @@ class OidcngResourceServerClient implements OidcClientInterface
     {
         $clientId = isset($data['data']['entityid']) ? $data['data']['entityid'] : '';
         $clientSecret = isset($data['data']['metaDataFields']['secret']) ? $data['data']['metaDataFields']['secret'] : '';
-        $grantType = isset($data['data']['metaDataFields']['grants'])
-            ? reset($data['data']['metaDataFields']['grants']) : '';
+        $grants = isset($data['data']['metaDataFields']['grants'])
+            ? $data['data']['metaDataFields']['grants'] : [];
         $scope = isset($data['data']['metaDataFields']['scopes']) ? $data['data']['metaDataFields']['scopes'] : '';
 
         Assert::stringNotEmpty($clientId);
         Assert::string($clientSecret);
-        Assert::string($grantType);
+        Assert::isArray($grants);
         Assert::isArray($scope);
 
         return new self(
             $clientId,
             $clientSecret,
-            $grantType,
+            $grants,
             $scope
         );
     }
@@ -65,12 +65,12 @@ class OidcngResourceServerClient implements OidcClientInterface
     public function __construct(
         string $clientId,
         ?string $clientSecret,
-        ?string $grantType,
+        array $grants,
         array $scope
     ) {
         $this->clientId = $clientId;
         $this->clientSecret = $clientSecret;
-        $this->grantType = $grantType;
+        $this->grants = $grants;
         $this->scope = $scope;
     }
 
@@ -90,12 +90,9 @@ class OidcngResourceServerClient implements OidcClientInterface
         return $this->clientSecret;
     }
 
-    /**
-     * @return string
-     */
-    public function getGrantType()
+    public function getGrants(): array
     {
-        return $this->grantType;
+        return $this->grants;
     }
 
     /**
@@ -152,7 +149,7 @@ class OidcngResourceServerClient implements OidcClientInterface
     {
         $this->clientId = is_null($client->getClientId()) ? null : $client->getClientId();
         $this->clientSecret = is_null($client->getClientSecret()) ? null : $client->getClientSecret();
-        $this->grantType = is_null($client->getGrantType()) ? null : $client->getGrantType();
+        $this->grants = is_null($client->getGrants()) ? null : $client->getGrants();
         $this->scope = is_null($client->getScope()) ? null : $client->getScope();
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcngResourceServerClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcngResourceServerClient.php
@@ -98,7 +98,7 @@ class OidcngResourceServerClient implements OidcClientInterface
     /**
      * @return array
      */
-    public function getScope()
+    public function getScopes()
     {
         return $this->scope;
     }
@@ -150,6 +150,6 @@ class OidcngResourceServerClient implements OidcClientInterface
         $this->clientId = is_null($client->getClientId()) ? null : $client->getClientId();
         $this->clientSecret = is_null($client->getClientSecret()) ? null : $client->getClientSecret();
         $this->grants = is_null($client->getGrants()) ? null : $client->getGrants();
-        $this->scope = is_null($client->getScope()) ? null : $client->getScope();
+        $this->scope = is_null($client->getScopes()) ? null : $client->getScopes();
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Grants.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Grants.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Domain\ValueObject;
+
+class Grants
+{
+    private $grants = [];
+
+    public function addGrant(OidcGrantType $grant): void
+    {
+        $this->grants[$grant->getGrantType()] = $grant;
+    }
+
+    public function getGrants(): array
+    {
+        return $this->grants;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
@@ -20,6 +20,7 @@ namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\E
 
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngEntityCommand;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\OidcngClient;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -39,7 +40,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class OidcngEntityType extends AbstractType
 {
-
     /**
      * @var OidcngResourceServerOptionsFactory
      */
@@ -147,18 +147,19 @@ class OidcngEntityType extends AbstractType
                 ]
             )
             ->add(
-                'grantType',
+                'grants',
                 ChoiceType::class,
                 [
                     'expanded' => true,
-                    'multiple' => false,
-                    'choices'  => [
-                        'entity.edit.label.authorization_code' => OidcGrantType::GRANT_TYPE_AUTHORIZATION_CODE,
-                        'entity.edit.label.implicit' => OidcGrantType::GRANT_TYPE_IMPLICIT,
-                    ],
+                    'multiple' => true,
+                    'required' => true,
+                    'choices'  => OidcngClient::FORM_MANAGED_GRANTS,
                     'attr' => [
                         'data-help' => 'entity.edit.information.grantType',
                     ],
+                    'choice_attr' => function () {
+                        return ['class' => 'decorated'];
+                    },
                 ]
             )
             ->add(

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -176,9 +176,6 @@ services:
         class: Surfnet\ServiceProviderDashboard\Application\Metadata\OidcngJsonGenerator
         tags:
             - { name: dashboard.json_generator, identifier: oidcng }
-        arguments:
-            $oidcPlaygroundUriTest: '%playground_uri_test%'
-            $oidcPlaygroundUriProd: '%playground_uri_prod%'
 
     Surfnet\ServiceProviderDashboard\Application\Metadata\OidcngResourceServerJsonGenerator:
         class: Surfnet\ServiceProviderDashboard\Application\Metadata\OidcngResourceServerJsonGenerator

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detail.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detail.html.twig
@@ -25,17 +25,10 @@
             {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.name_id_format'|trans, value: entity.nameIdFormat|replace({'urn:oasis:names:tc:SAML:2.0:nameid-format:': ''}), informationPopup: 'entity.edit.information.nameIdFormat'} %}
         {% endif %}
 
-        {% if entity.protocol == "oidc" %}
-            {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.client_id'|trans, value: entity.entityId, informationPopup: 'entity.edit.information.clientId'} %}
-            {% include '@Dashboard/EntityDetail/detailListField.html.twig' with {label: 'entity.detail.metadata.redirect_uris'|trans, value: entity.redirectUris, informationPopup: 'entity.edit.information.redirectUris'} %}
-            {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.grant_type'|trans, value: ('entity.edit.label.' ~ entity.grantType)|trans, informationPopup: 'entity.edit.information.grantType'} %}
-            {% include '@Dashboard/EntityDetail/detailBooleanField.html.twig' with {label: 'entity.detail.metadata.playground_enabled'|trans, value: entity.playgroundEnabled, informationPopup: 'entity.edit.information.enablePlayground'} %}
-        {% endif %}
-
         {% if entity.protocol == "oidcng" %}
             {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.client_id'|trans, value: entity.entityId, informationPopup: 'entity.edit.information.clientId'} %}
             {% include '@Dashboard/EntityDetail/detailListField.html.twig' with {label: 'entity.detail.metadata.redirect_uris'|trans, value: entity.redirectUris, informationPopup: 'entity.edit.information.redirectUris'} %}
-            {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.grant_type'|trans, value: ('entity.edit.label.' ~ entity.grantType)|trans, informationPopup: 'entity.edit.information.grantType'} %}
+            {% include '@Dashboard/EntityDetail/detailListField.html.twig' with {label: 'entity.detail.metadata.grant_type'|trans, value: entity.grants, informationPopup: 'entity.edit.information.grantType'} %}
             {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.subject_type'|trans, value: entity.nameIdFormat|replace({'urn:oasis:names:tc:SAML:2.0:nameid-format:': ''}), informationPopup: 'entity.edit.information.subjectType'} %}
             {% include '@Dashboard/EntityDetail/detailBooleanField.html.twig' with {label: 'entity.detail.metadata.playground_enabled'|trans, value: entity.playgroundEnabled, informationPopup: 'entity.edit.information.enablePlayground'} %}
             {% include '@Dashboard/EntityDetail/detailBooleanField.html.twig' with {label: 'entity.detail.metadata.is_public_client'|trans, value: entity.publicClient, informationPopup: 'entity.edit.information.isPublicClient'} %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Factory/SaveCommandFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Factory/SaveCommandFactory.php
@@ -128,7 +128,7 @@ class SaveCommandFactory implements SaveCommandFactoryInterface
 
         // OidcNg settings
         $command->setSecret($manageEntity->getOidcClient()->getClientSecret());
-        $command->setGrantType($manageEntity->getOidcClient()->getGrantType());
+        $command->setGrants($manageEntity->getOidcClient()->getGrants());
 
         // The SAML nameidformat is used as the OIDC subject type https://www.pivotaltracker.com/story/show/167511146
         $command->setSubjectType($metaData->getNameIdFormat());

--- a/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
@@ -93,6 +93,10 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
                         'description:nl' => 'description nl',
                         'grants' => [
                             'authorization_code',
+                            'refresh_token',
+                        ],
+                        'scopes' => [
+                            'oidc',
                         ],
                         'isPublicClient' => true,
                         'name:en' => 'name en',
@@ -170,7 +174,9 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
                         ],
                         'metaDataFields.grants' => [
                             'authorization_code',
+                            'refresh_token',
                         ],
+                        'metaDataFields.scopes' => ['oidc'],
                         'metaDataFields.isPublicClient' => true,
                         'revisionnote' => 'revisionnote',
                         'state' => 'testaccepted',

--- a/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
@@ -95,9 +95,6 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
                             'authorization_code',
                             'refresh_token',
                         ],
-                        'scopes' => [
-                            'oidc',
-                        ],
                         'isPublicClient' => true,
                         'name:en' => 'name en',
                         'name:nl' => 'name nl',
@@ -176,7 +173,6 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
                             'authorization_code',
                             'refresh_token',
                         ],
-                        'metaDataFields.scopes' => ['oidc'],
                         'metaDataFields.isPublicClient' => true,
                         'revisionnote' => 'revisionnote',
                         'state' => 'testaccepted',

--- a/tests/webtests/EntityCreateOidcngTest.php
+++ b/tests/webtests/EntityCreateOidcngTest.php
@@ -171,7 +171,7 @@ class EntityCreateOidcngTest extends WebTestCase
                     'nameNl' => 'The A Team',
                     'clientId' => 'https://entity-id',
                     'isPublicClient' => true,
-                    'grantType' => 'implicit',
+                    'grants' => ['authorization_code'],
                     'accessTokenValidity' => 3600,
                     'logoUrl' => 'https://logo-url',
                 ],


### PR DESCRIPTION
In order to support setting multiple grants, several changes to the code where required.

1. Support for multiple grants in SPD is required. Previously we only handled a single grant. This is now a simple collection of grants
2. Do not overwrite the Manage managed grants. These are being ovewritten as we only kept a single value and posted that back into the manage environment.

Note to reviewer: 
~This was rebased onto the docker PR. Please only review the `Allow setting multiple grants` commit.~
The additional commit was a fixup of a mistake I made. One of the previous stories mentioned that OIDCng entities should not track scopes at all. This was not implemented fully yet.

See: https://www.pivotaltracker.com/story/show/174746007