### PR TITLE
Ensure add production entity is always clickable

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/Service/overview.html.twig
@@ -33,7 +33,7 @@
             {% set testId = "add-for-test-" ~ shortName %}
             {% set productionId = "add-for-production-" ~ shortName %}
             <input type="checkbox" id="{{ testId }}" name="{{ testId }}" />
-            {% if productionEntitiesEnabled is defined and productionEntitiesEnabled[loop.index0] %}
+            {% if service.isProductionEntitiesEnabled %}
                 <input type="checkbox" id="{{ productionId }}" name="{{ productionId }}" />
             {% endif %}
             <div class="service-status-container">


### PR DESCRIPTION
Prior to this change, production entities could not be added because the link was not clickable in all situations.

This change ensures the link is always clickable.

Pivotal issue at: https://www.pivotaltracker.com/story/show/177677810