### PR TITLE
Use the lastest OpenConext docker image

### DIFF
--- a/docker/Dockerfiledev
+++ b/docker/Dockerfiledev
@@ -1,4 +1,4 @@
-FROM ghcr.io/openconext/openconext-deploy/openconext-core:merge AS openconext
+FROM ghcr.io/openconext/openconext-deploy/openconext-core:master AS openconext
 COPY ./conf/prep_oc.sh /tmp/prep_oc.sh
 COPY ./conf/saml20_sp.json /tmp/saml20_sp.json
 COPY ./conf/engineblock.crt /etc/openconext/engineblock.crt

--- a/docker/conf/prep_oc.sh
+++ b/docker/conf/prep_oc.sh
@@ -1,5 +1,5 @@
 # Check whether we ran before
-if [ -f /etc//first_run_done ]
+if [ -f /etc/first_run_done ]
     then exit
 fi
 
@@ -9,7 +9,7 @@ while ! mysqladmin ping -h localhost --silent; do
 done
 
 # First we create the spdashboard database and user
-mysql -e "create database spdashboard"
+mysql -e "create database if not exists spdashboard"
 mysql -e "grant all on spdashboard.* to spdrw identified by 'secret'"
 
 # We wait until manage becomes available
@@ -32,7 +32,8 @@ systemctl restart manage
 # Add spdashboard to the loadbalancer. We reuse the welcome backend for it 
 echo "  backend spdashboard_be" >> /etc/haproxy/haproxy_backend.cfg
 echo "  server spd spdashboard_web:80" >> /etc/haproxy/haproxy_backend.cfg
-sed -i 's/welcome/spdashboard/g' /etc/haproxy/haproxy_frontend.cfg
+echo "spdashboard.vm.openconext.org spdashboard_be"  >> /etc/haproxy/maps/backends.map
+echo "spdashboard.vm.openconext.org" >> /etc/haproxy/acls/validvhostsunrestricted.acl
 systemctl reload haproxy
 
 # Finished, make sure we don't run again


### PR DESCRIPTION
This PR makes sure the latest openconext docker image is pulled.
Some changes were necessary to change to the new Haproxy configuration layout