### PR TITLE
Fix custom redirect url validation

### DIFF
--- a/app/js/components/validator_helper.test.ts
+++ b/app/js/components/validator_helper.test.ts
@@ -112,11 +112,13 @@ describe('validation functions', () => {
 
   it('should correctly flip urls', () => {
     const expectancies = [
-      { url: 'com.example.foobar://whatever', flipped: 'whatever://foobar.example.com' },
-      { url: 'com.github://https/client', flipped: 'https://github.com/client' },
-      { url: 'https://foobar.example.com', flipped: 'foobar.example.com://https' },
-      { url: 'https://foobar.example.com/foo/bar', flipped: 'foobar.example.com://https/foo/bar' },
-      { url: 'http://11.22.33.44', flipped: '11.22.33.44://http' },
+      { url: 'com.example.foobar://https', flipped: 'https://foobar.example.com/' },
+      { url: 'com.example.foobar:/https', flipped: 'https://foobar.example.com/' },
+      { url: 'com.example.foobar:/https/redirect/to/somewhere', flipped: 'https://foobar.example.com/redirect/to/somewhere' },
+      { url: 'nl.myapp:/redirect', flipped: 'https://myapp.nl/redirect' },
+      { url: 'com.example.foobar://https/foo/bar', flipped: 'https://foobar.example.com/foo/bar' },
+      { url: 'com.example.foobar://https:7777/foo/bar', flipped: 'https://foobar.example.com:7777/foo/bar' },
+      { url: '44.33.22.11://http', flipped: 'http://11.22.33.44/' },
     ];
     const helper = new ValidatorHelper();
     for (const expectation of expectancies) {

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/ValidRedirectUrlValidator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/ValidRedirectUrlValidator.php
@@ -50,7 +50,7 @@ class ValidRedirectUrlValidator extends UrlValidator
         // Test if we have Url violations, if so re validate the url with the reverse redirect URL rules
         $violations = $this->context->getViolations();
         if ($violations->count() > $numberOfViolations) {
-            $parts = parse_url($value);
+            $parts = parse_url($this->allowSingleSlash($value));
             if (!isset($parts['host'])) {
                 return;
             }
@@ -99,6 +99,17 @@ class ValidRedirectUrlValidator extends UrlValidator
     private function reverseHostname($hostname)
     {
         return implode('.', array_reverse(explode('.', $hostname)));
+    }
+
+    private function allowSingleSlash(string $url)
+    {
+        $hasDoubleSlash = strpos($url, '://');
+        $hasSingleSlash = strpos($url, ':/');
+        if (!$hasDoubleSlash && $hasSingleSlash) {
+            return str_replace(':/', '://', $url);
+        }
+
+        return $url;
     }
 
     private function dropLastAddedErrors(


### PR DESCRIPTION
Prior to this change, custom urls didn't validate correctly.

This change ensures that custom redirect urls are valid.  Custom urls are urls where the hostname is provided in reverse as per https://tools.ietf.org/html/rfc8252#section-7.1.
We also allowed for technically "faulty" custom redirect urls which feature a double //.  Eg: nl.test://redirect.  This ought to be nl.test:/redirect as per te specs (with a single /).  The use case where a user types it with double slash is covered however.

For more info see https://www.pivotaltracker.com/story/show/173624681