### PR TITLE
Ensure name in En/Nl is mandatory

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OauthClientCredentialEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OauthClientCredentialEntityType.php
@@ -124,7 +124,7 @@ class OauthClientCredentialEntityType extends AbstractType
                 'nameNl',
                 TextType::class,
                 [
-                    'required' => false,
+                    'required' => true,
                     'attr' => ['data-help' => 'entity.edit.information.nameNl'],
                 ]
             )
@@ -143,7 +143,7 @@ class OauthClientCredentialEntityType extends AbstractType
                 'nameEn',
                 TextType::class,
                 [
-                    'required' => false,
+                    'required' => true,
                     'attr' => ['data-help' => 'entity.edit.information.nameEn'],
                 ]
             )

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
@@ -194,7 +194,7 @@ class OidcngEntityType extends AbstractType
                 'nameNl',
                 TextType::class,
                 [
-                    'required' => false,
+                    'required' => true,
                     'attr' => ['data-help' => 'entity.edit.information.nameNl'],
                 ]
             )
@@ -213,7 +213,7 @@ class OidcngEntityType extends AbstractType
                 'nameEn',
                 TextType::class,
                 [
-                    'required' => false,
+                    'required' => true,
                     'attr' => ['data-help' => 'entity.edit.information.nameEn'],
                 ]
             )

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngResourceServerEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngResourceServerEntityType.php
@@ -83,7 +83,7 @@ class OidcngResourceServerEntityType extends AbstractType
                 'nameNl',
                 TextType::class,
                 [
-                    'required' => false,
+                    'required' => true,
                     'attr' => ['data-help' => 'entity.edit.information.nameNl'],
                 ]
             )
@@ -102,7 +102,7 @@ class OidcngResourceServerEntityType extends AbstractType
                 'nameEn',
                 TextType::class,
                 [
-                    'required' => false,
+                    'required' => true,
                     'attr' => ['data-help' => 'entity.edit.information.nameEn'],
                 ]
             )

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
@@ -165,7 +165,7 @@ class SamlEntityType extends AbstractType
                         'nameNl',
                         TextType::class,
                         [
-                            'required' => false,
+                            'required' => true,
                             'attr' => ['data-help' => 'entity.edit.information.nameNl'],
                         ]
                     )
@@ -184,7 +184,7 @@ class SamlEntityType extends AbstractType
                         'nameEn',
                         TextType::class,
                         [
-                            'required' => false,
+                            'required' => true,
                             'attr' => ['data-help' => 'entity.edit.information.nameEn'],
                         ]
                     )


### PR DESCRIPTION
Prior to this change the names of the organization were not mandatory.

This change makes them mandatory.

Pivotal story at: https://www.pivotaltracker.com/story/show/177659336