### PR TITLE
Only update acl fields on edit idp whitelist

### DIFF
--- a/docs/generator.md
+++ b/docs/generator.md
@@ -1,0 +1,10 @@
+# How to add a new generator
+
+1. make a copy of the JsonGenerator
+2. get rid of all the stuff you don't need
+3. ensure that it get's the tag you want via services.yml.  The example below uses a fictitious acl identifier:
+```
+tags:
+    - { name: dashboard.json_generator, identifier: acl }
+```
+4. ensure it gets loaded via the JsonGeneratorStrategy.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,3 +10,4 @@
 3. [Third party frontend packages](third_party_packages.md)
 3. [Jira docker setup guide](jira.md)
 3. [Release guide](release.md)
+3. [Generators](generator.md)

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/UpdateEntityAclCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/UpdateEntityAclCommandHandler.php
@@ -71,7 +71,7 @@ class UpdateEntityAclCommandHandler implements CommandHandler
         $allowedIdps = new AllowedIdentityProviders($idps, $command->isSelectAll());
         $entity->getAllowedIdentityProviders()->merge($allowedIdps);
         try {
-            $this->publishClient->publish($entity);
+            $this->publishClient->publish($entity, 'ACL');
         } catch (PublishMetadataException $e) {
             $this->logger->error(
                 sprintf(

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/GeneratorInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/GeneratorInterface.php
@@ -34,6 +34,14 @@ interface GeneratorInterface
      * generateNew(), but only contains fields stored in SP-dashboard, and
      * never overwrites fields not managed by the dashboard (such as allowed
      * entities).
+     *
+     * The updatedPart parameter currently is only used when updating the ACL.
+     * It was introduced as part of fixing the bug described here: https://www.pivotaltracker.com/story/show/178461498.
+     * The idea is that it'll be used in the future for all updates.
      */
-    public function generateForExistingEntity(ManageEntity $entity, string $workflowState): array;
+    public function generateForExistingEntity(
+        ManageEntity $entity,
+        string $workflowState,
+        string $updatedPart = ''
+    ): array;
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGeneratorStrategy.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGeneratorStrategy.php
@@ -58,9 +58,10 @@ class JsonGeneratorStrategy
      * @return array
      * @throws JsonGeneratorStrategyNotFoundException
      */
-    public function generateForExistingEntity(ManageEntity $entity, string $workflowState)
+    public function generateForExistingEntity(ManageEntity $entity, string $workflowState, string $updatedPart = '')
     {
-        return $this->getStrategy($entity->getProtocol()->getProtocol())->generateForExistingEntity($entity, $workflowState);
+        return $this->getStrategy($entity->getProtocol()->getProtocol())
+                    ->generateForExistingEntity($entity, $workflowState, $updatedPart);
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OauthClientCredentialsClientJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OauthClientCredentialsClientJsonGenerator.php
@@ -61,15 +61,16 @@ class OauthClientCredentialsClientJsonGenerator implements GeneratorInterface
         ];
     }
 
-    public function generateForExistingEntity(ManageEntity $entity, string $workflowState): array
-    {
-        $data = [
-            'pathUpdates' => $this->generateDataForExistingEntity($entity, $workflowState),
+    public function generateForExistingEntity(
+        ManageEntity $entity,
+        string $workflowState,
+        string $updatedPart = ''
+    ): array {
+        return [
+            'pathUpdates' => $this->generateDataForExistingEntity($entity, $workflowState, $updatedPart),
             'type' => 'oidc10_rp',
             'id' => $entity->getId(),
         ];
-
-        return $data;
     }
 
     private function generateDataForNewEntity(ManageEntity $entity, string $workflowState): array
@@ -93,24 +94,28 @@ class OauthClientCredentialsClientJsonGenerator implements GeneratorInterface
         return $metadata;
     }
 
-    /**
-     * @param ManageEntity $entity
-     * @param string $workflowState
-     * @return array
-     */
-    private function generateDataForExistingEntity(ManageEntity $entity, $workflowState)
-    {
+    private function generateDataForExistingEntity(
+        ManageEntity $entity,
+        string $workflowState,
+        string $updatedPart
+    ): array {
         $metadata = [
             'entityid' => OidcngClientIdParser::parse($entity->getMetaData()->getEntityId()),
-            'state' => $workflowState,
         ];
 
-        $metadata += $this->generateAclData($entity);
-        $metadata += $this->generateAllowedResourceServers($entity);
+        switch ($updatedPart) {
+            case 'ACL':
+                $metadata += $this->generateAclData($entity);
+                break;
 
-        $metadata += $this->flattenMetadataFields(
-            $this->generateMetadataFields($entity)
-        );
+            default:
+                $metadata['state'] = $workflowState;
+
+                $metadata += $this->generateAllowedResourceServers($entity);
+                $metadata += $this->flattenMetadataFields(
+                    $this->generateMetadataFields($entity)
+                );
+        }
 
         if ($entity->hasComments()) {
             $metadata['revisionnote'] = $entity->getComments();

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
@@ -24,7 +24,6 @@ use Surfnet\ServiceProviderDashboard\Application\Parser\OidcngClientIdParser;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
-use function in_array;
 
 /**
  * The OidcngResourceServerJsonGenerator generates oauth20-rs resource server entity json
@@ -63,10 +62,13 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
         ];
     }
 
-    public function generateForExistingEntity(ManageEntity $entity, string $workflowState): array
-    {
+    public function generateForExistingEntity(
+        ManageEntity $entity,
+        string $workflowState,
+        string $updatedPart = ''
+    ): array {
         return [
-            'pathUpdates' => $this->generateDataForExistingEntity($entity, $workflowState),
+            'pathUpdates' => $this->generateDataForExistingEntity($entity, $workflowState, $updatedPart),
             'type' => 'oauth20_rs',
             'active' => true,
             'id' => $entity->getId(),
@@ -90,8 +92,11 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
         return $metadata;
     }
 
-    private function generateDataForExistingEntity(ManageEntity $entity, $workflowState)
-    {
+    private function generateDataForExistingEntity(
+        ManageEntity $entity,
+        string $workflowState,
+        string $updatedPart
+    ): array {
         $metadata = [
             'entityid' => OidcngClientIdParser::parse($entity->getMetaData()->getEntityId()),
             'state' => $workflowState,

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Repository/PublishEntityRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Repository/PublishEntityRepository.php
@@ -26,10 +26,9 @@ interface PublishEntityRepository
      * Publishes the Entity to a Service registry (like Manage, ..) This action might also result in the
      * sending of a mail message to a service desk who in turn can publish the entity in the registry.
      *
-     * @param ManageEntity $entity
      * @return mixed
      */
-    public function publish(ManageEntity $entity);
+    public function publish(ManageEntity $entity, string $part = '');
 
     /**
      * Push the metadata from Manage to Engineblock

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php
@@ -68,7 +68,7 @@ class PublishEntityClient implements PublishEntityRepositoryInterface
      *
      * @SuppressWarnings(PHPMD.ElseExpression)
      */
-    public function publish(ManageEntity $entity)
+    public function publish(ManageEntity $entity, string $updatedPart = '')
     {
         try {
             if (empty($entity->getId())) {
@@ -85,7 +85,8 @@ class PublishEntityClient implements PublishEntityRepositoryInterface
                 $this->logger->info(sprintf('Updating existing \'%s\' entity in manage', $entity->getId()));
                 $data = json_encode($this->generator->generateForExistingEntity(
                     $entity,
-                    $this->manageConfig->getPublicationStatus()->getStatus()
+                    $this->manageConfig->getPublicationStatus()->getStatus(),
+                    $updatedPart
                 ));
 
                 $response = $this->client->put(

--- a/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
@@ -176,9 +176,7 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
                         'metaDataFields.isPublicClient' => true,
                         'revisionnote' => 'revisionnote',
                         'state' => 'testaccepted',
-                        'allowedEntities' => [],
                         'allowedResourceServers' => [],
-                        'allowedall' => true,
                         'metaDataFields.coin:institution_id' => 'service-institution-id',
                         'metaDataFields.coin:institution_guid' => '543b4e5b-76b5-453f-af1e-5648378bb266'
                     ),
@@ -202,7 +200,7 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
             'http://oidc.prod.playground.example.com'
         );
 
-        $data = $generator->generateForExistingEntity($this->createManageEntity(), 'testaccepted');
+        $data = $generator->generateForExistingEntity($this->createManageEntity(), 'testaccepted', 'ACL');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(true, $data['pathUpdates']['allowedall']);
@@ -226,7 +224,7 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
 
         $entity = $this->createManageEntity(true);
 
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
+        $data = $generator->generateForExistingEntity($entity, 'testaccepted', 'ACL');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(true, $data['pathUpdates']['allowedall']);
@@ -250,7 +248,7 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
 
         $entity = $this->createManageEntity(false);
 
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
+        $data = $generator->generateForExistingEntity($entity, 'testaccepted', 'ACL');
 
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
@@ -277,7 +275,7 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
             'entity-id',
         ]);
 
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
+        $data = $generator->generateForExistingEntity($entity, 'testaccepted', 'ACL');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(false, $data['pathUpdates']['allowedall']);
@@ -305,7 +303,7 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
             'entity-id2',
         ]);
 
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted');
+        $data = $generator->generateForExistingEntity($entity, 'testaccepted', 'ACL');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(false, $data['pathUpdates']['allowedall']);
@@ -317,8 +315,8 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
     }
 
     private function createManageEntity(
-        ?bool $idpAllowAll = null,
-        ?array $idpWhitelist = null,
+        ?bool $idpAllowAll = true,
+        ?array $idpWhitelist = [],
         ?string $environment = null
     ): ManageEntity {
 
@@ -330,25 +328,13 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
         $entity->setComments('revisionnote');
         $entity = m::mock($entity);
 
-        if ($idpAllowAll !== null) {
-            $entity
-                ->shouldReceive('getAllowedIdentityProviders->isAllowAll')
-                ->andReturn($idpAllowAll);
-        } else {
-            $entity
-                ->shouldReceive('getAllowedIdentityProviders->isAllowAll')
-                ->andReturn(true);
-        }
+        $entity
+            ->shouldReceive('getAllowedIdentityProviders->isAllowAll')
+            ->andReturn($idpAllowAll);
 
-        if ($idpWhitelist !== null) {
-            $entity
-                ->shouldReceive('getAllowedIdentityProviders->getAllowedIdentityProviders')
-                ->andReturn($idpWhitelist);
-        } else {
-            $entity
-                ->shouldReceive('getAllowedIdentityProviders->getAllowedIdentityProviders')
-                ->andReturn([]);
-        }
+        $entity
+            ->shouldReceive('getAllowedIdentityProviders->getAllowedIdentityProviders')
+            ->andReturn($idpWhitelist);
 
         if ($environment !== null) {
             $entity

--- a/tests/webtests/Manage/Client/FakePublishEntityClient.php
+++ b/tests/webtests/Manage/Client/FakePublishEntityClient.php
@@ -39,7 +39,7 @@ class FakePublishEntityClient implements PublishEntityRepositoryInterface
         $this->pushOk = false;
     }
 
-    public function publish(ManageEntity $entity)
+    public function publish(ManageEntity $entity, string $part = '')
     {
         $entityId = $entity->getMetaData()->getEntityId();
         if (!array_key_exists($entityId, $this->publishResponses)) {


### PR DESCRIPTION
Prior to this change, the entire metadata for the entity was sent to mange just to update the acl.  This lead to some subtle bugs because too much was updated.  The user only updates the acl, so we should not send more than that to manage.

This change limits the data sent to manage to the data pertinant to the acl change.

Pivotal ticket @ https://www.pivotaltracker.com/story/show/178461498
API info for manage @ https://github.com/OpenConext/OpenConext-manage/wiki/API#merge-write