### PR TITLE
HTTPD: Add cache headers

### DIFF
--- a/docker/conf/000-default.conf
+++ b/docker/conf/000-default.conf
@@ -21,4 +21,9 @@ SetEnv HTTPS on
 <FilesMatch \.php$>
   SetHandler "proxy:fcgi://spdashboard_php-fpm:9000"
 </FilesMatch>
+ExpiresActive on
+ExpiresByType font/* "access plus 1 year"
+ExpiresByType image/* "access plus 6 months"
+ExpiresByType text/css "access plus 1 year"
+ExpiresByType text/js "access plus 1 year"
 </Directory>

--- a/docker/conf/httpd.conf
+++ b/docker/conf/httpd.conf
@@ -131,7 +131,7 @@ LoadModule log_config_module modules/mod_log_config.so
 LoadModule env_module modules/mod_env.so
 #LoadModule mime_magic_module modules/mod_mime_magic.so
 #LoadModule cern_meta_module modules/mod_cern_meta.so
-#LoadModule expires_module modules/mod_expires.so
+LoadModule expires_module modules/mod_expires.so
 LoadModule headers_module modules/mod_headers.so
 #LoadModule ident_module modules/mod_ident.so
 #LoadModule usertrack_module modules/mod_usertrack.so


### PR DESCRIPTION
This adds cache headers for the production Apache docker image.