### PR TITLE
Prevent calling count on null

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/IssueCollection.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/IssueCollection.php
@@ -25,7 +25,7 @@ class IssueCollection implements Countable
     /**
      * @var Issue[]
      */
-    private $issues;
+    private $issues = [];
 
     /**
      * @param Issue[] $issues

--- a/tests/unit/Domain/ValueObject/IssueCollectionTest.php
+++ b/tests/unit/Domain/ValueObject/IssueCollectionTest.php
@@ -24,6 +24,12 @@ use Surfnet\ServiceProviderDashboard\Domain\ValueObject\IssueCollection;
 
 class IssueCollectionTest extends TestCase
 {
+    public function test_can_be_used_with_empty_issue_set()
+    {
+        $collection = new IssueCollection([]);
+        self::assertEquals(0, $collection->count());
+    }
+
     public function test_get_issue_by_key()
     {
         $issue1 = new Issue('CTX-0123', 'issue-type-1', 'OPEN');


### PR DESCRIPTION
By setting the default value of the issues collection to be an array.
Count function can be used safely without warning. As calling count on
null started yielding warnings in PHP7.

Resolves first warning of:
https://www.pivotaltracker.com/story/show/177742668