### PR TITLE
Allow Resource Servers from outside of RP's team

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
@@ -31,10 +31,8 @@ use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Issue;
-use Surfnet\ServiceProviderDashboard\Domain\ValueObject\ResourceServerCollection;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Exception\QueryServiceProviderException;
 use Symfony\Component\Routing\RouterInterface;
-use Webmozart\Assert\Assert;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcClientInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcClientInterface.php
@@ -62,5 +62,10 @@ interface OidcClientInterface
 
     public function updateClientSecret(SecretInterface $secret): void;
 
-    public function merge(OidcClientInterface $client): void;
+    /**
+     * Merges the new Oidc data with the existing data already present on the entity.
+     * The home team is used to distinguish Manage tracked resource servers from
+     * outside of the team the entity is associated with.
+     */
+    public function merge(OidcClientInterface $client, string $homeTeam): void;
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcngResourceServerClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcngResourceServerClient.php
@@ -145,7 +145,7 @@ class OidcngResourceServerClient implements OidcClientInterface
         $this->clientSecret = $secret->getSecret();
     }
 
-    public function merge(OidcClientInterface $client): void
+    public function merge(OidcClientInterface $client, string $homeTeam): void
     {
         $this->clientId = is_null($client->getClientId()) ? null : $client->getClientId();
         $this->clientSecret = is_null($client->getClientSecret()) ? null : $client->getClientSecret();

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/ManageEntity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/ManageEntity.php
@@ -286,7 +286,7 @@ class ManageEntity
         $this->attributes->merge($newEntity->getAttributes());
         $protocol = $this->protocol->getProtocol();
         if ($protocol === Constants::TYPE_OPENID_CONNECT_TNG || $protocol === Constants::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER) {
-            $this->oidcClient->merge($newEntity->getOidcClient());
+            $this->oidcClient->merge($newEntity->getOidcClient(), $this->getService()->getTeamName());
         }
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/ManageEntity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/ManageEntity.php
@@ -74,6 +74,10 @@ class ManageEntity
      * @var Service
      */
     private $service;
+    /**
+     * @var bool
+     */
+    private $readOnly = false;
 
     /**
      * @param $data
@@ -250,11 +254,15 @@ class ManageEntity
         return $this->getEnvironment() === Constants::ENVIRONMENT_PRODUCTION;
     }
 
-    public function isReadOnly()
+    public function setIsReadOnly()
     {
-        // No read only scenarios exist currently. This was used to block oidc entities
-        // (during the Oidc TNG rollover period)
-        return false;
+        $this->readOnly = true;
+    }
+
+    public function isReadOnly(): bool
+    {
+        // Entities from outside the current team can be read only (can happen in RP -> RS connections created in Manage)
+        return $this->readOnly;
     }
 
     public function getService(): Service

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Repository/QueryEntityRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Repository/QueryEntityRepository.php
@@ -67,7 +67,7 @@ interface QueryEntityRepository
      *
      * @return ManageEntity|null
      */
-    public function findByEntityId($entityId, $state);
+    public function findResourceServerByEntityId($entityId, $state);
 
     public function findOidcngResourceServersByTeamName(string $teamName, string $state): array;
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityDetailController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityDetailController.php
@@ -24,6 +24,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Surfnet\ServiceProviderDashboard\Application\Service\EntityServiceInterface;
 use Surfnet\ServiceProviderDashboard\Application\ViewObject\EntityDetail;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AuthorizationService;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
@@ -69,7 +70,12 @@ class EntityDetailController extends Controller
     public function detailAction(string $id, int $serviceId, string $manageTarget)
     {
         $service = $this->authorizationService->changeActiveService($serviceId);
+        $team = $service->getTeamName();
+        /** @var ManageEntity $entity */
         $entity = $this->entityService->getEntityByIdAndTarget($id, $manageTarget, $service);
+        if ($entity->getMetaData()->getCoin()->getServiceTeamId() !== $team) {
+            $entity->setIsReadOnly();
+        }
         $viewObject = EntityDetail::fromEntity($entity, $this->playGroundUriTest, $this->playGroundUriProd);
 
         return [

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/QueryClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/QueryClient.php
@@ -227,14 +227,14 @@ class QueryClient implements QueryEntityRepository
 
             $searchResults = $this->client->post(
                 json_encode($params),
-                sprintf('/manage/api/internal/search/oidc10_rp')
+                sprintf('/manage/api/internal/search/oauth20_rs')
             );
 
             // For each search result, query manage to get the full SP entity data.
             return array_filter(array_map(
                 function ($result) {
                     $entity = $this->findByManageId($result['_id']);
-                    if ($entity && $entity->isOidcngResourceServer()) {
+                    if ($entity) {
                         return $entity;
                     }
                 },
@@ -249,9 +249,8 @@ class QueryClient implements QueryEntityRepository
         }
     }
 
-    public function findByEntityId($entityId, $state)
+    public function findResourceServerByEntityId($entityId, $state)
     {
-        // Query manage to get the internal id of every SP entity with given team ID.
         $params = [
             'entityid' => $entityId,
             'state' => $state
@@ -259,7 +258,7 @@ class QueryClient implements QueryEntityRepository
 
         $searchResults = $this->client->post(
             json_encode($params),
-            sprintf('/manage/api/internal/search/oidc10_rp')
+            sprintf('/manage/api/internal/search/oauth20_rs')
         );
 
         $count = count($searchResults);
@@ -302,7 +301,7 @@ class QueryClient implements QueryEntityRepository
             $resourceServers = [];
             $rs = isset($data['data']['allowedResourceServers']) ? $data['data']['allowedResourceServers'] : [];
             foreach ($rs as $resourceServer) {
-                $resourceServers[] = $this->findByEntityId($resourceServer['name'], $data['data']['state']);
+                $resourceServers[] = $this->findResourceServerByEntityId($resourceServer['name'], $data['data']['state']);
             }
             $data['resourceServers'] = $resourceServers;
         }

--- a/tests/webtests/Manage/Client/FakeQueryClient.php
+++ b/tests/webtests/Manage/Client/FakeQueryClient.php
@@ -88,7 +88,7 @@ class FakeQueryClient implements QueryEntityRepository
         return $results;
     }
 
-    public function findByEntityId($entityId, $state)
+    public function findResourceServerByEntityId($entityId, $state)
     {
         foreach ($this->entities as $entity) {
             $result = $entity->getEntityResult();


### PR DESCRIPTION
This one's a doozy. The PR is twofold.

1. Allow read-only view of RS outside of team
The detail window of RP enitties now also show RP's from outside their own team. This is possible as there is no team restriction in Manage.

2. Prevent RS overwrites when outside of team 
SPD would overwrite these changes upon push to manage. That is also fixed in this PR.

More details: https://www.pivotaltracker.com/story/show/173371940