### PR TITLE
Ensure ARP attributes is an object when empty

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator;
 
+use stdClass;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\AttributesMetadataRepository;
@@ -61,6 +62,16 @@ class ArpGenerator implements MetadataGenerator
         }
 
         $this->addManageOnlyAttributes($attributes, $entity);
+
+        /**
+         * If $attributes is empty, json-conversion will be to an empty array rather than to an empty object.
+         * In the case of a non-empty array it'll be converted to an object.
+         * We want both cases to be an object.
+         * So if it's an empty array return a simple stdClass (which does get converted to an empty object)
+         */
+        if (empty($attributes)) {
+            $attributes = new stdClass();
+        }
 
         return [
             'attributes' => $attributes,


### PR DESCRIPTION
Prior to this change, an empty attributes array got converted to an empty JSON array (makes sense).  However, when not empty the array got converted to a JSON object (as at that point it was an associative array before conversion).  The JSON schema for ARP specifies that the attributes property is an object, so the empty array did not get through schema validation.

This change replaces any empty attributes-array by a simple PHP stdClass (empty).  Which does get converted to an empty object in JSON.

Pivotal story at https://www.pivotaltracker.com/story/show/177697851