### PR TITLE
Fix user redirect after deleting published entity

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityDeleteController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityDeleteController.php
@@ -173,7 +173,11 @@ class EntityDeleteController extends Controller
                 );
             }
             $service = $this->authorizationService->changeActiveService($serviceId);
-            return $this->redirectToRoute('service_admin_overview', ['serviceId' => $service->getId()]);
+            if ($this->isGranted('ROLE_ADMINISTRATOR')) {
+                return $this->redirectToRoute('service_admin_overview', ['serviceId' => $service->getId()]);
+            }
+
+            return $this->redirectToRoute('service_overview');
         }
 
         return [


### PR DESCRIPTION
Prior to this change, users who deleted a published entity were redirected to /service/{id}, for which one needs admin access.  This resulted in an error.

This change ensures that the redirection takes into account their access level.  Normal users are now redirected to '/', admin users see no change.

Pivotal ticket: https://www.pivotaltracker.com/story/show/178034022