### PR TITLE
Ensure modal redirects correctly when submitted

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
@@ -103,7 +103,7 @@ class EntityCreateController extends Controller
         $form = $this->createForm(CreateNewEntityType::class, $formId);
 
         $form->handleRequest($request);
-        if ($form->isSubmitted() && $form->isValid()) {
+        if (($form->isSubmitted() || $request->isMethod('post')) && $form->isValid()) {
             $protocol = $request->get($formId . '_protocol');
             $environment = $request->get($formId . '_environment');
             $withTemplate = $request->get($formId . '_withtemplate');


### PR DESCRIPTION
Prior to this change, the form was sometimes evaluated as not submitted when it was ($form->isSubmitted() yielding the wrong result).  This resulted in an unstyled form for the modal on a blank page.

This change ensures that when the modal is "posted" (aka submitted), it'll be considered submitted & thus be redirected to the right page.

Found when testing release 2.8