### PR TITLE
Remove organizationName leftover

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/LoadMetadataCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/LoadMetadataCommandHandler.php
@@ -72,7 +72,6 @@ class LoadMetadataCommandHandler implements CommandHandler
                 break;
             default:
                 throw new InvalidArgumentException('Unable to load XML from the LoadMetadataCommand');
-                break;
         }
 
         $metadata = $this->metadataParser->parseXml($xml);
@@ -101,8 +100,6 @@ class LoadMetadataCommandHandler implements CommandHandler
             'descriptionEn' => ['getDescriptionEn', 'setDescriptionEn'],
             'applicationUrlEn' => ['getApplicationUrl', 'setApplicationUrl'],
             'certificate' => ['getCertificate', 'setCertificate'],
-            'organizationNameEn' => ['getOrganizationNameEn', 'setOrganizationNameEn'],
-            'organizationNameNl' => ['getOrganizationNameNl', 'setOrganizationNameNl'],
         ];
 
         $this->map($map, $command, $metadata);


### PR DESCRIPTION
Prior to this change the organizationNameEn and -NL fields were removed from the SaveSamlEntityCommand in commit 45864bd66c8c027998a54f00615fea66bc033715.  However, the LoadMetadataCommandHandler still had them as part of the mapTextfields method.  This caused numerous error logs.

This change removes the leftover, and thereby will clear the logs of the error.

For the error logs and pivotal ticket see: https://www.pivotaltracker.com/story/show/177742668