### PR TITLE
Ensure exclude from push coin value is honored

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Coin.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Coin.php
@@ -19,6 +19,7 @@
 namespace Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 
 use Webmozart\Assert\Assert;
+use function is_null;
 
 class Coin
 {
@@ -123,7 +124,7 @@ class Coin
         $this->signatureMethod = is_null($coin->getSignatureMethod()) ? null : $coin->getSignatureMethod();
         $this->serviceTeamId = is_null($coin->getServiceTeamId()) ? null : $coin->getServiceTeamId();
         $this->originalMetadataUrl = is_null($coin->getOriginalMetadataUrl()) ? null : $coin->getOriginalMetadataUrl();
-        $this->excludeFromPush = is_null($coin->getExcludeFromPush()) ? null : $coin->getExcludeFromPush();
+        $this->excludeFromPush = is_null($coin->getExcludeFromPush()) ? $this->excludeFromPush : $coin->getExcludeFromPush();
         $this->applicationUrl = is_null($coin->getApplicationUrl()) ? null : $coin->getApplicationUrl();
         $this->eula = is_null($coin->getEula()) ? null : $coin->getEula();
         $this->oidcClient = is_null($coin->getOidcClient()) ? null : $coin->getOidcClient();

--- a/tests/unit/Domain/Entity/Entity/CoinTest.php
+++ b/tests/unit/Domain/Entity/Entity/CoinTest.php
@@ -58,12 +58,12 @@ class CoinTest extends TestCase
         yield [
             new Coin('signatureMethod', '23', 'https://www.example.com', '1', 'https://example.com', 'https://example.com/eula', 1),
             new Coin('signatureMethod', null, 'https://www.example.com', null, 'https://example.com', 'https://example.com/eula', 1),
-            new Coin('signatureMethod', null, 'https://www.example.com', null, 'https://example.com', 'https://example.com/eula', 1),
+            new Coin('signatureMethod', null, 'https://www.example.com', '1', 'https://example.com', 'https://example.com/eula', 1),
         ];
         yield [
             new Coin('signatureMethod', '23', 'https://www.example.com', '1', 'https://example.com', 'https://example.com/eula', 1),
             new Coin(null, null, null, null, null, null, null),
-            new Coin(null, null, null, null, null, null, null)
+            new Coin(null, null, null, '1', null, null, null)
         ];
     }
 }


### PR DESCRIPTION
The exclude from push is set on the manage prod entity. And it was not
merged correctly onto the updated (SPD) entity that is to be published
to manage. This fixes that issue for the Coin value object.

https://www.pivotaltracker.com/story/show/177659443