### PR TITLE
Add info fields to create entity titles

### DIFF
--- a/app/scss/components/modal_add_entity.scss
+++ b/app/scss/components/modal_add_entity.scss
@@ -9,6 +9,10 @@
 .modal.add-entity-modal {
   max-width: 75ch;
 
+  .wysiwyg {
+    margin-bottom: 0;
+  }
+
   fieldset.add-entity-fieldset {
     div:not(.add-entity-field) {
       margin-bottom: 0;
@@ -22,10 +26,19 @@
       }
     }
   }
+
+  .button-row {
+    display: flex;
+    justify-content: flex-end;
+
+    .button {
+      height: 2.5rem;
+      line-height: normal;
+    }
+  }
 }
 
 .add-entity-fieldset {
-  display: flex;
   padding: 1.5rem 0;
 
   &:first-of-type {
@@ -35,16 +48,26 @@
 
 .add-entity-protocol {
   border-bottom: 1px solid $black;
+  padding-top: 1rem;
 }
 
 .add-entity-fieldset-fields {
-  margin-left: 2rem;
+  margin-top: 1rem;
 }
 
 .add-entity-question {
   color: $black;
-  font-weight: 700;
+  display: flex;
+  justify-content: space-between;
   min-width: 130px;
+
+  .title {
+    font-weight: 700;
+  }
+
+  .explanationLink {
+    color: $blue;
+  }
 }
 
 .add-entity-radio {

--- a/app/scss/components/tooltip.scss
+++ b/app/scss/components/tooltip.scss
@@ -1,0 +1,44 @@
+.tooltipContent {
+  margin-top: 1rem;
+  max-height: 0;
+  opacity: 0;
+
+  @include motion {
+    transition: max-height .4s, opacity .4s;
+  }
+
+  p + p {
+    margin-top: .5rem;
+  }
+
+  strong {
+    font-weight: 600;
+  }
+}
+
+label.tooltipLabel:not(.joske):not(.is):not(.nen):not(.koolmarchant) {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cdefs%3E%3Cstyle%3E.a%7Bfill:none;stroke:%23676767;stroke-linecap:round;stroke-linejoin:round;stroke-width:1.5px;%7D%3C/style%3E%3C/defs%3E%3Ctitle%3EWhy do we need this info%3F%3C/title%3E%3Cpath class='a' d='M14.25,16.5H13.5A1.5,1.5,0,0,1,12,15V11.25a.75.75,0,0,0-.75-.75H10.5'/%3E%3Cpath class='a' d='M11.625,6.75A.375.375,0,1,0,12,7.125a.375.375,0,0,0-.375-.375h0'/%3E%3Ccircle class='a' cx='12' cy='12' r='11.25'/%3E%3C/svg%3E");
+  background-position: right 0 top 0;
+  background-repeat: no-repeat;
+  background-size: 1.2rem 1.2rem;
+  color: $blue;
+  height: 1.5rem;
+  margin-left: auto;
+  padding-right: 1.6rem;
+}
+
+.tooltipCheckbox:checked ~ .tooltipContent {
+  max-height: 10vh;
+  opacity: 1;
+
+  @include motion {
+    transition: max-height .4s, opacity .4s;
+  }
+}
+
+.tooltipCheckbox:checked + .add-entity-question label.tooltipLabel:not(.joske):not(.is):not(.nen):not(.koolmarchant) {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cdefs%3E%3Cstyle%3E.a%7Bfill:none;stroke:%23676767;stroke-linecap:round;stroke-linejoin:round;stroke-width:1.5px;%7D%3C/style%3E%3C/defs%3E%3Ctitle%3EHide info%3C/title%3E%3Cline class='a' x1='0.75' y1='23.249' x2='23.25' y2='0.749'/%3E%3Cline class='a' x1='23.25' y1='23.249' x2='0.75' y2='0.749'/%3E%3C/svg%3E%0A");
+  background-position: right 0 top .125rem;
+  background-repeat: no-repeat;
+  background-size: .8rem .8rem;
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -585,8 +585,12 @@ entity.add.environment.title: Environment?
 entity.add.environment.production: production
 entity.add.environment.test: test
 entity.add.protocol.title: Protocol?
-entity.add.template.title: From template?
+entity.add.protocol.link.url: https://example.com
+entity.add.protocol.link.text: More info on protocols
+entity.add.template.title: From existing entity?
 entity.add.template.no: No, create blank registration form.
 entity.add.template.yes: Yes
+entity.add.template.title.tooltip.srText: What does this mean?
+entity.add.template.title.tooltip.text: <p>If you select an existing entity as the basis for your new entity, its data will be copied into the new entity.  That way you can avoid filling in a lot of duplicate info.  <strong>Do make sure you check all metadata to ensure it's correct for the new entity!</strong></p>
 entity.add.create: Create
 entity.add.cancel: Cancel

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityModal/addEntityModal.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityModal/addEntityModal.html.twig
@@ -17,7 +17,13 @@
                 </ul>
             </fieldset>
             <fieldset class="add-entity-fieldset add-entity-protocol" aria-describedby="fieldset2">
-                <h5 class="add-entity-question" id="fieldset2">{{ 'entity.add.protocol.title'|trans }}</h5>
+                {% set link = 'entity.add.protocol.link.url'|trans %}
+                {% set linkText = 'entity.add.protocol.link.text'|trans %}
+                {% set protocolTitle = 'entity.add.protocol.title'|trans %}
+                <h5 class="add-entity-question" id="fieldset2">
+                    <span class="title">{{ protocolTitle }}</span>
+                    <a href="{{ link }}" class="explanationLink">{{ linkText }}</a>
+                </h5>
                 <ul class="add-entity-fieldset-fields">
                     {% set fieldName = manageId ~ '_protocol' %}
                     {% for title, value in protocols %}
@@ -30,7 +36,18 @@
                 </ul>
             </fieldset>
             <fieldset class="add-entity-fieldset add-entity-template" aria-describedby="fieldset3">
-                <h5 class="add-entity-question" id="fieldset3">{{ 'entity.add.template.title'|trans }}</h5>
+                {% set templateTitle = 'entity.add.template.title'|trans %}
+                {% set allowedTags = 'allowed.html.tags'|trans %}
+                <input type="checkbox" name="templateTooltip" id="templateTooltip" hidden class="tooltip tooltipCheckbox" />
+                <h5 class="add-entity-question" id="fieldset3">
+                    <span class="title">{{ templateTitle }}</span>
+                    <label for="templateTooltip" class="tooltip tooltipLabel">
+                        {{ 'entity.add.template.title.tooltip.srText'|trans }}
+                    </label>
+                </h5>
+                <div class="tooltip tooltipContent">
+                    {{ 'entity.add.template.title.tooltip.text'|striptags('<br><wbr><p><a><ul><ol><li><dl><dd><dt><blockquote><cite><strong><em><div><span><address><time>')|trans|raw }}
+                </div>
                 {% set fieldName = manageId ~ '_withtemplate' %}
                 <ul class="add-entity-fieldset-fields">
                     <li class="add-entity-field">
@@ -58,8 +75,8 @@
                 </ul>
             </fieldset>
             <div class="button-row">
-                <button type="submit" class="button pull-right blue">{{ 'entity.add.create'|trans }}</button>
-                <label class="button pull-right" for="{{ inputId }}" rel="modal:close">{{ 'entity.add.cancel'|trans }}</label>
+                <label class="button" for="{{ inputId }}" rel="modal:close">{{ 'entity.add.cancel'|trans }}</label>
+                <button type="submit" class="button blue">{{ 'entity.add.create'|trans }}</button>
             </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
Prior to this change, the create entity modal had no extra info to explain the different fields / titles.

This change ensures that protocol gains an explanation link & template gains an explanation fold-out (aka tooltip modern version).

For more info see https://www.pivotaltracker.com/story/show/165599582