### PR TITLE
Do not verify service restraint on RS entities

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityServiceInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityServiceInterface.php
@@ -31,13 +31,7 @@ interface EntityServiceInterface
      */
     public function createEntityUuid();
 
-    /**
-     * @param string $id
-     * @param string $manageTarget
-     * @param Service $service
-     * @return mixed
-     */
-    public function getEntityByIdAndTarget($id, $manageTarget, Service $service);
+    public function getEntityByIdAndTarget(string $id, string $manageTarget, Service $service): ManageEntity;
 
     /**
      * @param Service $service


### PR DESCRIPTION
The RS entities can be viewed from outside of the users team. This is a requirement.  But it was not allowed for production entities.

In addition two boy scout rule actions have been undertaken:
1. The test entities are now testing for explicit access to the other entity types (was only performed for prod entities)
2. Typehints where added to the method that was touched in this PR