### PR TITLE
Docker for development: Add Teams

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ services:
       engine-api.vm.openconext.org: 127.0.0.2
       engine.vm.openconext.org: 127.0.0.1
       manage.vm.openconext.org: 127.0.0.1
+      voot.vm.openconext.org: 127.0.0.1
+      connect.vm.openconext.org: 127.0.0.1
+      test.openconext.org: 127.0.0.1
     privileged: true
     networks:
       spdashboard:

--- a/docker/Dockerfiledev
+++ b/docker/Dockerfiledev
@@ -1,4 +1,4 @@
-FROM ghcr.io/openconext/openconext-deploy/openconext-core:master AS openconext
+FROM ghcr.io/openconext/openconext-deploy/openconext-core:feature_build_image_with_teams_included AS openconext
 COPY ./conf/prep_oc.sh /tmp/prep_oc.sh
 COPY ./conf/saml20_sp.json /tmp/saml20_sp.json
 COPY ./conf/engineblock.crt /etc/openconext/engineblock.crt


### PR DESCRIPTION
In order to use this, you need to recreate some parts of your dev env:

Delete the mongo database: 
```
docker volume rm sp-dashboard_spdashboard_mongo
```
Pull the new image:
```
docker pull ghcr.io/openconext/openconext-deploy/openconext-core:feature_build_image_with_teams_included
```
Rebuild the OpenConext container
```
docker-compose build openconext
```
Start it, wait some time until everything is started. Then you need to fix a scope provisioning issue in OpenConext deploy:

- navigate to https://manage.vm.openconext.org
- Open the scopes tab, and add the scope "groups" (name and description don't matter)
- Move to the resource servers tab, and edit the resource server voot.vm.openconext.org
- Remove the "groups" scope. And save it
- Reopen it, and add it again (yes this is really how you get it up & running again)
- Click on PUSH
- You should now be able to open https://teams.vm.openconext.org (which in your /etc/hosts should point to 127.0.01)



