### PR TITLE
Ensure attribute value is set on publishing entity

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
@@ -51,7 +51,7 @@ class ArpGenerator implements MetadataGenerator
                 }
                 $attributes[$urn][] = [
                     'source' => $attribute->getSource(),
-                    'value' => $attribute->getValue(),
+                    'value' => $attribute->getValue() === '' ? '*' : $attribute->getValue(),
                     'motivation' => $attribute->getMotivation(),
                 ];
             }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/AttributeList.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/AttributeList.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 
+use function array_key_exists;
 use function reset;
 
 class AttributeList
@@ -105,8 +106,14 @@ class AttributeList
         $originalAttributes = $this->attributes;
         $this->clear();
         foreach ($attributes->getAttributes() as $urn => $attributeList) {
-            // Grab the matching original manage attribute set
-            $manageAttribute = $originalAttributes[$urn];
+            // If the attribute was not yet created, use the new value
+            $manageAttribute = $attributes->getAttributes()[$urn];
+
+            // Else, grab the matching original manage attribute set
+            if (array_key_exists($urn, $originalAttributes)) {
+                $manageAttribute = $originalAttributes[$urn];
+            }
+
             $newMotivation = '';
             foreach ($attributeList as $attr) {
                 if ($attr->hasMotivation()) {


### PR DESCRIPTION
A missing attribute value will cause the system to break. Setting the default (a star) fixes this problem. This is implemented in the attribute generator.

In addition the Attribute list is now also dealing with new attributes correctly. It would previously only deal with existing attributes.

Relates to:
 - https://www.pivotaltracker.com/story/show/174549876
 - https://github.com/SURFnet/sp-dashboard/pull/413