### PR TITLE
Repair faulty Jira ticket status implementation

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Issue.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Issue.php
@@ -29,6 +29,7 @@ class Issue implements JsonSerializable
 
     const STATUS_CLOSED = 'CLOSED';
     const STATUS_RESOLVED = 'RESOLVED';
+    const STATUS_OPEN = 'To Do';
 
     private $key;
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/DevelopmentIssueRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/DevelopmentIssueRepository.php
@@ -22,6 +22,7 @@ use Surfnet\ServiceProviderDashboard\Application\Service\TicketServiceInterface;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Issue;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\IssueCollection;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Ticket;
+use function array_key_exists;
 
 class DevelopmentIssueRepository implements TicketServiceInterface
 {
@@ -79,7 +80,7 @@ class DevelopmentIssueRepository implements TicketServiceInterface
     public function createIssueFrom(Ticket $ticket)
     {
         $this->loadData();
-        $issue = new Issue($ticket->getManageId(), $ticket->getIssueType(), 'OPEN');
+        $issue = new Issue($ticket->getManageId(), $ticket->getIssueType(), Issue::STATUS_OPEN);
         $this->data[$ticket->getManageId()] = $issue;
         $this->storeData();
         return $issue;
@@ -117,6 +118,9 @@ class DevelopmentIssueRepository implements TicketServiceInterface
     {
         $output = [];
         foreach ($rawData as $issueData) {
+            if (!array_key_exists(Issue::IDENTIFIER_TICKET_STATUS, $issueData)) {
+                $issueData[Issue::IDENTIFIER_TICKET_STATUS] = Issue::STATUS_OPEN;
+            }
             $output[$issueData['key']] = Issue::fromSerializedData($issueData);
         }
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/IssueRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/IssueRepository.php
@@ -100,7 +100,7 @@ class IssueRepository implements TicketServiceInterface
         foreach ($issues->issues as $issue) {
             $manageId = $issue->fields->customFields[$this->manageIdFieldName];
             if (in_array($manageId, $manageIds)) {
-                $collection[$manageId] = new Issue($issue->key, $this->issueType, $issue->fields->status);
+                $collection[$manageId] = new Issue($issue->key, $this->issueType, $issue->fields->status->name);
             }
         }
         return new IssueCollection($collection);
@@ -121,7 +121,7 @@ class IssueRepository implements TicketServiceInterface
         );
         if ($issues->getTotal() > 0) {
             $issue = $issues->getIssue(0);
-            return new Issue($issue->key, $this->issueType, $issue->fields->status);
+            return new Issue($issue->key, $this->issueType, $issue->fields->status->name);
         }
         return null;
     }
@@ -141,7 +141,7 @@ class IssueRepository implements TicketServiceInterface
         );
         if ($issues->getTotal() > 0) {
             $issue = $issues->getIssue(0);
-            return new Issue($issue->key, $issueType, $issue->fields->status);
+            return new Issue($issue->key, $issueType, $issue->fields->status->name);
         }
         return null;
     }
@@ -151,7 +151,7 @@ class IssueRepository implements TicketServiceInterface
         $issueField = $this->issueFactory->fromTicket($ticket);
         $issueService = $this->jiraFactory->buildIssueService();
         $issue = $issueService->create($issueField);
-        return new Issue($issue->key, $ticket->getIssueType(), $issue->fields->status);
+        return new Issue($issue->key, $ticket->getIssueType(), Issue::STATUS_OPEN);
     }
 
     public function delete($issueKey)


### PR DESCRIPTION
Previously the status was added to the Jira Issue solution. This status is used to figure out the entity status.

Problem is that the status id was not yanked from the Jira status field, the entire status object was set on the type restricted Issue constructor.

While at it, a similar development issue was fixed.

https://www.pivotaltracker.com/story/show/177659652