### PR TITLE
Client secret reset service issue

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/ResetOidcSecretCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/ResetOidcSecretCommandHandler.php
@@ -73,7 +73,8 @@ class ResetOidcSecretCommandHandler implements CommandHandler
             throw new InvalidArgumentException('Only OIDC TNG entities can be processed');
         }
 
-        if ($entity->getStatus() !== Constants::STATE_PUBLISHED) {
+        $status = $entity->getStatus();
+        if ($status !== Constants::STATE_PUBLISHED && $status !== Constants::STATE_PUBLICATION_REQUESTED) {
             throw new InvalidArgumentException('The requested entity can not be processed, invalid state');
         }
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
@@ -356,6 +356,11 @@ class OidcngJsonGenerator implements GeneratorInterface
             $collection = $client->getResourceServers();
             if ($collection) {
                 foreach ($collection as $clientId) {
+                    // When Client resetting, the collection of RS is built of ManageEntities, in other cases
+                    // they are entity Id strings
+                    if ($clientId instanceof ManageEntity) {
+                        $clientId = $clientId->getMetaData()->getEntityId();
+                    }
                     $allowedResourceServers[]['name'] = $clientId;
                 }
             }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
@@ -121,6 +121,7 @@ class EntityService implements EntityServiceInterface
                 // Entities that are still excluded from push are not really published, but have a publication request
                 // with the service desk.
                 $this->updateStatus($entity);
+                $this->updateOrganizationNames($entity, $service->getOrganizationNameEn(), $service->getOrganizationNameNl());
                 $issue = $this->findIssueBy($entity);
                 $shouldUseTicketStatus = $entity->getStatus() !== Constants::STATE_PUBLISHED &&
                     $entity->getStatus() !== Constants::STATE_PUBLICATION_REQUESTED;
@@ -132,6 +133,7 @@ class EntityService implements EntityServiceInterface
                 $entity = $this->findAndverifyAccessAllowed($id, $manageTarget, $service);
                 $entity->setEnvironment($manageTarget);
                 $entity->setService($service);
+                $this->updateOrganizationNames($entity, $service->getOrganizationNameEn(), $service->getOrganizationNameNl());
                 return $entity;
             default:
                 throw new EntityNotFoundException(
@@ -222,6 +224,8 @@ class EntityService implements EntityServiceInterface
         $service = $this->serviceService->getServiceByTeamName($entity->getMetaData()->getCoin()->getServiceTeamId());
         $entity->setService($service);
         $this->updateStatus($entity);
+        // As the organization names are tracked on the Service, we update it on the Manage Entity Organization VO
+        $this->updateOrganizationNames($entity, $service->getOrganizationNameEn(), $service->getOrganizationNameNl());
         return $entity;
     }
 
@@ -319,5 +323,15 @@ class EntityService implements EntityServiceInterface
         if ($excludeFromPush === '0') {
             $entity->updateStatus(Constants::STATE_PUBLISHED);
         }
+    }
+
+    /**
+     * As the organization names are tracked on the Service, we update it on the Manage
+     * Entity Organization
+     */
+    public function updateOrganizationNames(ManageEntity $entity, $orgNameEn, $orgNameNl)
+    {
+        $entity->getMetaData()->getOrganization()->updateNameEn($orgNameEn);
+        $entity->getMetaData()->getOrganization()->updateNameNl($orgNameNl);
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/ServiceService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/ServiceService.php
@@ -90,7 +90,7 @@ class ServiceService
         return $this->services->findById($id);
     }
 
-    public function getServiceByTeamName(?string $serviceTeamName)
+    public function getServiceByTeamName(?string $serviceTeamName): ?Service
     {
         return $this->services->findByTeamName($serviceTeamName);
     }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Organization.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Organization.php
@@ -105,4 +105,14 @@ class Organization
         $this->displayNameNl = is_null($organization->getDisplayNameNl()) ? null : $organization->getDisplayNameNl();
         $this->urlNl = is_null($organization->getUrlNl()) ? null : $organization->getUrlNl();
     }
+
+    public function updateNameEn($nameEn)
+    {
+        $this->nameEn = $nameEn;
+    }
+
+    public function updateNameNl($nameNl)
+    {
+        $this->nameNl = $nameNl;
+    }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Repository/ServiceRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Repository/ServiceRepository.php
@@ -73,5 +73,5 @@ interface ServiceRepository
      */
     public function delete(Service $service);
 
-    public function findByTeamName(?string $serviceTeamName);
+    public function findByTeamName(?string $serviceTeamName): ?Service;
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityResetSecretController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityResetSecretController.php
@@ -53,11 +53,15 @@ class EntityResetSecretController extends Controller
     {
         $flashBag = $this->get('session')->getFlashBag();
         $flashBag->clear();
-
-        $service = $this->serviceService->getServiceById($serviceId);
-
         $manageEntity = $this->entityService->getManageEntityById($manageId, $environment);
-        $manageEntity->setService($service);
+        $entityServiceId = $manageEntity->getService()->getId();
+        if ($serviceId !== $entityServiceId) {
+            throw $this->createAccessDeniedException(
+                'You are not allowed to view an Entity from another Service'
+            );
+        }
+        // Verify the Entity Service Id is one of the logged in users services
+        $this->authorizationService->assertServiceIdAllowed($entityServiceId);
 
         $resetOidcSecretCommand = new ResetOidcSecretCommand($manageEntity);
         try {

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityResetSecretController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityResetSecretController.php
@@ -42,14 +42,10 @@ class EntityResetSecretController extends Controller
      * @Route("/entity/reset-secret/{serviceId}/{manageId}/{environment}", name="entity_reset_secret")
      * @Security("has_role('ROLE_USER')")
      *
-     * @param Request $request
-     * @param string $manageId
-     * @param string $environment
-     *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
-    public function resetAction(Request $request, $serviceId, $manageId, $environment)
+    public function resetAction(Request $request, int $serviceId, string $manageId, string $environment)
     {
         $flashBag = $this->get('session')->getFlashBag();
         $flashBag->clear();

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Repository/ServiceRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Repository/ServiceRepository.php
@@ -126,7 +126,7 @@ class ServiceRepository extends DoctrineEntityRepository implements ServiceRepos
         $this->getEntityManager()->flush($service);
     }
 
-    public function findByTeamName(?string $serviceTeamName)
+    public function findByTeamName(?string $serviceTeamName): ?Service
     {
         return parent::findOneBy([
             'teamName' => $serviceTeamName,


### PR DESCRIPTION
The Organization value object is loaded from the manage provided metadata. This metadata might or might not include the Organization Name (NL/EN). We track the organization name on the Service entity. And that name is leading in the entities organization names. To ensure we have those org names on every Entity Manage interaction. I now update the OrgNames based on the service entity value. 

This happens to fix the issue where the client secret reset would fail on a missing org name value.

Bugfix for bug reported in: https://www.pivotaltracker.com/story/show/177701148