### PR TITLE
Ensure all attributes are shown on view

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityDetail.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityDetail.php
@@ -173,6 +173,11 @@ class EntityDetail
     /**
      * @var Attribute
      */
+    private $eduPersonTargetedIDAttribute;
+
+    /**
+     * @var Attribute
+     */
     private $uidAttribute;
 
     /**
@@ -338,14 +343,17 @@ class EntityDetail
         $entityDetail->commonNameAttribute = $attributes->findByUrn('urn:mace:dir:attribute-def:cn');
         $entityDetail->displayNameAttribute = $attributes->findByUrn('urn:mace:dir:attribute-def:displayName');
         $entityDetail->emailAddressAttribute = $attributes->findByUrn('urn:mace:dir:attribute-def:mail');
-        $entityDetail->organizationAttribute = $attributes->findByUrn('urn:mace:terena:attribute-def:schacHomeOrganization');
-        $entityDetail->organizationTypeAttribute = $attributes->findByUrn('urn:mace:terena:attribute-def:schacHomeOrganizationType');
+        $entityDetail->organizationAttribute =
+            $attributes->findByUrn('urn:mace:terena.org:attribute-def:schacHomeOrganization');
+        $entityDetail->organizationTypeAttribute =
+            $attributes->findByUrn('urn:mace:terena.org:attribute-def:schacHomeOrganizationType');
         $entityDetail->affiliationAttribute = $attributes->findByUrn('urn:mace:dir:attribute-def:eduPersonAffiliation');
         $entityDetail->entitlementAttribute = $attributes->findByUrn('urn:mace:dir:attribute-def:eduPersonEntitlement');
         $entityDetail->principleNameAttribute = $attributes->findByUrn('urn:mace:dir:attribute-def:eduPersonPrincipalName');
+        $entityDetail->eduPersonTargetedIDAttribute = $attributes->findByUrn('urn:mace:dir:attribute-def:eduPersonTargetedID');
         $entityDetail->uidAttribute = $attributes->findByUrn('urn:mace:dir:attribute-def:uid');
         $entityDetail->preferredLanguageAttribute = $attributes->findByUrn('urn:mace:dir:attribute-def:preferredLanguage');
-        $entityDetail->personalCodeAttribute = $attributes->findByUrn('urn:schac:dir:attribute-def:schacPersonalUniqueCode');
+        $entityDetail->personalCodeAttribute = $attributes->findByUrn('urn:schac:attribute-def:schacPersonalUniqueCode');
         $entityDetail->scopedAffiliationAttribute = $attributes->findByUrn('urn:mace:dir:attribute-def:eduPersonScopedAffiliation');
     }
 
@@ -583,6 +591,15 @@ class EntityDetail
     public function getScopedAffiliationAttribute()
     {
         return $this->scopedAffiliationAttribute;
+    }
+
+
+    /**
+     * @return Attribute
+     */
+    public function getEduPersonTargetedIDAttribute()
+    {
+        return $this->eduPersonTargetedIDAttribute;
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -106,6 +106,7 @@ entity:
         prefered_language: Preferred language attribute
         personal_code: Personal code attribute
         scoped_affiliation: Scoped affiliation attribute
+        edu_person_targeted_id: Edu person targeted ID attribute
       oidc:
         title: Attributes
         html: <strong>information about the attribute fields</strong>

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detail.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detail.html.twig
@@ -88,7 +88,9 @@
         {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.prefered_language')|trans, value: entity.preferredLanguageAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.preferredLanguageAttribute'} %}
         {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.personal_code')|trans, value: entity.personalCodeAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.personalCodeAttribute'} %}
         {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.scoped_affiliation')|trans, value: entity.scopedAffiliationAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.scopedAffiliationAttribute'} %}
-
+        {% if entity.protocol == "saml20" %}
+            {% include '@Dashboard/EntityDetail/detailAttributeField.html.twig' with {label: ('entity.detail.attribute.' ~ type ~ '.edu_person_targeted_id')|trans, value: entity.eduPersonTargetedIDAttribute, informationPopup: 'entity.edit.information.' ~ type ~ '.eduPersonTargetedIDAttribute'} %}
+        {% endif %}
     </div>
 
     {% endif %}


### PR DESCRIPTION
Prior to this change, four attributes weren't shown: organization attribute, organization type attribute, personal code attribute and edu person targeted id attribute.  These attributes were visible in the edit and create actions though.

This change adds the correct urn-lookups for the organization attribute, the organization type attribute and the personal code attribute thereby rendering them visible.  It also adds the edu person targeted id attribute to the detail view and to the entitydetail object.

Pivotal ticket @ https://www.pivotaltracker.com/story/show/177945756