### PR TITLE
Refrain from overwriting Manage tracked attributes

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/AttributeList.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/AttributeList.php
@@ -28,6 +28,8 @@ class AttributeList
      */
     private $attributes = [];
 
+    private $originalAttributes = [];
+
     public static function fromApiResponse(array $data)
     {
         $list = new self();
@@ -96,6 +98,14 @@ class AttributeList
         return $this->attributes;
     }
 
+    /**
+     * @return Attribute[]
+     */
+    public function getOriginalAttributes(): array
+    {
+        return $this->originalAttributes;
+    }
+
     private function clear()
     {
         $this->attributes = [];
@@ -103,15 +113,15 @@ class AttributeList
 
     public function merge(AttributeList $attributes)
     {
-        $originalAttributes = $this->attributes;
+        $this->originalAttributes = $this->attributes;
         $this->clear();
         foreach ($attributes->getAttributes() as $urn => $attributeList) {
             // If the attribute was not yet created, use the new value
             $manageAttribute = $attributes->getAttributes()[$urn];
 
             // Else, grab the matching original manage attribute set
-            if (array_key_exists($urn, $originalAttributes)) {
-                $manageAttribute = $originalAttributes[$urn];
+            if (array_key_exists($urn, $this->originalAttributes)) {
+                $manageAttribute = $this->originalAttributes[$urn];
             }
 
             $newMotivation = '';

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Factory/SaveCommandFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Factory/SaveCommandFactory.php
@@ -189,14 +189,12 @@ class SaveCommandFactory implements SaveCommandFactoryInterface
                 continue;
             }
 
-            if ($manageAttribute->hasMotivation()) {
-                $attribute = new Attribute();
-                $attribute->setRequested(true);
-                $attribute->setMotivation($manageAttribute->getMotivation());
+            $attribute = new Attribute();
+            $attribute->setRequested(true);
+            $attribute->setMotivation($manageAttribute->getMotivation());
 
-                $setter = $attributeDefinition->setterName;
-                $command->{$setter}($attribute);
-            }
+            $setter = $attributeDefinition->setterName;
+            $command->{$setter}($attribute);
         }
     }
 

--- a/tests/unit/Application/Metadata/JsonGenerator/ArpGeneratorTest.php
+++ b/tests/unit/Application/Metadata/JsonGenerator/ArpGeneratorTest.php
@@ -46,8 +46,9 @@ class ArpGeneratorTest extends MockeryTestCase
 
         $entity->shouldReceive('getProtocol->getProtocol')
             ->andReturn('saml20');
-
+        $entity->shouldReceive('getAttributes->getOriginalAttributes')->andReturn([]);
         $entity->shouldReceive('getAttributes->findAllByUrn')->andReturn([]);
+
         $metadataRepository = new AttributesMetadataRepository(__DIR__ . '/../../../../../app/Resources');
 
         $factory = new ArpGenerator($metadataRepository);
@@ -131,6 +132,9 @@ class ArpGeneratorTest extends MockeryTestCase
         $manageEntity
             ->shouldReceive('getAttributes->getAttributes')
             ->andReturn($attributes);
+        $manageEntity
+            ->shouldReceive('getAttributes->getOriginalAttributes')
+            ->andReturn([]);
 
         // all the rest yield no search results
         $manageEntity


### PR DESCRIPTION
It was believed the manage attributes where no longer overwritten. This was not the case. As the new logic does not actually check if the attribute is either manage or spd tracked. This is now fixed in the Json generator. Here we can use the attribute dictionary (repo) to get an intersection of the spd and manage managed attributes.