### PR TITLE
Consider closed and resolved status from Jira

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
@@ -262,8 +262,7 @@ class EntityService implements EntityServiceInterface
                         // A published entity needs no status update unless it's a removal requested entity
                         continue;
                     }
-
-                    if ($issue && $issue->getIssueType() === $this->removalStatus) {
+                    if ($issue && $issue->getIssueType() === $this->removalStatus && !$issue->isClosedOrResolved()) {
                         $entity->updateStatus(Constants::STATE_REMOVAL_REQUESTED);
                     }
                 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Issue.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Issue.php
@@ -25,21 +25,22 @@ class Issue implements JsonSerializable
 {
     const IDENTIFIER_KEY = 'key';
     const IDENTIFIER_ISSUE_TYPE = 'issueType';
+    const IDENTIFIER_TICKET_STATUS = 'ticketStatus';
 
-    /**
-     * @var string
-     */
+    const STATUS_CLOSED = 'CLOSED';
+    const STATUS_RESOLVED = 'RESOLVED';
+
     private $key;
-    /**
-     * @var string
-     */
+
     private $issueType;
+
+    private $ticketStatus;
 
     /**
      * @param string $key
      * @param string $issueType
      */
-    public function __construct($key, $issueType)
+    public function __construct(string $key, string $issueType, string $status)
     {
         if (!is_string($key) || empty($key)) {
             throw new InvalidArgumentException("An invalid issue key is provided, must be a non empty string");
@@ -50,12 +51,17 @@ class Issue implements JsonSerializable
         }
 
         $this->key = $key;
+        $this->ticketStatus = $status;
         $this->issueType = $issueType;
     }
 
     public static function fromSerializedData($issueData)
     {
-        return new self($issueData[self::IDENTIFIER_KEY], $issueData[self::IDENTIFIER_ISSUE_TYPE]);
+        return new self(
+            $issueData[self::IDENTIFIER_KEY],
+            $issueData[self::IDENTIFIER_ISSUE_TYPE],
+            $issueData[self::IDENTIFIER_TICKET_STATUS]
+        );
     }
 
     /**
@@ -74,11 +80,17 @@ class Issue implements JsonSerializable
         return $this->issueType;
     }
 
+    public function isClosedOrResolved(): bool
+    {
+        return $this->ticketStatus === self::STATUS_CLOSED || $this->ticketStatus === self::STATUS_RESOLVED;
+    }
+
     public function jsonSerialize()
     {
         return [
             self::IDENTIFIER_KEY => $this->key,
-            self::IDENTIFIER_ISSUE_TYPE => $this->issueType
+            self::IDENTIFIER_ISSUE_TYPE => $this->issueType,
+            self::IDENTIFIER_TICKET_STATUS => $this->ticketStatus
         ];
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/DevelopmentIssueRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/DevelopmentIssueRepository.php
@@ -79,7 +79,7 @@ class DevelopmentIssueRepository implements TicketServiceInterface
     public function createIssueFrom(Ticket $ticket)
     {
         $this->loadData();
-        $issue = new Issue($ticket->getManageId(), $ticket->getIssueType());
+        $issue = new Issue($ticket->getManageId(), $ticket->getIssueType(), 'OPEN');
         $this->data[$ticket->getManageId()] = $issue;
         $this->storeData();
         return $issue;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/IssueRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/IssueRepository.php
@@ -100,7 +100,7 @@ class IssueRepository implements TicketServiceInterface
         foreach ($issues->issues as $issue) {
             $manageId = $issue->fields->customFields[$this->manageIdFieldName];
             if (in_array($manageId, $manageIds)) {
-                $collection[$manageId] = new Issue($issue->key, $this->issueType);
+                $collection[$manageId] = new Issue($issue->key, $this->issueType, $issue->fields->status);
             }
         }
         return new IssueCollection($collection);
@@ -120,7 +120,8 @@ class IssueRepository implements TicketServiceInterface
             )
         );
         if ($issues->getTotal() > 0) {
-            return new Issue($issues->getIssue(0)->key, $this->issueType);
+            $issue = $issues->getIssue(0);
+            return new Issue($issue->key, $this->issueType, $issue->fields->status);
         }
         return null;
     }
@@ -139,7 +140,8 @@ class IssueRepository implements TicketServiceInterface
             )
         );
         if ($issues->getTotal() > 0) {
-            return new Issue($issues->getIssue(0)->key, $issueType);
+            $issue = $issues->getIssue(0);
+            return new Issue($issue->key, $issueType, $issue->fields->status);
         }
         return null;
     }
@@ -149,7 +151,7 @@ class IssueRepository implements TicketServiceInterface
         $issueField = $this->issueFactory->fromTicket($ticket);
         $issueService = $this->jiraFactory->buildIssueService();
         $issue = $issueService->create($issueField);
-        return new Issue($issue->key, $ticket->getIssueType());
+        return new Issue($issue->key, $ticket->getIssueType(), $issue->fields->status);
     }
 
     public function delete($issueKey)

--- a/tests/unit/Domain/ValueObject/IssueCollectionTest.php
+++ b/tests/unit/Domain/ValueObject/IssueCollectionTest.php
@@ -26,8 +26,8 @@ class IssueCollectionTest extends TestCase
 {
     public function test_get_issue_by_key()
     {
-        $issue1 = new Issue('CTX-0123', 'issue-type-1');
-        $issue2 = new Issue('CTX-0124', 'issue-type-2');
+        $issue1 = new Issue('CTX-0123', 'issue-type-1', 'OPEN');
+        $issue2 = new Issue('CTX-0124', 'issue-type-2', 'OPEN');
 
         $collection = new IssueCollection(
             ['00000000-0000-0000-0000-000000000000' => $issue1, '00000000-0000-0000-0000-000000000001' => $issue2]
@@ -40,13 +40,13 @@ class IssueCollectionTest extends TestCase
 
     public function test_count()
     {
-        $issue1 = new Issue('00000000-0000-0000-0000-000000000000', 'issue-type-1');
-        $issue2 = new Issue('00000000-0000-0000-0000-000000000001', 'issue-type-2');
-        $issue3 = new Issue('00000000-0000-0000-0000-000000000002', 'issue-type-3');
-        $issue4 = new Issue('00000000-0000-0000-0000-000000000003', 'issue-type-4');
+        $issue1 = new Issue('00000000-0000-0000-0000-000000000000', 'issue-type-1', 'OPEN');
+        $issue2 = new Issue('00000000-0000-0000-0000-000000000001', 'issue-type-2', 'OPEN');
+        $issue3 = new Issue('00000000-0000-0000-0000-000000000002', 'issue-type-3', 'OPEN');
+        $issue4 = new Issue('00000000-0000-0000-0000-000000000003', 'issue-type-4', 'OPEN');
         // Duplicate entries are not counted/added
-        $issue5 = new Issue('00000000-0000-0000-0000-000000000003', 'issue-type-4');
-        $issue6 = new Issue('00000000-0000-0000-0000-000000000003', 'issue-type-4');
+        $issue5 = new Issue('00000000-0000-0000-0000-000000000003', 'issue-type-4', 'OPEN');
+        $issue6 = new Issue('00000000-0000-0000-0000-000000000003', 'issue-type-4', 'OPEN');
 
         $collection = new IssueCollection([
             $issue1->getKey() => $issue1,


### PR DESCRIPTION
When service desk closes or resolves a Jira tikcet, but the matching
entity is still present in Manage, we should no longer consider it as
a request for delete status code.

https://www.pivotaltracker.com/story/show/176244612