### PR TITLE
Validate entity id for SAML

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/LoadEntityService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/LoadEntityService.php
@@ -49,19 +49,20 @@ class LoadEntityService
     }
 
     /**
-     * @param int $dashboardId
-     * @param string $manageId
-     * @param Service $service
-     * @param string $sourceEnvironment
-     * @param string $environment
-     * @param bool $isClientReset
      * @return ManageEntity
      * @throws InvalidArgumentException
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
-    public function load($dashboardId, $manageId, Service $service, $sourceEnvironment, $environment, $isClientReset = false)
-    {
+    public function load(
+        ?int $dashboardId,
+        string $manageId,
+        Service $service,
+        string $sourceEnvironment,
+        string $environment,
+        bool $isClientReset = false,
+        bool $isCopy = false
+    ) {
         $manageClient = $this->manageProductionClient;
         if ($sourceEnvironment == 'test') {
             $manageClient = $this->manageTestClient;
@@ -94,8 +95,9 @@ class LoadEntityService
         // Published production entities must be cloned, not copied
         $isProductionClone = $environment === Constants::ENVIRONMENT_PRODUCTION && $manageStagingState === 0;
         // Entities copied from test to prod should not have a manage id either
-        $isCopyToProduction = $environment === Constants::ENVIRONMENT_PRODUCTION && $sourceEnvironment === Constants::ENVIRONMENT_TEST  ;
-        if (($isProductionClone || $isCopyToProduction) && !$isClientReset) {
+        $isCopyToProduction =
+            $environment === Constants::ENVIRONMENT_PRODUCTION && $sourceEnvironment === Constants::ENVIRONMENT_TEST  ;
+        if (($isProductionClone || $isCopyToProduction || $isCopy) && !$isClientReset) {
             $manageEntity = $manageEntity->resetId();
             $manageEntity->setEnvironment($environment);
         }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
@@ -28,7 +28,6 @@ use Surfnet\ServiceProviderDashboard\Application\Service\EntityMergeService;
 use Surfnet\ServiceProviderDashboard\Application\Service\EntityService;
 use Surfnet\ServiceProviderDashboard\Application\Service\LoadEntityService;
 use Surfnet\ServiceProviderDashboard\Application\Service\ServiceService;
-use Surfnet\ServiceProviderDashboard\Application\ViewObject\Entity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Factory\EntityTypeFactory;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity\CreateNewEntityType;
@@ -260,13 +259,10 @@ class EntityCreateController extends Controller
         $service = $this->authorizationService->changeActiveService($serviceId);
 
         $entity = $this->loadEntityService->load(
-            null,
             $manageId,
             $service,
             $sourceEnvironment,
-            $targetEnvironment,
-            false,
-            true
+            $targetEnvironment
         );
         $entity->getAllowedIdentityProviders()->clear();
         $entity->setEnvironment($targetEnvironment);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
@@ -259,7 +259,15 @@ class EntityCreateController extends Controller
 
         $service = $this->authorizationService->changeActiveService($serviceId);
 
-        $entity = $this->loadEntityService->load(null, $manageId, $service, $sourceEnvironment, $targetEnvironment);
+        $entity = $this->loadEntityService->load(
+            null,
+            $manageId,
+            $service,
+            $sourceEnvironment,
+            $targetEnvironment,
+            false,
+            true
+        );
         $entity->getAllowedIdentityProviders()->clear();
         $entity->setEnvironment($targetEnvironment);
 

--- a/tests/unit/Application/Service/LoadEntityServiceTest.php
+++ b/tests/unit/Application/Service/LoadEntityServiceTest.php
@@ -93,7 +93,7 @@ class LoadEntityServiceTest extends MockeryTestCase
         $this->expectException(InvalidArgumentException::class);
 
         $this->copyService->load(
-            'dashboardid',
+            null,
             'manageid',
             $this->service,
             Constants::ENVIRONMENT_TEST,
@@ -126,7 +126,7 @@ class LoadEntityServiceTest extends MockeryTestCase
         $this->expectException(InvalidArgumentException::class);
 
         $this->copyService->load(
-            'dashboardid',
+            null,
             'manageid',
             $this->service,
             Constants::ENVIRONMENT_PRODUCTION,
@@ -212,7 +212,7 @@ JSON
             ));
 
         $this->copyService->load(
-            'dashboardid',
+            null,
             'manageid',
             $this->service,
             Constants::ENVIRONMENT_TEST,
@@ -298,7 +298,7 @@ JSON
             ));
 
         $this->copyService->load(
-            'dashboardid',
+            null,
             'manageid',
             $this->service,
             Constants::ENVIRONMENT_PRODUCTION,
@@ -314,7 +314,7 @@ JSON
             ->andReturn($manageDto);
 
         $entity = $this->copyService->load(
-            'dashboardid',
+            null,
             'manageid',
             $this->service,
             Constants::ENVIRONMENT_TEST,
@@ -334,7 +334,7 @@ JSON
             ->andReturn($manageDto);
 
         $entity = $this->copyService->load(
-            'dashboardid',
+            null,
             'manageid',
             $this->service,
             Constants::ENVIRONMENT_TEST,
@@ -349,7 +349,7 @@ JSON
             ->andReturn($manageDto);
 
         $entity = $this->copyService->load(
-            'dashboardid',
+            null,
             'manageid',
             $this->service,
             Constants::ENVIRONMENT_PRODUCTION,
@@ -368,7 +368,7 @@ JSON
             ->andReturn($manageDto);
 
         $entity = $this->copyService->load(
-            'dashboardid',
+            null,
             'manageid',
             $this->service,
             Constants::ENVIRONMENT_TEST,
@@ -389,7 +389,7 @@ JSON
             ->andReturn($manageDto);
         
         $entity = $this->copyService->load(
-            'dashboardid',
+            null,
             'manageid2',
             $this->service,
             Constants::ENVIRONMENT_TEST,

--- a/tests/unit/Application/Service/LoadEntityServiceTest.php
+++ b/tests/unit/Application/Service/LoadEntityServiceTest.php
@@ -74,12 +74,7 @@ class LoadEntityServiceTest extends MockeryTestCase
 
         $this->copyService = new LoadEntityService(
             $this->manageTestClient,
-            $this->manageProdClient,
-            $this->attributesMetadataRepository,
-            self::OIDC_PLAYGROUND_URL_TEST,
-            self::OIDC_PLAYGROUND_URL_PROD,
-            self::OIDCNG_PLAYGROUND_URL_TEST,
-            self::OIDCNG_PLAYGROUND_URL_PROD
+            $this->manageProdClient
         );
     }
 
@@ -93,7 +88,6 @@ class LoadEntityServiceTest extends MockeryTestCase
         $this->expectException(InvalidArgumentException::class);
 
         $this->copyService->load(
-            null,
             'manageid',
             $this->service,
             Constants::ENVIRONMENT_TEST,
@@ -126,7 +120,6 @@ class LoadEntityServiceTest extends MockeryTestCase
         $this->expectException(InvalidArgumentException::class);
 
         $this->copyService->load(
-            null,
             'manageid',
             $this->service,
             Constants::ENVIRONMENT_PRODUCTION,
@@ -212,7 +205,6 @@ JSON
             ));
 
         $this->copyService->load(
-            null,
             'manageid',
             $this->service,
             Constants::ENVIRONMENT_TEST,
@@ -298,7 +290,6 @@ JSON
             ));
 
         $this->copyService->load(
-            null,
             'manageid',
             $this->service,
             Constants::ENVIRONMENT_PRODUCTION,
@@ -314,7 +305,6 @@ JSON
             ->andReturn($manageDto);
 
         $entity = $this->copyService->load(
-            null,
             'manageid',
             $this->service,
             Constants::ENVIRONMENT_TEST,
@@ -334,7 +324,6 @@ JSON
             ->andReturn($manageDto);
 
         $entity = $this->copyService->load(
-            null,
             'manageid',
             $this->service,
             Constants::ENVIRONMENT_TEST,
@@ -349,7 +338,6 @@ JSON
             ->andReturn($manageDto);
 
         $entity = $this->copyService->load(
-            null,
             'manageid',
             $this->service,
             Constants::ENVIRONMENT_PRODUCTION,
@@ -368,7 +356,6 @@ JSON
             ->andReturn($manageDto);
 
         $entity = $this->copyService->load(
-            null,
             'manageid',
             $this->service,
             Constants::ENVIRONMENT_TEST,
@@ -389,7 +376,6 @@ JSON
             ->andReturn($manageDto);
         
         $entity = $this->copyService->load(
-            null,
             'manageid2',
             $this->service,
             Constants::ENVIRONMENT_TEST,


### PR DESCRIPTION
Prior to this change, the entity id was not validated for uniqueness with SAML entities.  This lead to an indistinct error when publishing.

This change applies the correct validation for uniqueness.  This ensures the error is shown on the create page with a more helpful text.
It also employs the boyscout rule to use type hinting and to get rid of some legacy code.

Pivotal ticket @: https://www.pivotaltracker.com/story/show/172022288