### PR TITLE
Only show the privacy questions banner when toggle is on

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
@@ -73,7 +73,7 @@
                         </ul>
                     {% endif %}
                 </h2>
-                {% if not privacyStatusEntities[loop.index0] %}
+                {% if not privacyStatusEntities[loop.index0] and service.arePrivacyQuestionsEnabled %}
                     {% include '@Dashboard/Privacy/notification.html.twig' with { hlvl: "3"} %}
                 {% endif %}
                 <section class="service-status-entities">


### PR DESCRIPTION
The check for the privacy questions enabled feature flag (service edit / create form) was not evaluated while rendering the privacy questions nag banner.

Note that this PR is based on the #435 PR. Only the last commit is relevant for this bugfix.

As described in bug report: https://www.pivotaltracker.com/story/show/177677377