### PR TITLE
Ensure attributes are validated also on test

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
@@ -207,7 +207,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $givenNameAttribute;
 
@@ -215,7 +215,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $surNameAttribute;
 
@@ -223,7 +223,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $commonNameAttribute;
 
@@ -231,7 +231,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $displayNameAttribute;
 
@@ -239,7 +239,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $emailAddressAttribute;
 
@@ -247,7 +247,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $organizationAttribute;
 
@@ -255,7 +255,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $organizationTypeAttribute;
 
@@ -263,7 +263,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $affiliationAttribute;
 
@@ -271,7 +271,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $entitlementAttribute;
 
@@ -279,7 +279,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $principleNameAttribute;
 
@@ -287,7 +287,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $uidAttribute;
 
@@ -295,7 +295,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $preferredLanguageAttribute;
 
@@ -303,7 +303,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $personalCodeAttribute;
 
@@ -311,7 +311,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $scopedAffiliationAttribute;
 
@@ -319,7 +319,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $eduPersonTargetedIDAttribute;
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveSamlEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveSamlEntityCommand.php
@@ -192,7 +192,7 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $givenNameAttribute;
 
@@ -200,7 +200,7 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $surNameAttribute;
 
@@ -208,7 +208,7 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $commonNameAttribute;
 
@@ -216,7 +216,7 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $displayNameAttribute;
 
@@ -224,7 +224,7 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $emailAddressAttribute;
 
@@ -232,7 +232,7 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $organizationAttribute;
 
@@ -240,7 +240,7 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $organizationTypeAttribute;
 
@@ -248,7 +248,7 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $affiliationAttribute;
 
@@ -256,7 +256,7 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $entitlementAttribute;
 
@@ -264,7 +264,7 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $principleNameAttribute;
 
@@ -272,7 +272,7 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $uidAttribute;
 
@@ -280,7 +280,7 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $preferredLanguageAttribute;
 
@@ -288,7 +288,7 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $personalCodeAttribute;
 
@@ -296,7 +296,7 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $scopedAffiliationAttribute;
 
@@ -304,7 +304,7 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
      * @var Attribute
      *
      * @Assert\Type(type="Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute")
-     * @SpDashboardAssert\ValidAttribute(groups={"production"})
+     * @SpDashboardAssert\ValidAttribute
      */
     private $eduPersonTargetedIDAttribute;
 


### PR DESCRIPTION
Prior to this change, leaving an arp motivation empty was possible on test, but not on production.  However, an attribute with an empty motivation was not added to the ARP.  Whilst privacyfriendly, this didn't match the expectations.

This change uses the same validation for production as for test when it comes to attributes.  Given that production and test now have the same behaviour things should be clearer.

Pivotal story: https://www.pivotaltracker.com/story/show/177774124