### PR TITLE
Log authenticated user

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Contact.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Contact.php
@@ -120,6 +120,11 @@ class Contact
         return $this->displayName;
     }
 
+    public function getNameId(): string
+    {
+        return $this->nameId;
+    }
+
     /**
      * @param Service $service
      *

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Security/Authentication/Handler/ProcessSamlAuthenticationHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Security/Authentication/Handler/ProcessSamlAuthenticationHandler.php
@@ -170,6 +170,7 @@ class ProcessSamlAuthenticationHandler implements AuthenticationHandler
                 return;
             }
 
+            // Store the login timestamp in the session
             $this->authenticatedSession->logAuthenticationMoment();
             $this->tokenStorage->setToken($authToken);
 
@@ -178,7 +179,11 @@ class ProcessSamlAuthenticationHandler implements AuthenticationHandler
 
             $event->setResponse(new RedirectResponse($this->authenticatedSession->getCurrentRequestUri()));
 
-            $logger->notice('Authentication succeeded, redirecting to original location');
+            $user = $authToken->getUser();
+            $logger->notice(
+                'Authentication succeeded, redirecting to original location',
+                ['user' => $user->getContact()->getNameId(), 'displayName' => (string)$user]
+            );
 
             return;
         }


### PR DESCRIPTION
While researching a reported issue by a user it was not clear which messages in the logs to look for. Log who authenticates so we can quickly find associated log lines with that session.