### PR TITLE
Docker: use the prebuilt openconext containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       - type: bind
         source: /dev/log
         target: /dev/log
+    environment:
+      - PHPFPM_PORT=9000
     networks:
       spdashboard:
         aliases: 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,16 +1,14 @@
-FROM php:7.2-fpm-alpine AS node-build
-COPY --from=composer:1 /usr/bin/composer /usr/bin/composer
+FROM ghcr.io/openconext/openconext-containers/openconext-phpfpm-dev:latest AS node-build
 COPY . /var/www/html/
 WORKDIR /var/www/html/
 ENV SYMFONY_ENV=prod
 RUN composer install -n --prefer-dist -o --ignore-platform-reqs --no-dev && \
     composer run-script symfony-scripts && \
     bin/console assets:install && \
-    apk add --no-cache yarn && \
     yarn install && \
     yarn run encore production
 
-FROM httpd:2.4-alpine AS httpd-build
+FROM ghcr.io/openconext/openconext-containers/openconext-httpd:latest AS httpd-build
 MAINTAINER Bart Geesink (bart.geesink@surf.nl)
 RUN mkdir -p /var/www/html/
 COPY --from=node-build /var/www/html/web/. /var/www/html/web/
@@ -21,7 +19,7 @@ EXPOSE 80
 
 CMD ["httpd", "-D", "FOREGROUND"]
 
-FROM php:7.2-fpm-alpine AS phpfpm-build
+FROM ghcr.io/openconext/openconext-containers/openconext-phpfpm:latest AS phpfpm-build
 COPY --from=node-build /var/www/html/app/. /var/www/html/app/
 COPY --from=node-build /var/www/html/web/. /var/www/html/web/
 COPY --from=node-build /var/www/html/vendor/. /var/www/html/vendor/
@@ -32,10 +30,7 @@ COPY --from=node-build /var/www/html/composer.json /var/www/html/
 
 LABEL maintainer "Bart Geesink" <bart.geesink@surf.nl>
 
-RUN apk add --no-cache libxml2-dev \
-    freetype-dev && \
-    docker-php-ext-install soap gd pdo_mysql opcache && \
-    chown -R www-data /var/www/html/var/cache && \
+RUN chown -R www-data /var/www/html/var/cache && \
     chown -R www-data /var/www/html/var/logs && \
     chown -R www-data /var/www/html/var/sessions && \
     rm -rf /var/www/html/var/cache/prod/

--- a/docker/Dockerfiledev
+++ b/docker/Dockerfiledev
@@ -6,20 +6,16 @@ COPY ./conf/engineblock.pem /etc/openconext/engineblock.pem
 COPY ./conf/start.sh /tmp/start.sh
 CMD ["/tmp/start.sh"]
 
-FROM ghcr.io/surfnet/sp-dashboard/spdashboard_php-fpm:3.0.0 AS spdphpfpm
+FROM ghcr.io/openconext/openconext-containers/openconext-phpfpm-dev:latest AS spdphpfpm
 WORKDIR /var/www/html/
 COPY --from=openconext /etc/pki/ca-trust/source/anchors/star.vm.openconext.org.pem /usr/local/share/ca-certificates/star.vm.openconext.org.pem
 COPY ./conf/xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 RUN /usr/sbin/update-ca-certificates && \
-    rm -rf /tmp/sp-dashboard/ /tmp/sp-dashboard-sessions/ && \
-    apk --update --no-cache add autoconf g++ make && \
-    pecl install -f xdebug && \
-    docker-php-ext-enable xdebug && \
-    apk del --purge autoconf g++ make
+    rm -rf /tmp/sp-dashboard/ /tmp/sp-dashboard-sessions/ 
 
 CMD ["/usr/local/sbin/php-fpm" , "-F"]
 
-FROM ghcr.io/surfnet/sp-dashboard/spdashboard_web:3.0.0 AS spdhttpd
+FROM ghcr.io/openconext/openconext-containers/openconext-httpd:latest AS spdhttpd
 COPY ./conf/000-default-dev.conf /usr/local/apache2/conf/000-default.conf
 EXPOSE 80
 CMD ["httpd", "-D", "FOREGROUND"]


### PR DESCRIPTION
We build openconext containers in a seperate project, so they can be reused in other OpenConext projects