### PR TITLE
Ensure that copied entities have a clear ACL

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/AllowedIdentityProviders.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/AllowedIdentityProviders.php
@@ -92,4 +92,10 @@ class AllowedIdentityProviders
         $this->providers = is_null($allowedIdPs->getAllowedIdentityProviders()) ? null : $allowedIdPs->getAllowedIdentityProviders();
         $this->allowAll = is_null($allowedIdPs->isAllowAll()) ? null : $allowedIdPs->isAllowAll();
     }
+
+    public function clear()
+    {
+        $this->allowAll = true;
+        $this->providers = [];
+    }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
@@ -257,6 +257,7 @@ class EntityCreateController extends Controller
         $service = $this->authorizationService->changeActiveService($serviceId);
 
         $entity = $this->loadEntityService->load(null, $manageId, $service, $sourceEnvironment, $targetEnvironment);
+        $entity->getAllowedIdentityProviders()->clear();
         $entity->setEnvironment($targetEnvironment);
 
         // load entity into form


### PR DESCRIPTION
Prior to this change, an entity based on a template would keep the ACL from the original entity.  This obviously should not be the case, as it's a new entity with it's own ACL.

This change ensures the new entity receives a fresh ACL.

Pivotal story available at: https://www.pivotaltracker.com/story/show/177884116