### PR TITLE
Build docker image when merging to develop.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     branches: [ develop ]
   release:
-    types: [published]
+    types: [ published ]
+  push: 
+    branches: [ develop ]
 
 jobs:
   build:


### PR DESCRIPTION
I'd like to be able to test the develop branch on a regular basis, but so far, only on release or on a commit in a pull_request a docker image was built. Now on all commits in the develop branch a docker image will be built