### PR TITLE
Retrieve only Unresolved issues from Jira

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/IssueRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/IssueRepository.php
@@ -94,7 +94,7 @@ class IssueRepository implements TicketServiceInterface
         $issueService = $this->jiraFactory->buildIssueService();
         // Search all CTX: spd-delete-production-entity issues
         $issues = $issueService->search(
-            sprintf('project = %s AND issuetype = %s', $this->projectKey, $this->issueType)
+            sprintf('project = %s AND resolution = Unresolved AND issuetype = %s', $this->projectKey, $this->issueType)
         );
         $collection = [];
         foreach ($issues->issues as $issue) {
@@ -112,7 +112,7 @@ class IssueRepository implements TicketServiceInterface
         // Search CTX: spd-delete-production-entity issues with manage id as provided in the $manageId parameter
         $issues = $issueService->search(
             sprintf(
-                'project = %s AND issuetype = %s AND "%s" ~ %s',
+                'project = %s AND resolution = Unresolved AND issuetype = %s AND "%s" ~ %s',
                 $this->projectKey,
                 $this->issueType,
                 $this->manageIdFieldLabel,


### PR DESCRIPTION
During a peer programming session with Bart, we encountered that the request delete of prod entity status was not reverted back when the issue status in Jira was set to 'resolved'. Resulting in the ticket retaining its faulty status. This feature was encountered when users unintentionally clicked the 'remove prod entity' button. And the support team verified the action with the user, resulting in the resolution of the ticket (without any action). This should have resulted in the entity status reverting back to 'published'.

By simply filtering the Jira results to only show the Unresolved items we resolved this issue. With the additional benefit of only retrieving the active tickets at that point. Decreasing the processing time and resource hogging.

See: https://www.pivotaltracker.com/story/show/176244612