### PR TITLE
Resource server: Fix the type as set in manage

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
@@ -77,7 +77,7 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
     {
         // the type for entities is always oidc10-rp because manage is using saml internally
         $metadata = [
-            'type' => 'oauth20_rs',
+            'type' => 'oauth20-rs',
             'entityid' => OidcngClientIdParser::parse($entity->getMetaData()->getEntityId()),
             'active' => true,
             'state' => $workflowState,

--- a/tests/unit/Application/Metadata/OidcngResourceServerJsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/OidcngResourceServerJsonGeneratorTest.php
@@ -72,7 +72,7 @@ class OidcngResourceServerJsonGeneratorTest extends MockeryTestCase
         $this->assertEquals(
             [
                 'data' => [
-                    'type' => 'oauth20_rs',
+                    'type' => 'oauth20-rs',
                     'state' => 'testaccepted',
                     'entityid' => 'entityid',
                     'active' => true,


### PR DESCRIPTION
Manage identifies a resource server as type: oauth20-rs and not oauth20_rs