### PR TITLE
Hide content of tooltip

### DIFF
--- a/app/scss/components/tooltip.scss
+++ b/app/scss/components/tooltip.scss
@@ -3,6 +3,10 @@
   max-height: 0;
   opacity: 0;
 
+  * {
+    display: none;
+  }
+
   @include motion {
     transition: max-height .4s, opacity .4s;
   }
@@ -28,8 +32,12 @@ label.tooltipLabel:not(.joske):not(.is):not(.nen):not(.koolmarchant) {
 }
 
 .tooltipCheckbox:checked ~ .tooltipContent {
-  max-height: 10vh;
+  max-height: 25vh;
   opacity: 1;
+
+  * {
+    display: initial;
+  }
 
   @include motion {
     transition: max-height .4s, opacity .4s;


### PR DESCRIPTION
Prior to this change, the content of the tooltip was visually hidden but still used up room.

This change ensures that when the tooltip is hidden the content is as well

Found when testing release 2.8