### PR TITLE
Show the correct descriptions per language

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityDetail.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityDetail.php
@@ -303,8 +303,8 @@ class EntityDetail
         }
         $entityDetail->nameNl = $entity->getMetaData()->getNameNl();
         $entityDetail->nameEn = $entity->getMetaData()->getNameEn();
-        $entityDetail->descriptionNl = $entity->getMetaData()->getDescriptionEn();
-        $entityDetail->descriptionEn = $entity->getMetaData()->getDescriptionNl();
+        $entityDetail->descriptionNl = $entity->getMetaData()->getDescriptionNl();
+        $entityDetail->descriptionEn = $entity->getMetaData()->getDescriptionEn();
         $entityDetail->applicationUrl = $entity->getMetaData()->getCoin()->getApplicationUrl();
         $entityDetail->eulaUrl = $entity->getMetaData()->getCoin()->getEula();
         $entityDetail->administrativeContact = $entity->getMetaData()->getContacts()->findAdministrativeContact();


### PR DESCRIPTION
Prior to this change, the description for NL was shown under EN and vice versa.

This change shows the correct description per language

Pivotal ticket at: https://www.pivotaltracker.com/story/show/178121329