### PR TITLE
Store the sessions in the database: Nice for HA setups

### DIFF
--- a/app/DoctrineMigrations/Version20211013095152.php
+++ b/app/DoctrineMigrations/Version20211013095152.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20211013095152 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+	// this up() migration is auto-generated, please modify it to your needs
+	$this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->addSql('
+        CREATE TABLE `sessions` (
+        `sess_id` VARBINARY(128) NOT NULL PRIMARY KEY,
+        `sess_data` BLOB NOT NULL,
+        `sess_lifetime` INTEGER UNSIGNED NOT NULL,
+        `sess_time` INTEGER UNSIGNED NOT NULL,
+        INDEX `sessions_sess_lifetime_idx` (`sess_lifetime`)
+	) COLLATE utf8mb4_bin, ENGINE = InnoDB;
+        ');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP TABLE `sessions`');
+    }
+}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -28,8 +28,7 @@ framework:
     trusted_hosts: ~
     session:
         # http://symfony.com/doc/current/reference/configuration/framework.html#handler-id
-        handler_id:  session.handler.native_file
-        save_path:   "%kernel.root_dir%/../var/sessions/%kernel.environment%"
+        handler_id: Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler
     fragments: ~
     http_method_override: true
     assets:

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -8,3 +8,6 @@ services:
         autowire: true
         autoconfigure: true
         public: false
+    Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler:
+        arguments: 
+          - '%env(DATABASE_URL)%'

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -10,4 +10,4 @@ services:
         public: false
     Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler:
         arguments: 
-          - '%env(DATABASE_URL)%'
+          - 'mysql://%database_user%:%database_password%@%database_host%/%database_name%?serverVersion=5.7'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,6 @@ services:
       - type: bind
         source: /dev/log
         target: /dev/log
-    environment:
-      - DATABASE_URL=mysql://spdrw:secret@db.vm.openconext.org:3306/spdashboard?serverVersion=5.7
     networks:
       spdashboard:
         aliases: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,8 @@ services:
       - type: bind
         source: /dev/log
         target: /dev/log
+    environment:
+      - DATABASE_URL=mysql://spdrw:secret@db.vm.openconext.org:3306/spdashboard?serverVersion=5.7
     networks:
       spdashboard:
         aliases: 


### PR DESCRIPTION
I've tried setting up session storage in the database, since I want to make the SPdashboard suitable for using in a multi node Docker setup, without having to worry about session affinity or saving session files during restarts. 
This setups works, and would even be nicer if we can reuse the Doctrine database settings. Is that possible in any way?