### PR TITLE
Add the teamId also to the service switcher

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/ServiceService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/ServiceService.php
@@ -38,7 +38,7 @@ class ServiceService
     /**
      * Retrieve names of all services.
      *
-     * Format: [ '<service id>' => '<service display name>' ]
+     * Format: [ '<service id>' => '<service display name> [<msp service team id>]' ]
      * @return array
      */
     public function getServiceNamesById()
@@ -46,7 +46,12 @@ class ServiceService
         $options = [];
 
         foreach ($this->services->findAll() as $service) {
-            $options[$service->getId()] = $service->getName();
+            $teamNameParts = explode(':', $service->getTeamName());
+            $options[$service->getId()] = sprintf(
+                "%s [%s]",
+                $service->getName(),
+                end($teamNameParts)
+            );
         }
 
         asort($options);

--- a/tests/unit/Application/Service/ServiceServiceTest.php
+++ b/tests/unit/Application/Service/ServiceServiceTest.php
@@ -46,24 +46,30 @@ class ServiceServiceTest extends MockeryTestCase
                     ->shouldReceive('getId')
                     ->andReturn('c')->getMock()
                     ->shouldReceive('getName')
-                    ->andReturn('C')->getMock(),
+                    ->andReturn('C')->getMock()
+                    ->shouldReceive('getTeamName')
+                    ->andReturn('urn:example:1')->getMock(),
                 m::mock(Service::class)
                     ->shouldReceive('getId')
                     ->andReturn('a')->getMock()
                     ->shouldReceive('getName')
-                    ->andReturn('A')->getMock(),
+                    ->andReturn('A')->getMock()
+                    ->shouldReceive('getTeamName')
+                    ->andReturn('urn:example:2')->getMock(),
                 m::mock(Service::class)
                     ->shouldReceive('getId')
                     ->andReturn('b')->getMock()
                     ->shouldReceive('getName')
-                    ->andReturn('B')->getMock(),
+                    ->andReturn('B')->getMock()
+                    ->shouldReceive('getTeamName')
+                    ->andReturn('urn:example:3')->getMock(),
             ]);
 
         $this->assertEquals(
             [
-                'a' => 'A',
-                'b' => 'B',
-                'c' => 'C',
+                'a' => 'A [2]',
+                'b' => 'B [3]',
+                'c' => 'C [1]',
             ],
             $this->service->getServiceNamesById()
         );

--- a/tests/webtests/ServiceCreateTest.php
+++ b/tests/webtests/ServiceCreateTest.php
@@ -45,6 +45,7 @@ class ServiceCreateTest extends WebTestCase
                 ],
                 'teams' => [
                     'teamManagerEmail' => 'loeki@example.org',
+                    'teamName' => 'team loeki the lion',
                 ]
             ]
         ];
@@ -77,6 +78,7 @@ class ServiceCreateTest extends WebTestCase
                 ],
                 'teams' => [
                     'teamManagerEmail' => 'loeki@example.org',
+                    'teamName' => 'team loeki the lion',
                 ]
             ]
         ];
@@ -114,6 +116,7 @@ class ServiceCreateTest extends WebTestCase
                 ],
                 'teams' => [
                     'teamManagerEmail' => 'loeki@example.org',
+                    'teamName' => 'team loeki the lion',
                 ]
             ]
         ];
@@ -147,6 +150,7 @@ class ServiceCreateTest extends WebTestCase
                 ],
                 'teams' => [
                     'teamManagerEmail' => 'loeki@example.org',
+                    'teamName' => 'SURFnet',
                 ]
             ]
         ];
@@ -182,6 +186,7 @@ class ServiceCreateTest extends WebTestCase
                 ],
                 'teams' => [
                     'teamManagerEmail' => 'loeki@example.org',
+                    'teamName' => 'team loeki the lion',
                 ]
             ]
         ];

--- a/tests/webtests/ServiceSwitcherTest.php
+++ b/tests/webtests/ServiceSwitcherTest.php
@@ -92,8 +92,8 @@ class ServiceSwitcherTest extends WebTestCase
         $this->assertCount(3, $options, 'Expecting 2 services in service switcher (excluding empty option)');
 
         $this->assertEquals('', $options->eq(0)->text());
-        $this->assertEquals('Ibuildings B.V.', $options->eq(1)->text());
-        $this->assertEquals('SURFnet', $options->eq(2)->text());
+        $this->assertEquals('Ibuildings B.V. [ibuildings.nl]', $options->eq(1)->text());
+        $this->assertEquals('SURFnet [surf.nl]', $options->eq(2)->text());
     }
 
     public function test_switcher_remembers_selected_services()
@@ -120,6 +120,6 @@ class ServiceSwitcherTest extends WebTestCase
 
         $selectedService = $crawler->filter('select#service-switcher option:selected')->first();
 
-        $this->assertEquals('SURFnet', $selectedService->text(), "Service 'SURFnet' should be selected");
+        $this->assertEquals('SURFnet [surf.nl]', $selectedService->text(), "Service 'SURFnet' should be selected");
     }
 }


### PR DESCRIPTION
As an administrator, I sometimes want to be able to find a space when I know only the teamId. Add the most significant part of the teamId urn to the service switcher so you can find services also in that way.