### PR TITLE
Separate modal oidc for environment

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityPublishedController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityPublishedController.php
@@ -85,6 +85,9 @@ class EntityPublishedController extends Controller
 
         $viewObject = EntityOidcConfirmation::fromEntity($entity);
 
-        return ['entity' => $viewObject];
+        return [
+            'entity' => $viewObject,
+            'environment' => $entity->getEnvironment(),
+        ];
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -173,7 +173,8 @@ entity.list.modal.oidc_confirmation:
   client_secret:
     label: Secret
   warning: This message will be displayed only once
-  info.html: <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+  info.production.html: <p>PRODUCTION Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+  info.test.html: <p>TEST Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 entity.list.oidcng_connection.info.html: <p><strong>Select OIDC RP to connect this Resource Server to</strong></p><p><i class="fa fa-exclamation-triangle"></i> Only access_tokens from connected clients can be introspected by the resource server.</p>
 entity.edit.error.publish: "Unable to publish the entity, try again later"
 entity.edit.error.push: "Unable to publish the entity, try again later"

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -150,11 +150,7 @@ entity:
         prefered_language: Preferred language attribute
         personal_code: Personal code attribute
         scoped_affiliation: Scoped affiliation attribute
-
-  type:
-    oauth20:
-      ccc:
-        title:entity.list.add_to_test: New test entity
+entity.list.add_to_test: New test entity
 entity.list.add_to_production: New production entity
 entity.list.name: Entity
 entity.list.entity_id: Entity ID

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/oidcConfirmationModal.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/oidcConfirmationModal.html.twig
@@ -3,8 +3,9 @@
 {% block page_heading %} {{ 'entity.list.modal.oidc_confirmation.title'|trans }} {% endblock %}
 
 {% block body %}
+    {% set infoString = 'entity.list.modal.oidc_confirmation.info.' ~ environment ~ '.html' %}
     <div class="warning"><i class="fa fa-exclamation-triangle"></i>{{ 'entity.list.modal.oidc_confirmation.warning'|trans }}</div>
-    <div class="wysiwyg">{{ 'entity.list.modal.oidc_confirmation.info.html'|trans|wysiwyg }}</div>
+    <div class="wysiwyg">{{ infoString|trans|wysiwyg }}</div>
 
     <div class="row oidc-confirmation">
         {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.list.modal.oidc_confirmation.client_secret.label'|trans, value: entity.clientSecret} %}


### PR DESCRIPTION
Prior to this PR there was only one message for both environments to which a OIDC was published.

This PR ensures that a separate message is possible, depending on the environment.  In all other respects the modal remains the same.
It also applies the boyscout rule to fix a broken translation.

Pivotal ticket at https://www.pivotaltracker.com/story/show/175656934