### PR TITLE
Ensure privacy link is visible for normal users

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
@@ -39,8 +39,8 @@
             <div class="service-status-container">
                 <h2 class="service-status-title">
                     {{ service.name }}
-                    {% if isAdmin %}
-                        <ul class="service-status-title-actions">
+                    <ul class="service-status-title-actions">
+                        {% if isAdmin %}
                             <li class="service-status-title-action-item">
                                 <a
                                     class="button admin title service-status-title-button"
@@ -59,19 +59,19 @@
                                     {{ 'service.overview.action.serviceDelete'|trans }}
                                 </a>
                             </li>
-                            {% if service.arePrivacyQuestionsEnabled %}
-                                <li class="service-status-title-action-item">
-                                    <a
-                                        class="button blue title service-status-title-button"
-                                        href="{{ path('privacy_questions', {'serviceId': service.id}) }}"
-                                    >
-                                        <i class="fa fa-key" aria-hidden="true"></i>
-                                        {{ 'service.overview.action.privacyQuestions'|trans }}
-                                    </a>
-                                </li>
-                            {% endif %}
-                        </ul>
-                    {% endif %}
+                        {% endif %}
+                        {% if service.arePrivacyQuestionsEnabled %}
+                            <li class="service-status-title-action-item">
+                                <a
+                                    class="button blue title service-status-title-button"
+                                    href="{{ path('privacy_questions', {'serviceId': service.id}) }}"
+                                >
+                                    <i class="fa fa-key" aria-hidden="true"></i>
+                                    {{ 'service.overview.action.privacyQuestions'|trans }}
+                                </a>
+                            </li>
+                        {% endif %}
+                    </ul>
                 </h2>
                 {% if not privacyStatusEntities[loop.index0] %}
                     {% include '@Dashboard/Privacy/notification.html.twig' with { hlvl: "3"} %}

--- a/tests/webtests/ServiceOverviewTest.php
+++ b/tests/webtests/ServiceOverviewTest.php
@@ -52,7 +52,8 @@ class ServiceOverviewTest extends WebTestCase
         $nodes = $crawler->filter('.service-status-container .service-status-title');
         $serviceNode = $nodes->first();
 
-        $this->assertEquals('SURFnet', trim($serviceNode->text()));
+        $this->assertContains('SURFnet', trim($serviceNode->text()));
+        $this->assertContains('Privacy questions', trim($serviceNode->text()));
     }
 
     /**
@@ -78,8 +79,9 @@ class ServiceOverviewTest extends WebTestCase
         $serviceNode = $nodes->first();
         $service2 = $nodes->eq(1);
 
-        $this->assertEquals('Ibuildings B.V.', trim($serviceNode->text()));
-        $this->assertEquals('SURFnet', trim($service2->text()));
+        $this->assertContains('Ibuildings B.V.', trim($serviceNode->text()));
+        $this->assertContains('Privacy questions', trim($serviceNode->text()));
+        $this->assertContains('SURFnet', trim($service2->text()));
     }
 
     /**


### PR DESCRIPTION
Prior to this change, the privacy link was only visible to admin users.  Meaning that once the questions were answered, you could no longer go to the privacy questions.

This change ensures the link is now also visible for normal users (as was the original intent).  Additionally it also adds a link to the privacy questions in the tooltip for the status summary.

Pivotal ticket at https://www.pivotaltracker.com/story/show/177682438