### PR TITLE
Ensure redirect url is correct for copy action

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
@@ -287,7 +287,11 @@ class EntityCreateController extends Controller
                         }
 
                         // When publishing failed, forward to the edit action and show the error messages there
-                        return $this->redirectToRoute('service_admin_overview', ['serviceId' => $entity->getService()->getId()]);
+                        if ($this->isGranted('ROLE_ADMINISTRATOR')) {
+                            return $this->redirectToRoute('service_admin_overview', ['serviceId' => $service->getId()]);
+                        }
+
+                        return $this->redirectToRoute('service_overview');
                     } else {
                         $this->addFlash('error', 'entity.edit.metadata.validation-failed');
                     }


### PR DESCRIPTION
Prior to this change, when a user tried to copy an entity and it went wrong: the redirect url was to the admin service overview.  This obviously led to an "access denied".

This change ensures that the redirect url is dependant on the user's access level.  Users get redirect to the service overview, admins to the admin service overview.

For more info see https://www.pivotaltracker.com/story/show/165965607