### PR TITLE
Docker: Fix xdebug

### DIFF
--- a/docker/Dockerfiledev
+++ b/docker/Dockerfiledev
@@ -9,7 +9,6 @@ CMD ["/usr/local/sbin/start.sh"]
 FROM ghcr.io/openconext/openconext-containers/openconext-phpfpm-dev:latest AS spdphpfpm
 WORKDIR /var/www/html/
 COPY --from=openconext /etc/pki/ca-trust/source/anchors/star.vm.openconext.org.pem /usr/local/share/ca-certificates/star.vm.openconext.org.pem
-COPY ./conf/xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 RUN /usr/sbin/update-ca-certificates && \
     rm -rf /tmp/sp-dashboard/ /tmp/sp-dashboard-sessions/ 
 

--- a/docker/conf/xdebug.ini
+++ b/docker/conf/xdebug.ini
@@ -1,4 +1,0 @@
-xdebug.mode = debug
-xdebug.discover_client_host = true
-xdebug.start_with_request = yes
-xdebug.idekey = PHPSTORM


### PR DESCRIPTION
Replacing the config file for xdebug makes xdebug no longer work. After this change, a docker-compose build should build a new fpm image with a working xdebug