### PR TITLE
Merge comment (revision note) upon updating entity

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -2,7 +2,7 @@
 # Set parameters here that may be different on each deployment target of the app, e.g. development, staging, production.
 # http://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
 parameters:
-    database_host: 127.0.0.1
+    database_host: db.vm.openconext.org
     database_port: ~
     database_name: spdashboard
     database_user: spdrw

--- a/docker/Dockerfiledev
+++ b/docker/Dockerfiledev
@@ -6,7 +6,7 @@ COPY ./conf/engineblock.pem /etc/openconext/engineblock.pem
 COPY ./conf/start.sh /tmp/start.sh
 CMD ["/tmp/start.sh"]
 
-FROM ghcr.io/surfnet/sp-dashboard/spdashboard_php-fpm:3.0.1 AS spdphpfpm
+FROM ghcr.io/surfnet/sp-dashboard/spdashboard_php-fpm:3.0.0 AS spdphpfpm
 WORKDIR /var/www/html/
 COPY --from=openconext /etc/pki/ca-trust/source/anchors/star.vm.openconext.org.pem /usr/local/share/ca-certificates/star.vm.openconext.org.pem
 COPY ./conf/xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
@@ -19,7 +19,7 @@ RUN /usr/sbin/update-ca-certificates && \
 
 CMD ["/usr/local/sbin/php-fpm" , "-F"]
 
-FROM ghcr.io/surfnet/sp-dashboard/spdashboard_web:3.0.1 AS spdhttpd
+FROM ghcr.io/surfnet/sp-dashboard/spdashboard_web:3.0.0 AS spdhttpd
 COPY ./conf/000-default-dev.conf /usr/local/apache2/conf/000-default.conf
 EXPOSE 80
 CMD ["httpd", "-D", "FOREGROUND"]

--- a/docker/conf/xdebug.ini
+++ b/docker/conf/xdebug.ini
@@ -1,4 +1,4 @@
-xdebug.remote_enable = 1
-xdebug.remote_connect_back = 1
-xdebug.remote_host = 172.23.0.4
-xdebug.idekey = "PHPSTORM"
+xdebug.mode = debug
+xdebug.discover_client_host = true
+xdebug.start_with_request = yes
+xdebug.idekey = PHPSTORM

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/ManageEntity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/ManageEntity.php
@@ -288,6 +288,7 @@ class ManageEntity
         if ($protocol === Constants::TYPE_OPENID_CONNECT_TNG || $protocol === Constants::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER) {
             $this->oidcClient->merge($newEntity->getOidcClient(), $this->getService()->getTeamName());
         }
+        $this->comments = $newEntity->getComments();
     }
 
     public function setStatus(string $status)


### PR DESCRIPTION
The revision note was lost in the publication action when updating an existing entity.

This PR also addresses the incorrect Xdebug setup as we now get Xdebug3 vs 2.