### PR TITLE
Ensure typecheck for redirect url doesn't fail

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcngClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcngClient.php
@@ -61,7 +61,7 @@ class OidcngClient implements OidcClientInterface
     {
         $clientId = self::getStringOrEmpty($data['data'], 'entityid');
         $clientSecret = self::getStringOrEmpty($data['data']['metaDataFields'], 'secret');
-        $redirectUris = self::getStringOrEmpty($data['data']['metaDataFields'], 'redirectUrls');
+        $redirectUris = self::getArrayOrEmpty($data['data']['metaDataFields'], 'redirectUrls');
         $scope = self::getStringOrNull($data['data']['metaDataFields'], 'scopes');
 
         $grantType = isset($data['data']['metaDataFields']['grants'])
@@ -124,6 +124,16 @@ class OidcngClient implements OidcClientInterface
     private static function getStringOrEmpty(array $data, $key)
     {
         return isset($data[$key]) ? $data[$key] : '';
+    }
+
+    /**
+     * @param array $data
+     * @param $key
+     * @return array
+     */
+    private static function getArrayOrEmpty(array $data, $key)
+    {
+        return isset($data[$key]) ? $data[$key] : [];
     }
 
     /**


### PR DESCRIPTION
Prior to this change, the typecheck for the redirect url failed when the redirect url wasn't set.

This change ensures the check doesn't fail by ensuring that if the field isn't set an empty array is used.

Bug found while testing PR #413