### PR TITLE
Hide edit for PE on removal requested

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityActions.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityActions.php
@@ -83,12 +83,14 @@ class EntityActions
         return $this->environment;
     }
 
-    /**
-     * @return bool
-     */
-    public function allowEditAction()
+    public function allowEditAction(): bool
     {
-        if ($this->isPublishedToProduction() || $this->readOnly) {
+        $notEditable =
+            $this->isPublishedToProduction()
+            || $this->readOnly
+            || $this->status === Constants::STATE_REMOVAL_REQUESTED;
+
+        if ($notEditable) {
             return false;
         }
         return true;

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/ManageEntity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/ManageEntity.php
@@ -181,7 +181,7 @@ class ManageEntity
 
     public function isPublished()
     {
-        return ($this->status === 'published');
+        return ($this->status === Constants::STATE_PUBLISHED);
     }
 
     /**

--- a/tests/integration/Application/ViewObject/EntityActionsTest.php
+++ b/tests/integration/Application/ViewObject/EntityActionsTest.php
@@ -26,7 +26,14 @@ class EntityActionsTest extends TestCase
 {
     public function test_it_hides_idp_whitlist_option_for_oidcng_resource_server()
     {
-        $actions = new EntityActions('manage-id', 1, Constants::STATE_PUBLISHED, Constants::ENVIRONMENT_TEST, Constants::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER, false);
+        $actions = new EntityActions(
+            'manage-id',
+            1,
+            Constants::STATE_PUBLISHED,
+            Constants::ENVIRONMENT_TEST,
+            Constants::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER,
+            false
+        );
         $this->assertFalse($actions->allowAclAction());
     }
 
@@ -38,8 +45,13 @@ class EntityActionsTest extends TestCase
      *
      * @dataProvider resetClientOptions
      */
-    public function test_oidc_entities_can_reset_client_secret($expectation, $protocol, $publicationStatus, $description)
-    {
+    public function test_oidc_entities_can_reset_client_secret(
+        $expectation,
+        $protocol,
+        $publicationStatus,
+        $description
+    ) {
+    
         $actions = new EntityActions('manage-id', 1, $publicationStatus, Constants::ENVIRONMENT_TEST, $protocol, false);
 
         $this->assertEquals($expectation, $actions->allowSecretResetAction(), $description);
@@ -48,24 +60,105 @@ class EntityActionsTest extends TestCase
     public static function resetClientOptions()
     {
         return [
-            [true, Constants::TYPE_OPENID_CONNECT_TNG, Constants::STATE_PUBLISHED, 'Published OIDC TNG entity should have reset option'],
-            [true, Constants::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER, Constants::STATE_PUBLISHED, 'Published OIDC Resource Server TNG entity should have reset option'],
+            [
+                true,
+                Constants::TYPE_OPENID_CONNECT_TNG,
+                Constants::STATE_PUBLISHED,
+                'Published OIDC TNG entity should have reset option'
+            ],
+            [
+                true,
+                Constants::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER,
+                Constants::STATE_PUBLISHED,
+                'Published OIDC Resource Server TNG entity should have reset option'
+            ],
 
-            [true, Constants::TYPE_OPENID_CONNECT_TNG, Constants::STATE_PUBLICATION_REQUESTED, 'Request for publication OIDC TNG entity should have reset option'],
-            [true, Constants::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER, Constants::STATE_PUBLISHED, 'Request for publication OIDC Resource Server TNG entity should have reset option'],
+            [
+                true,
+                Constants::TYPE_OPENID_CONNECT_TNG,
+                Constants::STATE_PUBLICATION_REQUESTED,
+                'Request for publication OIDC TNG entity should have reset option'
+            ],
+            [
+                true,
+                Constants::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER,
+                Constants::STATE_PUBLISHED,
+                'Request for publication OIDC Resource Server TNG entity should have reset option'
+            ],
 
-            [false, Constants::TYPE_SAML, Constants::STATE_PUBLISHED, 'SAML entities do not perform client resets'],
+            [
+                false,
+                Constants::TYPE_SAML,
+                Constants::STATE_PUBLISHED,
+                'SAML entities do not perform client resets'
+            ],
         ];
     }
 
     public function test_read_only_restricts_cud_actions()
     {
-        $actions = new EntityActions('manage-id', 1, Constants::STATE_DRAFT, Constants::ENVIRONMENT_TEST, Constants::TYPE_OPENID_CONNECT_TNG, true);
+        $actions = new EntityActions(
+            'manage-id',
+            1,
+            Constants::STATE_DRAFT,
+            Constants::ENVIRONMENT_TEST,
+            Constants::TYPE_OPENID_CONNECT_TNG,
+            true
+        );
         $this->assertFalse($actions->allowEditAction());
         $this->assertFalse($actions->allowDeleteAction());
         $this->assertFalse($actions->allowAclAction());
         $this->assertFalse($actions->allowCopyAction());
         $this->assertFalse($actions->allowCopyToProductionAction());
         $this->assertFalse($actions->allowSecretResetAction());
+    }
+
+    public function testEditActionVisibility(): void
+    {
+        $removalRequested = new EntityActions(
+            'manage-id',
+            1,
+            Constants::STATE_REMOVAL_REQUESTED,
+            Constants::ENVIRONMENT_PRODUCTION,
+            Constants::TYPE_OPENID_CONNECT_TNG,
+            false
+        );
+        $this->assertFalse($removalRequested->allowEditAction());
+        $readOnly = new EntityActions(
+            'manage-id',
+            1,
+            Constants::STATE_PUBLICATION_REQUESTED,
+            Constants::ENVIRONMENT_PRODUCTION,
+            Constants::TYPE_OPENID_CONNECT_TNG,
+            true
+        );
+        $this->assertFalse($readOnly->allowEditAction());
+        $publishedToProd = new EntityActions(
+            'manage-id',
+            1,
+            Constants::STATE_PUBLISHED,
+            Constants::ENVIRONMENT_PRODUCTION,
+            Constants::TYPE_OPENID_CONNECT_TNG,
+            false
+        );
+        $this->assertFalse($publishedToProd->allowEditAction());
+        $shouldBeEditable = new EntityActions(
+            'manage-id',
+            1,
+            Constants::STATE_PUBLICATION_REQUESTED,
+            Constants::ENVIRONMENT_PRODUCTION,
+            Constants::TYPE_OPENID_CONNECT_TNG,
+            false
+        );
+        $this->assertTrue($shouldBeEditable->allowEditAction());
+        $shouldBeEditable2 = new EntityActions(
+            'manage-id',
+            1,
+            Constants::STATE_PUBLISHED,
+            Constants::ENVIRONMENT_TEST,
+            Constants::TYPE_OPENID_CONNECT_TNG,
+            false
+        );
+        $this->assertTrue($shouldBeEditable2->allowEditAction());
     }
 }


### PR DESCRIPTION
Prior to this change, the edit option was visible for entities that had the status of removal requested.  Upon clicking the edit button, an access denied screen was shown.  This behaviour was right, but the option to click edit should not be present.

This change removes the edit option.

Pivotal ticket: https://www.pivotaltracker.com/story/show/178034009