### PR TITLE
Make tooltip for test entity clickable

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityModal/addEntityModal.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityModal/addEntityModal.html.twig
@@ -37,11 +37,12 @@
             </fieldset>
             <fieldset class="add-entity-fieldset add-entity-template" aria-describedby="fieldset3">
                 {% set templateTitle = 'entity.add.template.title'|trans %}
+                {% set tooltipId = manageId  ~ 'tooltip' %}
                 {% set allowedTags = 'allowed.html.tags'|trans %}
-                <input type="checkbox" name="templateTooltip" id="templateTooltip" hidden class="tooltip tooltipCheckbox" />
+                <input type="checkbox" name="templateTooltip" id={{ tooltipId}} hidden class="tooltip tooltipCheckbox" />
                 <h5 class="add-entity-question" id="fieldset3">
                     <span class="title">{{ templateTitle }}</span>
-                    <label for="templateTooltip" class="tooltip tooltipLabel">
+                    <label for="{{ tooltipId}}" class="tooltip tooltipLabel">
                         {{ 'entity.add.template.title.tooltip.srText'|trans }}
                     </label>
                 </h5>


### PR DESCRIPTION
Prior to this change, the tooltip in the add test entity modal was not clickable ("what does this mean").

This change ensures that it is by adding a unique id.

Found when testing release 2.8