### PR TITLE
Show new production entity link for admins

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -331,7 +331,7 @@ class ServiceController extends Controller
             'isAdmin' => true,
             'showOidcPopup' => $this->showOidcPopup($publishedEntity),
             'publishedEntity' => $publishedEntity,
-            'production_entities_enabled' => $productionEntitiesEnabled,
+            'productionEntitiesEnabled' => $productionEntitiesEnabled,
             'privacyStatusEntities' => $privacyOK,
         ]);
     }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
@@ -120,15 +120,11 @@
                         {% endif %}
                         {% if productionEntitiesEnabled is defined and productionEntitiesEnabled[loop.index0] %}
                             <tr class="service-status-entities-table-add-entity">
-                                <td>
+                                <td colspan="5">
                                     <label for="{{ productionId }}" class="link">
                                         {{ 'entity.list.add_to_production'|trans}}
                                     </label>
                                 </td>
-                                <td></td>
-                                <td></td>
-                                <td></td>
-                                <td></td>
                             </tr>
                         {% endif %}
                     </table>
@@ -173,15 +169,11 @@
                             </tr>
                         {% endif %}
                         <tr class="service-status-entities-table-add-entity">
-                            <td>
+                            <td colspan="5">
                                 <label for="{{ testId }}" class="link">
                                     {{ 'entity.list.add_to_test'|trans}}
                                 </label>
                             </td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
                         </tr>
                     </table>
                 </section>


### PR DESCRIPTION
Prior to this change, admins could not see the "new production entity" link.  Added to that when the label text was semi-long the hover effect was a tad ugly.

This change ensures that admins can see the link & that the hover effect is ok for a longer label.

Found when testing release 2.8