### PR TITLE
Remove form validation from CreateNewEntityType form

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
@@ -103,7 +103,8 @@ class EntityCreateController extends Controller
         $form = $this->createForm(CreateNewEntityType::class, $formId);
 
         $form->handleRequest($request);
-        if (($form->isSubmitted() || $request->isMethod('post')) && $form->isValid()) {
+
+        if ($form->isSubmitted() || $request->isMethod('post')) {
             $protocol = $request->get($formId . '_protocol');
             $environment = $request->get($formId . '_environment');
             $withTemplate = $request->get($formId . '_withtemplate');

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityModal/addEntityModal.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityModal/addEntityModal.html.twig
@@ -1,7 +1,8 @@
 {% block body %}
     <div class="row entity-type">
-            <fieldset class="add-entity-fieldset add-entity-environment hidden" aria-describedby="fieldset1">
-                <h5 class="add-entity-question" id="fieldset1">{{ 'entity.add.environment.title'|trans }}</h5>
+            {% set fieldsetTitleId = 'fieldset1' ~ manageId %}
+            <fieldset class="add-entity-fieldset add-entity-environment hidden" aria-describedby={{ fieldsetTitleId }}>
+                <h5 class="add-entity-question" id={{ fieldsetTitleId }}>{{ 'entity.add.environment.title'|trans }}</h5>
                 <ul class="add-entity-fieldset-fields">
                     {% set fieldName = manageId ~ '_environment' %}
                     <li class="add-entity-field">
@@ -16,11 +17,12 @@
                     </li>
                 </ul>
             </fieldset>
-            <fieldset class="add-entity-fieldset add-entity-protocol" aria-describedby="fieldset2">
+            {% set fieldsetTitleId = 'fieldset2' ~ manageId %}
+            <fieldset class="add-entity-fieldset add-entity-protocol" aria-describedby={{ fieldsetTitleId }}>
                 {% set link = 'entity.add.protocol.link.url'|trans %}
                 {% set linkText = 'entity.add.protocol.link.text'|trans %}
                 {% set protocolTitle = 'entity.add.protocol.title'|trans %}
-                <h5 class="add-entity-question" id="fieldset2">
+                <h5 class="add-entity-question" id={{ fieldsetTitleId }}>
                     <span class="title">{{ protocolTitle }}</span>
                     <a href="{{ link }}" class="explanationLink">{{ linkText }}</a>
                 </h5>
@@ -35,12 +37,13 @@
                     {% endfor %}
                 </ul>
             </fieldset>
-            <fieldset class="add-entity-fieldset add-entity-template" aria-describedby="fieldset3">
+            {% set fieldsetTitleId = 'fieldset3' ~ manageId %}
+            <fieldset class="add-entity-fieldset add-entity-template" aria-describedby={{ fieldsetTitleId }}>
                 {% set templateTitle = 'entity.add.template.title'|trans %}
                 {% set tooltipId = manageId  ~ 'tooltip' %}
                 {% set allowedTags = 'allowed.html.tags'|trans %}
                 <input type="checkbox" name="templateTooltip" id={{ tooltipId}} hidden class="tooltip tooltipCheckbox" />
-                <h5 class="add-entity-question" id="fieldset3">
+                <h5 class="add-entity-question" id={{ fieldsetTitleId }}>
                     <span class="title">{{ templateTitle }}</span>
                     <label for="{{ tooltipId}}" class="tooltip tooltipLabel">
                         {{ 'entity.add.template.title.tooltip.srText'|trans }}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityType/type.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityType/type.html.twig
@@ -5,7 +5,6 @@
 {% block page_heading %} {{ 'entity.type.title'|trans }} {% endblock %}
 
 {% block body %}
-
     <div class="wysiwyg">{{ 'entity.type.description.html'|trans|wysiwyg }}</div>
 
     <div class="row entity-type">


### PR DESCRIPTION
Prior to this change, the validation would always throw an error for the create entity modal when submitting a test entity.  This is because if the form is not "submitted" it is considered invalid.

This change alters the validation to check whether there are actual form errors.  If none are found the form is considered valid.

Following the boyscout rule the ids for the titles were also made unique to the modal so they pass html validation.

Found when testing release 2.8

**Edit @MKodde**
The solution to this problem is somewhat controversial, and can be considered bad practice. We created a TD ticket to later fix this issue. https://www.pivotaltracker.com/story/show/177183585