### PR TITLE
Lowercase protocol & hostname in redirect url

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
@@ -459,7 +459,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      */
     public function setEntityId($entityId)
     {
-        $this->entityId = $entityId;
+        $this->entityId = strtolower($entityId);
     }
 
     /**
@@ -501,7 +501,10 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
     {
         $urls = []; // because numeric array keys can be sparse so a for-loop cannot be trusted
         foreach ($redirectUrls as $url) {
-            $urls[] = strtolower($url);
+            $protocolSlashes = strpos($url, '://');
+            $hostname = strpos($url, '/', $protocolSlashes + 3);
+            $lowercased = strtolower(substr($url, 0, $hostname));
+            $urls[] = $lowercased . substr($url, $hostname);
         }
         $this->redirectUrls = $urls;
     }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngResourceServerEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngResourceServerEntityCommand.php
@@ -248,7 +248,7 @@ class SaveOidcngResourceServerEntityCommand implements SaveEntityCommandInterfac
      */
     public function setEntityId($entityId)
     {
-        $this->entityId = $entityId;
+        $this->entityId = strtolower($entityId);
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcngClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcngClient.php
@@ -148,7 +148,10 @@ class OidcngClient implements OidcClientInterface
         $urls = [];
         if (isset($data[$key])) {
             foreach ($data[$key] as $url) {
-                $urls[] = strtolower($url);
+                $protocolSlashes = strpos($url, '://');
+                $hostname = strpos($url, '/', $protocolSlashes + 3);
+                $lowercased = strtolower(substr($url, 0, $hostname));
+                $urls[] = $lowercased . substr($url, $hostname);
             }
         }
         return $urls;

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcngResourceServerClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcngResourceServerClient.php
@@ -60,7 +60,7 @@ class OidcngResourceServerClient implements OidcClientInterface
         ?string $clientSecret,
         array $grants
     ) {
-        $this->clientId = $clientId;
+        $this->clientId = strtolower($clientId);
         $this->clientSecret = $clientSecret;
         $this->grants = $grants;
     }


### PR DESCRIPTION
Prior to this change the entire redirect url was lowercased.  That wasn't the idea but not entirely clear in the orinal feature request.

This change lowercases only the correct parts.

See pivotal comment / ticket @ https://www.pivotaltracker.com/story/show/173276689/comments/225087260