### PR TITLE
Venture into using the MERGE WRITE Manage Endpoint for updating Entities

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/GeneratorInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/GeneratorInterface.php
@@ -18,6 +18,8 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Metadata;
 
+use Surfnet\ServiceProviderDashboard\Application\ViewObject\Entity;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\EntityDiff;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 
 interface GeneratorInterface
@@ -41,6 +43,7 @@ interface GeneratorInterface
      */
     public function generateForExistingEntity(
         ManageEntity $entity,
+        EntityDiff $differences,
         string $workflowState,
         string $updatedPart = ''
     ): array;

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGeneratorStrategy.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGeneratorStrategy.php
@@ -20,6 +20,7 @@ namespace Surfnet\ServiceProviderDashboard\Application\Metadata;
 
 use Surfnet\ServiceProviderDashboard\Application\Dto\MetadataConversionDto;
 use Surfnet\ServiceProviderDashboard\Application\Exception\JsonGeneratorStrategyNotFoundException;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\EntityDiff;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 
 /**
@@ -58,10 +59,10 @@ class JsonGeneratorStrategy
      * @return array
      * @throws JsonGeneratorStrategyNotFoundException
      */
-    public function generateForExistingEntity(ManageEntity $entity, string $workflowState, string $updatedPart = '')
+    public function generateForExistingEntity(ManageEntity $entity, EntityDiff $differences, string $workflowState, string $updatedPart = '')
     {
         return $this->getStrategy($entity->getProtocol()->getProtocol())
-                    ->generateForExistingEntity($entity, $workflowState, $updatedPart);
+                    ->generateForExistingEntity($entity, $differences, $workflowState, $updatedPart);
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OauthClientCredentialsClientJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OauthClientCredentialsClientJsonGenerator.php
@@ -22,7 +22,9 @@ use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\PrivacyQ
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\SpDashboardMetadataGenerator;
 use Surfnet\ServiceProviderDashboard\Application\Parser\OidcngClientIdParser;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Contact;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\EntityDiff;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
+use function sprintf;
 
 /**
  * The OauthClientCredentialsClientJsonGenerator generates oidc10_rp entity json
@@ -63,11 +65,12 @@ class OauthClientCredentialsClientJsonGenerator implements GeneratorInterface
 
     public function generateForExistingEntity(
         ManageEntity $entity,
+        EntityDiff $differences,
         string $workflowState,
         string $updatedPart = ''
     ): array {
         return [
-            'pathUpdates' => $this->generateDataForExistingEntity($entity, $workflowState, $updatedPart),
+            'pathUpdates' => $this->generateDataForExistingEntity($entity, $differences, $workflowState, $updatedPart),
             'type' => 'oidc10_rp',
             'id' => $entity->getId(),
         ];
@@ -96,61 +99,28 @@ class OauthClientCredentialsClientJsonGenerator implements GeneratorInterface
 
     private function generateDataForExistingEntity(
         ManageEntity $entity,
+        EntityDiff $differences,
         string $workflowState,
         string $updatedPart
     ): array {
         $metadata = [
             'entityid' => OidcngClientIdParser::parse($entity->getMetaData()->getEntityId()),
         ];
-
         switch ($updatedPart) {
             case 'ACL':
                 $metadata += $this->generateAclData($entity);
-                break;
+                return $metadata;
 
             default:
+                $metadata += $differences->getDiff();
                 $metadata['state'] = $workflowState;
-
                 $metadata += $this->generateAllowedResourceServers($entity);
-                $metadata += $this->flattenMetadataFields(
-                    $this->generateMetadataFields($entity)
-                );
+                $this->setExcludeFromPush($metadata, $entity, true);
+                if ($entity->hasComments()) {
+                    $metadata['revisionnote'] = $entity->getComments();
+                }
+                return $metadata;
         }
-
-        if ($entity->hasComments()) {
-            $metadata['revisionnote'] = $entity->getComments();
-        }
-
-        return $metadata;
-    }
-
-    /**
-     * Convert a list fields to a flat array expected by the merge-write API.
-     *
-     * Manage always returns metadata fields like this:
-     *
-     *     [ metaDataFields => [ description:en => ..., description:nl => ..., ...] ]
-     *
-     * But when using the merge-write API, sending a 'metaDataFields' property
-     * will overwrite all existing metadata fields. To prevent this, we only
-     * send the metadata fields we actually want to update by using the flat
-     * format:
-     *
-     *     [ metaDataFields.description:en => ..., metaDataFields.description:nl => ..., ...] ]
-     *
-     *
-     * @param array $fields
-     * @return array
-     */
-    private function flattenMetadataFields(array $fields)
-    {
-        $flatFields = [];
-
-        foreach ($fields as $name => $value) {
-            $flatFields['metaDataFields.'.$name] = $value;
-        }
-
-        return $flatFields;
     }
 
     /**
@@ -361,25 +331,30 @@ class OauthClientCredentialsClientJsonGenerator implements GeneratorInterface
         ];
     }
 
-    private function setExcludeFromPush(&$metadata, ManageEntity $entity): void
+    private function setExcludeFromPush(&$metadata, ManageEntity $entity, $flatten = false): void
     {
+        $fieldName = 'coin:exclude_from_push';
+        if ($flatten) {
+            $fieldName = sprintf('metaDataFields.coin:exclude_from_push');
+        }
+
         // Scenario 1: When publishing to production, the coin:exclude_from_push must be present and set to '1'.
         // This prevents the entity from being pushed to EngineBlock.
         if ($entity->isProduction()) {
-            $metadata['coin:exclude_from_push'] = '1';
+            $metadata[$fieldName] = '1';
         }
 
         // Scenario 2: When dealing with a client secret reset, keep the current exclude from push state.
         $secret = $entity->getOidcClient()->getClientSecret();
         if ($secret && $entity->isManageEntity() && !$entity->isExcludedFromPush()) {
-            $metadata['coin:exclude_from_push'] = '0';
+            $metadata[$fieldName] = '0';
         }
 
         // Scenario 3: We are resetting the client secret, the service desk removed the exclude from push coin
         // attribute. This also indicates the entity is published. But now we do not want to reset the coin to '0', we
         // simply unset it.
         if ($secret && $entity->isManageEntity() && !$entity->isExcludedFromPushSet()) {
-            unset($metadata['coin:exclude_from_push']);
+            unset($metadata[$fieldName]);
         }
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
@@ -23,7 +23,9 @@ use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\PrivacyQ
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\SpDashboardMetadataGenerator;
 use Surfnet\ServiceProviderDashboard\Application\Parser\OidcngClientIdParser;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Contact;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\EntityDiff;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
+use function sprintf;
 
 /**
  * The OidcngJsonGenerator generates oidc10_rp entity json
@@ -70,11 +72,12 @@ class OidcngJsonGenerator implements GeneratorInterface
 
     public function generateForExistingEntity(
         ManageEntity $entity,
+        EntityDiff $differences,
         string $workflowState,
         string $updatedPart = ''
     ): array {
         return [
-            'pathUpdates' => $this->generateDataForExistingEntity($entity, $workflowState, $updatedPart),
+            'pathUpdates' => $this->generateDataForExistingEntity($entity, $differences, $workflowState, $updatedPart),
             'type' => 'oidc10_rp',
             'id' => $entity->getId(),
         ];
@@ -104,62 +107,31 @@ class OidcngJsonGenerator implements GeneratorInterface
 
     private function generateDataForExistingEntity(
         ManageEntity $entity,
+        EntityDiff $differences,
         string $workflowState,
         string $updatedPart
     ): array {
         $metadata = [
             'entityid' => OidcngClientIdParser::parse($entity->getMetaData()->getEntityId()),
         ];
-
         switch ($updatedPart) {
             case 'ACL':
                 $metadata += $this->generateAclData($entity);
-                break;
+                return $metadata;
 
             default:
+                $metadata += $differences->getDiff();
                 $metadata['arp'] = $this->arpMetadataGenerator->build($entity);
                 $metadata['state'] = $workflowState;
 
                 $metadata += $this->generateAllowedResourceServers($entity);
-                $metadata += $this->flattenMetadataFields(
-                    $this->generateMetadataFields($entity)
-                );
+                $this->setExcludeFromPush($metadata, $entity, true);
+
+                if ($entity->hasComments()) {
+                    $metadata['revisionnote'] = $entity->getComments();
+                }
+                return $metadata;
         }
-
-        if ($entity->hasComments()) {
-            $metadata['revisionnote'] = $entity->getComments();
-        }
-
-        return $metadata;
-    }
-
-    /**
-     * Convert a list fields to a flat array expected by the merge-write API.
-     *
-     * Manage always returns metadata fields like this:
-     *
-     *     [ metaDataFields => [ description:en => ..., description:nl => ..., ...] ]
-     *
-     * But when using the merge-write API, sending a 'metaDataFields' property
-     * will overwrite all existing metadata fields. To prevent this, we only
-     * send the metadata fields we actually want to update by using the flat
-     * format:
-     *
-     *     [ metaDataFields.description:en => ..., metaDataFields.description:nl => ..., ...] ]
-     *
-     *
-     * @param array $fields
-     * @return array
-     */
-    private function flattenMetadataFields(array $fields)
-    {
-        $flatFields = [];
-
-        foreach ($fields as $name => $value) {
-            $flatFields['metaDataFields.'.$name] = $value;
-        }
-
-        return $flatFields;
     }
 
     /**
@@ -374,25 +346,30 @@ class OidcngJsonGenerator implements GeneratorInterface
         ];
     }
 
-    private function setExcludeFromPush(&$metadata, ManageEntity $entity): void
+    private function setExcludeFromPush(&$metadata, ManageEntity $entity, $flatten = false): void
     {
+        $fieldName = 'coin:exclude_from_push';
+        if ($flatten) {
+            $fieldName = sprintf('metaDataFields.coin:exclude_from_push');
+        }
+
         // Scenario 1: When publishing to production, the coin:exclude_from_push must be present and set to '1'.
         // This prevents the entity from being pushed to EngineBlock.
         if ($entity->isProduction()) {
-            $metadata['coin:exclude_from_push'] = '1';
+            $metadata[$fieldName] = '1';
         }
 
         // Scenario 2: When dealing with a client secret reset, keep the current exclude from push state.
         $secret = $entity->getOidcClient()->getClientSecret();
         if ($secret && $entity->isManageEntity() && !$entity->isExcludedFromPush()) {
-            $metadata['coin:exclude_from_push'] = '0';
+            $metadata[$fieldName] = '0';
         }
 
         // Scenario 3: We are resetting the client secret, the service desk removed the exclude from push coin
         // attribute. This also indicates the entity is published. But now we do not want to reset the coin to '0', we
         // simply unset it.
         if ($secret && $entity->isManageEntity() && !$entity->isExcludedFromPushSet()) {
-            unset($metadata['coin:exclude_from_push']);
+            unset($metadata[$fieldName]);
         }
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
@@ -23,7 +23,9 @@ use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\SpDashbo
 use Surfnet\ServiceProviderDashboard\Application\Parser\OidcngClientIdParser;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Contact;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\EntityDiff;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
+use function sprintf;
 
 /**
  * The OidcngResourceServerJsonGenerator generates oauth20-rs resource server entity json
@@ -64,11 +66,12 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
 
     public function generateForExistingEntity(
         ManageEntity $entity,
+        EntityDiff $differences,
         string $workflowState,
         string $updatedPart = ''
     ): array {
         return [
-            'pathUpdates' => $this->generateDataForExistingEntity($entity, $workflowState, $updatedPart),
+            'pathUpdates' => $this->generateDataForExistingEntity($entity, $differences, $workflowState),
             'type' => 'oauth20_rs',
             'active' => true,
             'id' => $entity->getId(),
@@ -94,52 +97,22 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
 
     private function generateDataForExistingEntity(
         ManageEntity $entity,
-        string $workflowState,
-        string $updatedPart
+        EntityDiff $differences,
+        string $workflowState
     ): array {
+
         $metadata = [
             'entityid' => OidcngClientIdParser::parse($entity->getMetaData()->getEntityId()),
             'state' => $workflowState,
         ];
 
-        $metadata += $this->flattenMetadataFields(
-            $this->generateMetadataFields($entity)
-        );
-
+        $metadata += $differences->getDiff();
+        $this->setExcludeFromPush($metadata, $entity, true);
         if ($entity->hasComments()) {
             $metadata['revisionnote'] = $entity->getComments();
         }
 
         return $metadata;
-    }
-
-    /**
-     * Convert a list fields to a flat array expected by the merge-write API.
-     *
-     * Manage always returns metadata fields like this:
-     *
-     *     [ metaDataFields => [ description:en => ..., description:nl => ..., ...] ]
-     *
-     * But when using the merge-write API, sending a 'metaDataFields' property
-     * will overwrite all existing metadata fields. To prevent this, we only
-     * send the metadata fields we actually want to update by using the flat
-     * format:
-     *
-     *     [ metaDataFields.description:en => ..., metaDataFields.description:nl => ..., ...] ]
-     *
-     *
-     * @param array $fields
-     * @return array
-     */
-    private function flattenMetadataFields(array $fields)
-    {
-        $flatFields = [];
-
-        foreach ($fields as $name => $value) {
-            $flatFields['metaDataFields.'.$name] = $value;
-        }
-
-        return $flatFields;
     }
 
     private function generateMetadataFields(ManageEntity $entity): array
@@ -264,25 +237,30 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
         return $metadata;
     }
 
-    private function setExcludeFromPush(&$metadata, ManageEntity $entity): void
+    private function setExcludeFromPush(&$metadata, ManageEntity $entity, $flatten = false): void
     {
+        $fieldName = 'coin:exclude_from_push';
+        if ($flatten) {
+            $fieldName = sprintf('metaDataFields.coin:exclude_from_push');
+        }
+
         // Scenario 1: When publishing to production, the coin:exclude_from_push must be present and set to '1'.
         // This prevents the entity from being pushed to EngineBlock.
         if ($entity->isProduction()) {
-            $metadata['coin:exclude_from_push'] = '1';
+            $metadata[$fieldName] = '1';
         }
 
         // Scenario 2: When dealing with a client secret reset, keep the current exclude from push state.
         $secret = $entity->getOidcClient()->getClientSecret();
         if ($secret && $entity->isManageEntity() && !$entity->isExcludedFromPush()) {
-            $metadata['coin:exclude_from_push'] = '0';
+            $metadata[$fieldName] = '0';
         }
 
         // Scenario 3: We are resetting the client secret, the service desk removed the exclude from push coin
         // attribute. This also indicates the entity is published. But now we do not want to reset the coin to '0', we
         // simply unset it.
         if ($secret && $entity->isManageEntity() && !$entity->isExcludedFromPushSet()) {
-            unset($metadata['coin:exclude_from_push']);
+            unset($metadata[$fieldName]);
         }
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityMergeService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityMergeService.php
@@ -192,13 +192,13 @@ class EntityMergeService
     private function buildContactListFromCommand(SaveEntityCommandInterface $command): ContactList
     {
         $contactList = new ContactList();
-        if ($command->getTechnicalContact()) {
+        if ($command->getTechnicalContact() && $command->getTechnicalContact()->isContactSet()) {
             $contactList->add(Contact::fromContact($command->getTechnicalContact(), 'technical'));
         }
-        if ($command->getAdministrativeContact()) {
+        if ($command->getAdministrativeContact() && $command->getAdministrativeContact()->isContactSet()) {
             $contactList->add(Contact::fromContact($command->getAdministrativeContact(), 'administrative'));
         }
-        if ($command->getSupportContact()) {
+        if ($command->getSupportContact() && $command->getSupportContact()->isContactSet()) {
             $contactList->add(Contact::fromContact($command->getSupportContact(), 'support'));
         }
         return $contactList;

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Comparable.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Comparable.php
@@ -18,17 +18,18 @@
 
 namespace Surfnet\ServiceProviderDashboard\Domain\Entity;
 
-use function array_diff;
-
-class EntityDiff
+interface Comparable
 {
-    public function __construct($data, $compareTo)
-    {
-        $this->diff = array_diff($data, $compareTo);
-    }
-
-    public function getDiff(): array
-    {
-        return $this->diff;
-    }
+    /**
+     * Serialize the entity to an array
+     *
+     * This, for the purpose of comparing two ManageEntities with one another.
+     * Giving us an easy means to compare differences between versions of an
+     * Entity. Which is usefull when writing an update of an Entity back to
+     * Manage.
+     *
+     * Keys should match the keys found in Manage (for easy transfer back to
+     * Manage later down the line).
+     */
+    public function asArray(): array;
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Comparable.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Comparable.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Domain\Entity;
+
+use function array_diff;
+
+class EntityDiff
+{
+    public function __construct($data, $compareTo)
+    {
+        $this->diff = array_diff($data, $compareTo);
+    }
+
+    public function getDiff(): array
+    {
+        return $this->diff;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Coin.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Coin.php
@@ -18,10 +18,11 @@
 
 namespace Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Comparable;
 use Webmozart\Assert\Assert;
 use function is_null;
 
-class Coin
+class Coin implements Comparable
 {
     private $signatureMethod;
     private $serviceTeamId;
@@ -128,5 +129,18 @@ class Coin
         $this->applicationUrl = is_null($coin->getApplicationUrl()) ? null : $coin->getApplicationUrl();
         $this->eula = is_null($coin->getEula()) ? null : $coin->getEula();
         $this->oidcClient = is_null($coin->getOidcClient()) ? null : $coin->getOidcClient();
+    }
+
+    public function asArray(): array
+    {
+        return [
+            'metaDataFields.coin:application_url' => $this->getApplicationUrl(),
+            'metaDataFields.coin:eula' => $this->getEula(),
+            'metaDataFields.coin:exclude_from_push' => $this->getExcludeFromPush(),
+            'metaDataFields.coin:oidc_client' => $this->getOidcClient(),
+            'metaDataFields.coin:original_metadata_url' => $this->getOriginalMetadataUrl(),
+//            'metaDataFields.coin:service_team_id' => $this->getServiceTeamId(),
+//            'metaDataFields.coin:signature_method' => $this->getSignatureMethod(),
+        ];
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Logo.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Logo.php
@@ -73,8 +73,6 @@ class Logo implements Comparable
     public function asArray(): array
     {
         return [
-//            'metaDataFields.logo:0:height' => $this->getHeight(),
-//            'metaDataFields.logo:0:width' => $this->getWidth(),
             'metaDataFields.logo:0:url' => $this->getUrl(),
         ];
     }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Logo.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Logo.php
@@ -18,9 +18,10 @@
 
 namespace Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Comparable;
 use Webmozart\Assert\Assert;
 
-class Logo
+class Logo implements Comparable
 {
     private $url;
     private $width;
@@ -67,5 +68,14 @@ class Logo
         $this->url = is_null($logo->getUrl()) ? null : $logo->getUrl();
         $this->width = is_null($logo->getWidth()) ? null : $logo->getWidth();
         $this->height = is_null($logo->getHeight()) ? null : $logo->getHeight();
+    }
+
+    public function asArray(): array
+    {
+        return [
+//            'metaDataFields.logo:0:height' => $this->getHeight(),
+//            'metaDataFields.logo:0:width' => $this->getWidth(),
+            'metaDataFields.logo:0:url' => $this->getUrl(),
+        ];
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/MetaData.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/MetaData.php
@@ -19,9 +19,10 @@
 namespace Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 
 use Surfnet\ServiceProviderDashboard\Application\Parser\OidcngSpdClientIdParser;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Comparable;
 use Webmozart\Assert\Assert;
 
-class MetaData
+class MetaData implements Comparable
 {
     /**
      * Supports 1 ACS location, the first entry is used that is passed from Manage
@@ -231,5 +232,27 @@ class MetaData
         $this->contacts->merge($metaData->getContacts());
         $this->organization->merge($metaData->getOrganization());
         $this->logo->merge($metaData->getLogo());
+    }
+
+    public function asArray(): array
+    {
+        $data = [
+            'entityid' => $this->getEntityId(),
+            'metadataurl' => $this->getMetaDataUrl(),
+            'metaDataFields.AssertionConsumerService:0:Location' => $this->getAcsLocation(),
+            'metaDataFields.NameIDFormat' => $this->getNameIdFormat(),
+            'metaDataFields.certData' => $this->getCertData(),
+            'metaDataFields.description:nl' => $this->getDescriptionNl(),
+            'metaDataFields.description:en' => $this->getDescriptionEn(),
+            'metaDataFields.name:nl' => $this->getNameNl(),
+            'metaDataFields.name:en' => $this->getNameEn(),
+
+        ];
+        $data += $this->coin->asArray();
+        $data += $this->contacts->asArray();
+        $data += $this->logo->asArray();
+        $data += $this->organization->asArray();
+
+        return $data;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OauthClientCredentialsClientClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OauthClientCredentialsClientClient.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Comparable;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\SecretInterface;
@@ -26,7 +27,7 @@ use function array_filter;
 use function array_merge;
 use function is_null;
 
-class OauthClientCredentialsClientClient implements OidcClientInterface
+class OauthClientCredentialsClientClient implements Comparable, OidcClientInterface
 {
     /**
      * @var string
@@ -163,5 +164,14 @@ class OauthClientCredentialsClientClient implements OidcClientInterface
         // The combination of the manage specific entityIds and the ones configured on the form is the
         // desired combination.
         $this->resourceServers = array_merge($clientResourceServers, $manageRsEntityIds);
+    }
+
+    public function asArray(): array
+    {
+        return [
+            'metaDataFields.accessTokenValidity' => $this->getAccessTokenValidity(),
+            'metaDataFields.secret' => $this->getClientSecret(),
+            'entityid' => $this->getClientId(),
+        ];
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcClientInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcClientInterface.php
@@ -63,4 +63,6 @@ interface OidcClientInterface
      * outside of the team the entity is associated with.
      */
     public function merge(OidcClientInterface $client, string $homeTeam): void;
+
+    public function asArray();
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcngClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcngClient.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Comparable;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\SecretInterface;
@@ -28,7 +29,7 @@ use function array_merge;
 use function is_null;
 use function strtolower;
 
-class OidcngClient implements OidcClientInterface
+class OidcngClient implements Comparable, OidcClientInterface
 {
     const FORM_MANAGED_GRANTS = [
         'entity.edit.label.authorization_code' => Constants::GRANT_TYPE_AUTHORIZATION_CODE,
@@ -229,6 +230,18 @@ class OidcngClient implements OidcClientInterface
         $this->accessTokenValidity = is_null($client->getAccessTokenValidity()) ? null : $client->getAccessTokenValidity();
         $this->mergeGrants($client->getGrants());
         $this->mergeResourceServers($client->getResourceServers(), $homeTeam);
+    }
+
+    public function asArray(): array
+    {
+        return [
+            'metaDataFields.accessTokenValidity' => $this->getAccessTokenValidity(),
+            'metaDataFields.grants' => $this->getGrants(),
+            'metaDataFields.isPublicClient' => $this->isPublicClient(),
+            'metaDataFields.redirectUrls' => $this->getRedirectUris(),
+            'metaDataFields.secret' => $this->getClientSecret(),
+            'entityid' => $this->getClientId(),
+        ];
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcngResourceServerClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/OidcngResourceServerClient.php
@@ -18,11 +18,12 @@
 
 namespace Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Comparable;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\SecretInterface;
 use Webmozart\Assert\Assert;
 use function is_null;
 
-class OidcngResourceServerClient implements OidcClientInterface
+class OidcngResourceServerClient implements Comparable, OidcClientInterface
 {
     /**
      * @var string
@@ -133,5 +134,14 @@ class OidcngResourceServerClient implements OidcClientInterface
         $this->clientId = is_null($client->getClientId()) ? null : $client->getClientId();
         $this->clientSecret = is_null($client->getClientSecret()) ? null : $client->getClientSecret();
         $this->grants = is_null($client->getGrants()) ? null : $client->getGrants();
+    }
+
+    public function asArray(): array
+    {
+        return [
+            'metaDataFields.grants' => $this->getGrants(),
+            'metaDataFields.secret' => $this->getClientSecret(),
+            'entityid' => $this->getClientId(),
+        ];
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Organization.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Organization.php
@@ -18,9 +18,10 @@
 
 namespace Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Comparable;
 use Webmozart\Assert\Assert;
 
-class Organization
+class Organization implements Comparable
 {
     private $nameEn;
     private $displayNameEn;
@@ -114,5 +115,17 @@ class Organization
     public function updateNameNl($nameNl)
     {
         $this->nameNl = $nameNl;
+    }
+
+    public function asArray(): array
+    {
+        return [
+            'metaDataFields.OrganizationURL:nl' => $this->getUrlNl(),
+            'metaDataFields.OrganizationURL:en' => $this->getUrlEn(),
+            'metaDataFields.OrganizationName:nl' => $this->getNameNl(),
+            'metaDataFields.OrganizationName:en' => $this->getNameEn(),
+            'metaDataFields.OrganizationDisplayName:nl' => $this->getDisplayNameNl(),
+            'metaDataFields.OrganizationDisplayName:en' => $this->getDisplayNameEn(),
+        ];
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Protocol.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Protocol.php
@@ -18,10 +18,11 @@
 
 namespace Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Comparable;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Webmozart\Assert\Assert;
 
-class Protocol
+class Protocol implements Comparable
 {
     const SAML20_SP = 'saml20_sp';
 
@@ -68,5 +69,12 @@ class Protocol
     public function merge(Protocol $protocol)
     {
         $this->protocol = is_null($protocol->getProtocol()) ? null : $protocol->getProtocol();
+    }
+
+    public function asArray(): array
+    {
+        return [
+            'type' => $this->getProtocol(),
+        ];
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/EntityDiff.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/EntityDiff.php
@@ -1,0 +1,339 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Domain\Entity;
+
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\AllowedIdentityProviders;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\AttributeList;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\MetaData;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\OauthClientCredentialsClientClient;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\OidcClientInterface;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\OidcngClient;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\OidcngResourceServerClient;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Protocol;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\SecretInterface;
+use function in_array;
+
+/**
+ * TODO: All factory logic should be offloaded to Application or Infra layers where the
+ * entity is used in a specific context. This particularly applies for the factory
+ * methods found in the 'Entity/Entity' namespace.
+ */
+class ManageEntity
+{
+    private $id;
+
+    /**
+     * @var string
+     */
+    private $status;
+
+    /**
+     * @var AttributeList
+     */
+    private $attributes;
+
+    /**
+     * @var MetaData
+     */
+    private $metaData;
+
+    /**
+     * @var OidcClientInterface
+     */
+    private $oidcClient;
+
+    /**
+     * @var Protocol
+     */
+    private $protocol;
+
+    /**
+     * @var AllowedIdentityProviders
+     */
+    private $allowedIdentityProviders;
+    
+    private $comments;
+
+    private $environment;
+
+    /**
+     * @var Service
+     */
+    private $service;
+    /**
+     * @var bool
+     */
+    private $readOnly = false;
+
+    /**
+     * @param $data
+     * @return ManageEntity
+     *
+     * @SuppressWarnings(PHPMD.ElseExpression)
+     */
+    public static function fromApiResponse($data)
+    {
+        $manageProtocol = self::extractManageProtocol($data);
+
+        $attributeList = AttributeList::fromApiResponse($data);
+        $metaData = MetaData::fromApiResponse($data);
+        $oidcClient = null;
+
+        switch ($manageProtocol) {
+            case Protocol::OAUTH20_RS:
+                $oidcClient = OidcngResourceServerClient::fromApiResponse($data);
+                break;
+            case Protocol::OIDC10_RP:
+                $oidcClient = OidcngClient::fromApiResponse($data);
+                break;
+            case Constants::TYPE_OAUTH_CLIENT_CREDENTIAL_CLIENT:
+                $oidcClient = OauthClientCredentialsClientClient::fromApiResponse($data);
+                break;
+        }
+
+        $allowedEdentityProviders = AllowedIdentityProviders::fromApiResponse($data);
+        $protocol = Protocol::fromApiResponse($manageProtocol);
+
+        return new self($data['id'], $attributeList, $metaData, $allowedEdentityProviders, $protocol, $oidcClient);
+    }
+
+    public function __construct(
+        ?string $id,
+        AttributeList $attributes,
+        MetaData $metaData,
+        AllowedIdentityProviders $allowedIdentityProviders,
+        Protocol $protocol,
+        ?OidcClientInterface $oidcClient = null,
+        ?Service $service = null
+    ) {
+        $this->id = $id;
+        $this->status = Constants::STATE_PUBLISHED;
+        $this->attributes = $attributes;
+        $this->metaData = $metaData;
+        $this->oidcClient = $oidcClient;
+        $this->protocol = $protocol;
+        $this->allowedIdentityProviders = $allowedIdentityProviders;
+        $this->service = $service;
+    }
+
+    private static function extractManageProtocol(array $data): string
+    {
+        $manageProtocol = $data['type'] ?? '';
+        $grantTypes = $data['data']['metaDataFields']['grants'] ?? [];
+        // No dedicated Manage protocol / entity type is defined yet for oauth client credential entities
+        $isClientCredentialsClient = in_array(Constants::GRANT_TYPE_CLIENT_CREDENTIALS, $grantTypes)
+            && count($grantTypes) === 1;
+        return $isClientCredentialsClient ? Constants::TYPE_OAUTH_CLIENT_CREDENTIAL_CLIENT : $manageProtocol;
+    }
+
+    public function resetId()
+    {
+        $clone = clone $this;
+        $clone->id = null;
+        return $clone;
+    }
+
+    public function setId(string $id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    public function getMetaData(): ?MetaData
+    {
+        return $this->metaData;
+    }
+
+    public function updateStatus($newStatus)
+    {
+        $this->status = $newStatus;
+    }
+
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    public function isPublished()
+    {
+        return ($this->status === Constants::STATE_PUBLISHED);
+    }
+
+    /**
+     * @return OidcClientInterface|null
+     */
+    public function getOidcClient()
+    {
+        return $this->oidcClient;
+    }
+
+    /**
+     * @return AllowedIdentityProviders
+     */
+    public function getAllowedIdentityProviders()
+    {
+        return $this->allowedIdentityProviders;
+    }
+
+    /**
+     * @return Protocol
+     */
+    public function getProtocol()
+    {
+        return $this->protocol;
+    }
+
+    public function isOidcngResourceServer()
+    {
+        if ($this->getOidcClient()) {
+            return $this->getOidcClient() instanceof OidcngResourceServerClient;
+        }
+
+        return false;
+    }
+
+    public function isExcludedFromPushSet()
+    {
+        if (is_null($this->getMetaData()->getCoin()->getExcludeFromPush())) {
+            return false;
+        }
+        return true;
+    }
+
+    public function isExcludedFromPush()
+    {
+        if (is_null($this->getMetaData()->getCoin()->getExcludeFromPush())) {
+            return false;
+        }
+        return $this->getMetaData()->getCoin()->getExcludeFromPush() == 1 ? true : false;
+    }
+
+    public function isManageEntity(): bool
+    {
+        return !is_null($this->getId());
+    }
+
+    public function setComments(?string $comments): void
+    {
+        $this->comments = $comments;
+    }
+
+    /**
+     * @return string
+     */
+    public function getComments(): ?string
+    {
+        return $this->comments;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasComments(): bool
+    {
+        return !(empty($this->comments));
+    }
+
+    public function setEnvironment(string $environment): void
+    {
+        $this->environment = $environment;
+    }
+
+    public function getEnvironment(): ?string
+    {
+        return $this->environment;
+    }
+
+    public function isProduction()
+    {
+        return $this->getEnvironment() === Constants::ENVIRONMENT_PRODUCTION;
+    }
+
+    public function setIsReadOnly()
+    {
+        $this->readOnly = true;
+    }
+
+    public function isReadOnly(): bool
+    {
+        // Entities from outside the current team can be read only (can happen in RP -> RS connections created in Manage)
+        return $this->readOnly;
+    }
+
+    public function getService(): Service
+    {
+        return $this->service;
+    }
+
+    public function setService(Service $service)
+    {
+        $this->service = $service;
+    }
+
+    /**
+     * Merge new data into an existing ManageEntity.
+     * @param ManageEntity $newEntity
+     */
+    public function merge(ManageEntity $newEntity)
+    {
+        $this->service = is_null($newEntity->getService()) ? null : $newEntity->getService();
+        $this->metaData->merge($newEntity->getMetaData());
+        $this->attributes->merge($newEntity->getAttributes());
+        if ($this->hasOicdClient()) {
+            $this->oidcClient->merge($newEntity->getOidcClient(), $this->getService()->getTeamName());
+        }
+        $this->comments = $newEntity->getComments();
+    }
+
+    public function setStatus(string $status)
+    {
+        $this->status = $status;
+    }
+
+    public function updateClientSecret(SecretInterface $secret)
+    {
+        $this->getOidcClient()->updateClientSecret($secret);
+    }
+
+    private function hasOicdClient()
+    {
+        $protocol = $this->protocol->getProtocol();
+        return $protocol === Constants::TYPE_OPENID_CONNECT_TNG
+            || $protocol === Constants::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER
+            || $protocol === Constants::TYPE_OAUTH_CLIENT_CREDENTIAL_CLIENT;
+    }
+
+    /**
+     *
+     */
+    public function diff(ManageEntity $compareTo): EntityDiff
+    {
+        $diff = new EntityDiff;
+        $this->metaData->diff($diff, $compareTo);
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/EntityDiff.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/EntityDiff.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2018 SURFnet B.V.
+ * Copyright 2022 SURFnet B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,322 +18,66 @@
 
 namespace Surfnet\ServiceProviderDashboard\Domain\Entity;
 
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\AllowedIdentityProviders;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\AttributeList;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\MetaData;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\OauthClientCredentialsClientClient;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\OidcClientInterface;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\OidcngClient;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\OidcngResourceServerClient;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Protocol;
-use Surfnet\ServiceProviderDashboard\Domain\ValueObject\SecretInterface;
-use function in_array;
-
-/**
- * TODO: All factory logic should be offloaded to Application or Infra layers where the
- * entity is used in a specific context. This particularly applies for the factory
- * methods found in the 'Entity/Entity' namespace.
- */
-class ManageEntity
+class EntityDiff
 {
-    private $id;
+    private $diff;
+
+    public function __construct($data, $compareTo)
+    {
+        $this->diff = $this->arrayRecursiveDiff($data, $compareTo);
+    }
+
+    public function getDiff(): array
+    {
+        return $this->diff;
+    }
 
     /**
-     * @var string
-     */
-    private $status;
-
-    /**
-     * @var AttributeList
-     */
-    private $attributes;
-
-    /**
-     * @var MetaData
-     */
-    private $metaData;
-
-    /**
-     * @var OidcClientInterface
-     */
-    private $oidcClient;
-
-    /**
-     * @var Protocol
-     */
-    private $protocol;
-
-    /**
-     * @var AllowedIdentityProviders
-     */
-    private $allowedIdentityProviders;
-    
-    private $comments;
-
-    private $environment;
-
-    /**
-     * @var Service
-     */
-    private $service;
-    /**
-     * @var bool
-     */
-    private $readOnly = false;
-
-    /**
-     * @param $data
-     * @return ManageEntity
+     * Recursive diff algorithm.
+     * Kindly shared by mhitza
+     * See https://stackoverflow.com/questions/3876435/recursive-array-diff
      *
      * @SuppressWarnings(PHPMD.ElseExpression)
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
-    public static function fromApiResponse($data)
+    private function arrayRecursiveDiff(array $data, array $originalData): array
     {
-        $manageProtocol = self::extractManageProtocol($data);
+        $diffResults = [];
+        foreach ($data as $key => $value) {
+            if (array_key_exists($key, $originalData)) {
+                if (is_array($value)) {
+                    $recursiveDiff = $this->arrayRecursiveDiff($value, $originalData[$key]);
+                    // Redirect urls should not be diffed, the complete list should be provided
+                    // Grants should not be diffed, the complete list should be provided
+                    if ($key === 'metaDataFields.redirectUrls' || $key === 'metaDataFields.grants') {
+                        $recursiveDiff = $value;
+                    }
 
-        $attributeList = AttributeList::fromApiResponse($data);
-        $metaData = MetaData::fromApiResponse($data);
-        $oidcClient = null;
-
-        switch ($manageProtocol) {
-            case Protocol::OAUTH20_RS:
-                $oidcClient = OidcngResourceServerClient::fromApiResponse($data);
-                break;
-            case Protocol::OIDC10_RP:
-                $oidcClient = OidcngClient::fromApiResponse($data);
-                break;
-            case Constants::TYPE_OAUTH_CLIENT_CREDENTIAL_CLIENT:
-                $oidcClient = OauthClientCredentialsClientClient::fromApiResponse($data);
-                break;
+                    if (count($recursiveDiff)) {
+                        $diffResults[$key] = $recursiveDiff;
+                    }
+                } else {
+                    if ($value != $originalData[$key]) {
+                        // When a secret is not changed (resulting in an empty value) do not include it in the diff.
+                        if ($key === 'metaDataFields.secret' && $value === '') {
+                            continue;
+                        }
+                        $diffResults[$key] = $value;
+                    }
+                }
+            } else {
+                $diffResults[$key] = $value;
+            }
         }
 
-        $allowedEdentityProviders = AllowedIdentityProviders::fromApiResponse($data);
-        $protocol = Protocol::fromApiResponse($manageProtocol);
-
-        return new self($data['id'], $attributeList, $metaData, $allowedEdentityProviders, $protocol, $oidcClient);
-    }
-
-    public function __construct(
-        ?string $id,
-        AttributeList $attributes,
-        MetaData $metaData,
-        AllowedIdentityProviders $allowedIdentityProviders,
-        Protocol $protocol,
-        ?OidcClientInterface $oidcClient = null,
-        ?Service $service = null
-    ) {
-        $this->id = $id;
-        $this->status = Constants::STATE_PUBLISHED;
-        $this->attributes = $attributes;
-        $this->metaData = $metaData;
-        $this->oidcClient = $oidcClient;
-        $this->protocol = $protocol;
-        $this->allowedIdentityProviders = $allowedIdentityProviders;
-        $this->service = $service;
-    }
-
-    private static function extractManageProtocol(array $data): string
-    {
-        $manageProtocol = $data['type'] ?? '';
-        $grantTypes = $data['data']['metaDataFields']['grants'] ?? [];
-        // No dedicated Manage protocol / entity type is defined yet for oauth client credential entities
-        $isClientCredentialsClient = in_array(Constants::GRANT_TYPE_CLIENT_CREDENTIALS, $grantTypes)
-            && count($grantTypes) === 1;
-        return $isClientCredentialsClient ? Constants::TYPE_OAUTH_CLIENT_CREDENTIAL_CLIENT : $manageProtocol;
-    }
-
-    public function resetId()
-    {
-        $clone = clone $this;
-        $clone->id = null;
-        return $clone;
-    }
-
-    public function setId(string $id)
-    {
-        $this->id = $id;
-    }
-
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    public function getAttributes()
-    {
-        return $this->attributes;
-    }
-
-    public function getMetaData(): ?MetaData
-    {
-        return $this->metaData;
-    }
-
-    public function updateStatus($newStatus)
-    {
-        $this->status = $newStatus;
-    }
-
-    public function getStatus()
-    {
-        return $this->status;
-    }
-
-    public function isPublished()
-    {
-        return ($this->status === Constants::STATE_PUBLISHED);
-    }
-
-    /**
-     * @return OidcClientInterface|null
-     */
-    public function getOidcClient()
-    {
-        return $this->oidcClient;
-    }
-
-    /**
-     * @return AllowedIdentityProviders
-     */
-    public function getAllowedIdentityProviders()
-    {
-        return $this->allowedIdentityProviders;
-    }
-
-    /**
-     * @return Protocol
-     */
-    public function getProtocol()
-    {
-        return $this->protocol;
-    }
-
-    public function isOidcngResourceServer()
-    {
-        if ($this->getOidcClient()) {
-            return $this->getOidcClient() instanceof OidcngResourceServerClient;
+        // Before returning the diff. Test if the source array contains keys not present in the new data. That way
+        // we can also mark removed metadata items correctly.
+        foreach ($originalData as $key => $value) {
+            if (!array_key_exists($key, $data)) {
+                $diffResults[$key] = null;
+            }
         }
 
-        return false;
-    }
-
-    public function isExcludedFromPushSet()
-    {
-        if (is_null($this->getMetaData()->getCoin()->getExcludeFromPush())) {
-            return false;
-        }
-        return true;
-    }
-
-    public function isExcludedFromPush()
-    {
-        if (is_null($this->getMetaData()->getCoin()->getExcludeFromPush())) {
-            return false;
-        }
-        return $this->getMetaData()->getCoin()->getExcludeFromPush() == 1 ? true : false;
-    }
-
-    public function isManageEntity(): bool
-    {
-        return !is_null($this->getId());
-    }
-
-    public function setComments(?string $comments): void
-    {
-        $this->comments = $comments;
-    }
-
-    /**
-     * @return string
-     */
-    public function getComments(): ?string
-    {
-        return $this->comments;
-    }
-
-    /**
-     * @return bool
-     */
-    public function hasComments(): bool
-    {
-        return !(empty($this->comments));
-    }
-
-    public function setEnvironment(string $environment): void
-    {
-        $this->environment = $environment;
-    }
-
-    public function getEnvironment(): ?string
-    {
-        return $this->environment;
-    }
-
-    public function isProduction()
-    {
-        return $this->getEnvironment() === Constants::ENVIRONMENT_PRODUCTION;
-    }
-
-    public function setIsReadOnly()
-    {
-        $this->readOnly = true;
-    }
-
-    public function isReadOnly(): bool
-    {
-        // Entities from outside the current team can be read only (can happen in RP -> RS connections created in Manage)
-        return $this->readOnly;
-    }
-
-    public function getService(): Service
-    {
-        return $this->service;
-    }
-
-    public function setService(Service $service)
-    {
-        $this->service = $service;
-    }
-
-    /**
-     * Merge new data into an existing ManageEntity.
-     * @param ManageEntity $newEntity
-     */
-    public function merge(ManageEntity $newEntity)
-    {
-        $this->service = is_null($newEntity->getService()) ? null : $newEntity->getService();
-        $this->metaData->merge($newEntity->getMetaData());
-        $this->attributes->merge($newEntity->getAttributes());
-        if ($this->hasOicdClient()) {
-            $this->oidcClient->merge($newEntity->getOidcClient(), $this->getService()->getTeamName());
-        }
-        $this->comments = $newEntity->getComments();
-    }
-
-    public function setStatus(string $status)
-    {
-        $this->status = $status;
-    }
-
-    public function updateClientSecret(SecretInterface $secret)
-    {
-        $this->getOidcClient()->updateClientSecret($secret);
-    }
-
-    private function hasOicdClient()
-    {
-        $protocol = $this->protocol->getProtocol();
-        return $protocol === Constants::TYPE_OPENID_CONNECT_TNG
-            || $protocol === Constants::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER
-            || $protocol === Constants::TYPE_OAUTH_CLIENT_CREDENTIAL_CLIENT;
-    }
-
-    /**
-     *
-     */
-    public function diff(ManageEntity $compareTo): EntityDiff
-    {
-        $diff = new EntityDiff;
-        $this->metaData->diff($diff, $compareTo);
+        return $diffResults;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/ManageEntity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/ManageEntity.php
@@ -33,6 +33,7 @@ use function in_array;
  * TODO: All factory logic should be offloaded to Application or Infra layers where the
  * entity is used in a specific context. This particularly applies for the factory
  * methods found in the 'Entity/Entity' namespace.
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class ManageEntity
 {
@@ -326,5 +327,26 @@ class ManageEntity
         return $protocol === Constants::TYPE_OPENID_CONNECT_TNG
             || $protocol === Constants::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER
             || $protocol === Constants::TYPE_OAUTH_CLIENT_CREDENTIAL_CLIENT;
+    }
+
+    public function diff(ManageEntity $compareTo): EntityDiff
+    {
+        $data = $this->asArray();
+        $otherData = $compareTo->asArray();
+        return new EntityDiff($otherData, $data);
+    }
+
+    public function asArray(): array
+    {
+        $data = [];
+        $data['id'] = $this->id;
+        $data['revisionnote'] = $this->getComments();
+        $data['environment'] = $this->environment;
+        $data = $this->metaData->asArray();
+        if ($this->hasOicdClient()) {
+            $data += $this->oidcClient->asArray();
+        }
+        $data += $this->protocol->asArray();
+        return $data;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Repository/PublishEntityRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Repository/PublishEntityRepository.php
@@ -28,7 +28,7 @@ interface PublishEntityRepository
      *
      * @return mixed
      */
-    public function publish(ManageEntity $entity, string $part = '');
+    public function publish(ManageEntity $entity, ?ManageEntity $pristineEntity, string $part = '');
 
     /**
      * Push the metadata from Manage to Engineblock

--- a/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Contact.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Contact.php
@@ -157,12 +157,15 @@ class Contact
         return $result;
     }
 
-    public function isContactSet()
+    /**
+     * Tests if any of the attributes of the contact are set
+     *
+     * If one of the fields is filled this method will return `true`, if none are initialized `false` is returned.
+     *
+     * As a suggestion for future improvement: create a NullContact VO that is instantiated instead of an empty Contact.
+     */
+    public function isContactSet(): bool
     {
-        if (empty($this->firstName) && empty($this->lastName) && empty($this->email) && empty($this->phone)) {
-            return false;
-        }
-
-        return true;
+        return !(empty($this->firstName) && empty($this->lastName) && empty($this->email) && empty($this->phone));
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -85,7 +85,6 @@ services:
         class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\PublishEntityTestCommandHandler
         arguments:
             $publishClient: '@Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\PublishEntityClient'
-
         tags:
             - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityTestCommand }
 
@@ -93,6 +92,7 @@ services:
         class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\PublishEntityProductionCommandHandler
         arguments:
             - '@surfnet.manage.client.publish_client.prod_environment'
+            - '@Surfnet\ServiceProviderDashboard\Application\Service\EntityService'
             - '@Surfnet\ServiceProviderDashboard\Application\Service\TicketService'
             - '@session.flash_bag'
             - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Factory\MailMessageFactory'

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php
@@ -68,10 +68,10 @@ class PublishEntityClient implements PublishEntityRepositoryInterface
      *
      * @SuppressWarnings(PHPMD.ElseExpression)
      */
-    public function publish(ManageEntity $entity, string $updatedPart = '')
+    public function publish(ManageEntity $entity, ?ManageEntity $pristineEntity, string $updatedPart = '')
     {
         try {
-            if (empty($entity->getId())) {
+            if (!$entity->isManageEntity()) {
                 $this->logger->info(sprintf('Creating new entity \'%s\' in manage', $entity->getId()));
 
                 $response = $this->client->post(
@@ -82,9 +82,12 @@ class PublishEntityClient implements PublishEntityRepositoryInterface
                     '/manage/api/internal/metadata'
                 );
             } else {
+                $diff = $pristineEntity->diff($entity);
                 $this->logger->info(sprintf('Updating existing \'%s\' entity in manage', $entity->getId()));
+
                 $data = json_encode($this->generator->generateForExistingEntity(
                     $entity,
+                    $diff,
                     $this->manageConfig->getPublicationStatus()->getStatus(),
                     $updatedPart
                 ));

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Factory/SaveCommandFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Factory/SaveCommandFactory.php
@@ -208,6 +208,8 @@ class SaveCommandFactory implements SaveCommandFactoryInterface
         $command->setDescriptionEn($metaData->getDescriptionEn());
 
         $command->setAccessTokenValidity($manageEntity->getOidcClient()->getAccessTokenValidity());
+        $command->setOidcngResourceServers($manageEntity->getOidcClient()->getResourceServers());
+
         $resourceServers = $command->getOidcngResourceServers();
         if (is_array($resourceServers) && reset($resourceServers) instanceof ManageEntity) {
             $resourceServers = $command->getOidcngResourceServers();

--- a/tests/integration/Application/CommandHandler/Entity/PublishEntityProductionCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/PublishEntityProductionCommandHandlerTest.php
@@ -26,6 +26,8 @@ use Mockery\Mock;
 use Psr\Log\LoggerInterface;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityProductionCommand;
 use Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\PublishEntityProductionCommandHandler;
+use Surfnet\ServiceProviderDashboard\Application\Service\EntityService;
+use Surfnet\ServiceProviderDashboard\Application\Service\EntityServiceInterface;
 use Surfnet\ServiceProviderDashboard\Application\Service\TicketService;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
@@ -76,9 +78,15 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
      */
     private $mailFactory;
 
+    /**
+     * @var EntityServiceInterface|Mock
+     */
+    private $entityService;
+
     public function setUp()
     {
         $this->publishEntityClient = m::mock(PublishEntityRepository::class);
+        $this->entityService = m::mock(EntityServiceInterface::class);
         $this->ticketService = m::mock(TicketService::class);
         $this->flashBag = m::mock(FlashBagInterface::class);
         $this->logger = m::mock(LoggerInterface::class);
@@ -88,6 +96,7 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
 
         $this->commandHandler = new PublishEntityProductionCommandHandler(
             $this->publishEntityClient,
+            $this->entityService,
             $this->ticketService,
             $this->flashBag,
             $this->mailFactory,
@@ -111,11 +120,13 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
         $manageEntity
             ->shouldReceive('getMetaData->getNameEn')
             ->andReturn('Test Entity Name');
+        $manageEntity->shouldReceive('isManageEntity')->andReturnTrue();
+        $manageEntity->shouldReceive('getEnvironment')->andReturn('production');
 
         $this->publishEntityClient
             ->shouldReceive('publish')
             ->once()
-            ->with($manageEntity)
+            ->with($manageEntity, $manageEntity)
             ->andReturn([
                 'id' => '123',
             ]);
@@ -153,6 +164,7 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
         $this->logger
             ->shouldReceive('info')
             ->times(4);
+        $this->entityService->shouldReceive('getManageEntityById')->andReturn($manageEntity);
 
         $applicant = new Contact('john:doe', 'john@example.com', 'John Doe');
         $command = new PublishEntityProductionCommand($manageEntity, $applicant);
@@ -179,7 +191,7 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
         $this->publishEntityClient
             ->shouldReceive('publish')
             ->once()
-            ->with($manageEntity)
+            ->with($manageEntity, $manageEntity)
             ->andReturn([
                 'id' => '123',
             ]);
@@ -191,6 +203,8 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
         $manageEntity
             ->shouldReceive('getId')
             ->andReturn('123');
+        $manageEntity->shouldReceive('isManageEntity')->andReturnTrue();
+        $manageEntity->shouldReceive('getEnvironment')->andReturn('production');
 
         $manageEntity
             ->shouldReceive('setStatus')
@@ -217,6 +231,7 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
         $this->logger
             ->shouldReceive('info')
             ->times(4);
+        $this->entityService->shouldReceive('getManageEntityById')->andReturn($manageEntity);
 
 
         $applicant = new Contact('john:doe', 'john@example.com', 'John Doe');
@@ -244,6 +259,8 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
         $manageEntity
             ->shouldReceive('getId')
             ->andReturn('123');
+        $manageEntity->shouldReceive('isManageEntity')->andReturnTrue();
+        $manageEntity->shouldReceive('getEnvironment')->andReturn('production');
 
         $manageEntity
             ->shouldReceive('setStatus')
@@ -279,6 +296,7 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
         $this->flashBag
             ->shouldReceive('add')
             ->with('error', 'entity.edit.error.publish');
+        $this->entityService->shouldReceive('getManageEntityById')->andReturn($manageEntity);
 
         $applicant = new Contact('john:doe', 'john@example.com', 'John Doe');
 

--- a/tests/unit/Application/Metadata/JsonGeneratorStrategyTest.php
+++ b/tests/unit/Application/Metadata/JsonGeneratorStrategyTest.php
@@ -25,6 +25,7 @@ use Surfnet\ServiceProviderDashboard\Application\Dto\MetadataConversionDto;
 use Surfnet\ServiceProviderDashboard\Application\Exception\JsonGeneratorStrategyNotFoundException;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\GeneratorInterface;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGeneratorStrategy;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\EntityDiff;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 
 class JsonGeneratorStrategyTest extends MockeryTestCase
@@ -82,10 +83,11 @@ class JsonGeneratorStrategyTest extends MockeryTestCase
         $entity = m::mock(ManageEntity::class);
 
         $entity->shouldReceive('getProtocol->getProtocol')->andReturn('saml');
-        $this->strategy->generateForExistingEntity($entity, 'prodaccepted');
+        $diff = m::mock(EntityDiff::class);
+        $this->strategy->generateForExistingEntity($entity, $diff, 'prodaccepted');
 
         $entity->shouldReceive('getProtocol->getProtocol')->andReturn('oidcng');
-        $this->strategy->generateForExistingEntity($entity, 'prodaccepted');
+        $this->strategy->generateForExistingEntity($entity, $diff, 'prodaccepted');
     }
 
     public function test_add_invalid_strategy()
@@ -96,6 +98,7 @@ class JsonGeneratorStrategyTest extends MockeryTestCase
 
         $this->expectException(JsonGeneratorStrategyNotFoundException::class);
         $this->expectExceptionMessage('The requested JsonGenerator for protocol "saml30" is not registered');
-        $this->strategy->generateForExistingEntity($entity, 'prodaccepted');
+        $diff = m::mock(EntityDiff::class);
+        $this->strategy->generateForExistingEntity($entity, $diff, 'prodaccepted');
     }
 }

--- a/tests/unit/Application/Metadata/JsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/JsonGeneratorTest.php
@@ -25,6 +25,7 @@ use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\ArpGener
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\PrivacyQuestionsMetadataGenerator;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\SpDashboardMetadataGenerator;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\EntityDiff;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use function file_get_contents;
@@ -122,8 +123,11 @@ class JsonGeneratorTest extends MockeryTestCase
             $this->spDashboardMetadataGenerator
         );
 
+        $entity = $this->createManageEntity();
+        $changedEntity = $this->createChangedManageEntity();
+        $diff = $entity->diff($changedEntity);
 
-        $metadata = $generator->generateForExistingEntity($this->createManageEntity(), 'testaccepted');
+        $metadata = $generator->generateForExistingEntity($entity, $diff, 'testaccepted');
         $metadata = $metadata['pathUpdates'];
 
         $this->assertArrayNotHasKey('active', $metadata);
@@ -134,26 +138,10 @@ class JsonGeneratorTest extends MockeryTestCase
         $this->assertEquals('revisionnote', $metadata['revisionnote']);
         $this->assertEquals(['arp' => 'arp'], $metadata['arp']);
 
-        $this->assertEquals('http://www.w3.org/2001/04/xmldsig-more#rsa-sha256', $metadata['metaDataFields.coin:signature_method']);
-        $this->assertEquals('privacy', $metadata['metaDataFields.privacy']);
-        $this->assertEquals('sp', $metadata['metaDataFields.sp']);
-        $this->assertEquals('http://acs', $metadata['metaDataFields.AssertionConsumerService:0:Location']);
-        $this->assertEquals(Constants::BINDING_HTTP_POST, $metadata['metaDataFields.AssertionConsumerService:0:Binding']);
-        $this->assertEquals('nameidformat', $metadata['metaDataFields.NameIDFormat']);
-        $this->assertEquals('name en', $metadata['metaDataFields.name:en']);
-        $this->assertEquals('name nl', $metadata['metaDataFields.name:nl']);
-        $this->assertEquals('description en', $metadata['metaDataFields.description:en']);
-        $this->assertEquals('description nl', $metadata['metaDataFields.description:nl']);
-        $this->assertEquals('certdata', $metadata['metaDataFields.certData']);
 
-        $this->assertEquals('orgen', $metadata['metaDataFields.OrganizationName:en']);
-        $this->assertEquals('orgnl', $metadata['metaDataFields.OrganizationName:nl']);
-
-        $this->assertEquals('support', $metadata['metaDataFields.contacts:0:contactType']);
-        $this->assertEquals('givenname', $metadata['metaDataFields.contacts:0:givenName']);
-        $this->assertEquals('surname', $metadata['metaDataFields.contacts:0:surName']);
-        $this->assertEquals('emailaddress', $metadata['metaDataFields.contacts:0:emailAddress']);
-        $this->assertEquals('telephonenumber', $metadata['metaDataFields.contacts:0:telephoneNumber']);
+        $this->assertEquals('Test Entity EN', $metadata['metaDataFields.name:en']);
+        $this->assertEquals('Test Entity NL', $metadata['metaDataFields.name:nl']);
+        $this->assertEquals('John Doe', $metadata['metaDataFields.contacts:2:givenName']);
     }
 
     public function test_it_can_build_saml_entity_data_for_new_entities()
@@ -220,39 +208,23 @@ class JsonGeneratorTest extends MockeryTestCase
             $this->spDashboardMetadataGenerator
         );
 
-        $data = $generator->generateForExistingEntity($this->createManageEntity(), 'testaccepted');
+        $entity = $this->createManageEntity();
+        $changedEntity = $this->createChangedManageEntity();
+        $diff = $entity->diff($changedEntity);
+
+        $data = $generator->generateForExistingEntity($entity, $diff, 'testaccepted');
 
         $this->assertEquals(array (
             'pathUpdates' =>
                 array (
-                    'arp' =>
-                        array (
-                            'arp' => 'arp',
-                        ),
+                    'arp' => array ('arp' => 'arp'),
                     'entityid' => 'http://entityid',
                     'metadataurl' => 'http://metadata',
-                    'metaDataFields.description:en' => 'description en',
-                    'metaDataFields.description:nl' => 'description nl',
-                    'metaDataFields.name:en' => 'name en',
-                    'metaDataFields.name:nl' => 'name nl',
-                    'metaDataFields.contacts:0:contactType' => 'support',
-                    'metaDataFields.contacts:0:givenName' => 'givenname',
-                    'metaDataFields.contacts:0:surName' => 'surname',
-                    'metaDataFields.contacts:0:emailAddress' => 'emailaddress',
-                    'metaDataFields.contacts:0:telephoneNumber' => 'telephonenumber',
-                    'metaDataFields.OrganizationName:en' => 'orgen',
-                    'metaDataFields.OrganizationName:nl' => 'orgnl',
-                    'metaDataFields.privacy' => 'privacy',
-                    'metaDataFields.sp' => 'sp',
-                    'metaDataFields.AssertionConsumerService:0:Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
-                    'metaDataFields.AssertionConsumerService:0:Location' => 'http://acs',
-                    'metaDataFields.NameIDFormat' => 'nameidformat',
-                    'metaDataFields.coin:signature_method' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
-                    'metaDataFields.certData' => 'certdata',
+                    'metaDataFields.name:en' => 'Test Entity EN',
+                    'metaDataFields.name:nl' => 'Test Entity NL',
                     'state' => 'testaccepted',
                     'revisionnote' => 'revisionnote',
-                    'metaDataFields.coin:institution_id' => 'service-institution-id',
-                    'metaDataFields.coin:institution_guid' => '543b4e5b-76b5-453f-af1e-5648378bb266',
+                    'metaDataFields.contacts:2:givenName' => 'John Doe',
                     'metaDataFields.coin:exclude_from_push' => '0'
                 ),
             'type' => 'saml20_sp',
@@ -269,8 +241,10 @@ class JsonGeneratorTest extends MockeryTestCase
         );
 
         $entity = $this->createManageEntity();
+        $changedEntity = $this->createChangedManageEntity();
+        $diff = $entity->diff($changedEntity);
 
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted', 'ACL');
+        $data = $generator->generateForExistingEntity($entity, $diff, 'testaccepted', 'ACL');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(true, $data['pathUpdates']['allowedall']);
@@ -287,8 +261,10 @@ class JsonGeneratorTest extends MockeryTestCase
         );
 
         $entity = $this->createManageEntity(true);
+        $changedEntity = $this->createChangedManageEntity();
+        $diff = $entity->diff($changedEntity);
 
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted', 'ACL');
+        $data = $generator->generateForExistingEntity($entity, $diff, 'testaccepted', 'ACL');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(true, $data['pathUpdates']['allowedall']);
@@ -305,8 +281,10 @@ class JsonGeneratorTest extends MockeryTestCase
         );
 
         $entity = $this->createManageEntity(false);
+        $changedEntity = $this->createChangedManageEntity();
+        $diff = $entity->diff($changedEntity);
 
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted', 'ACL');
+        $data = $generator->generateForExistingEntity($entity, $diff, 'testaccepted', 'ACL');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(false, $data['pathUpdates']['allowedall']);
@@ -324,8 +302,10 @@ class JsonGeneratorTest extends MockeryTestCase
 
         $idpWhitelist = ['entity-id'];
         $entity = $this->createManageEntity(false, $idpWhitelist);
+        $changedEntity = $this->createChangedManageEntity();
+        $diff = $entity->diff($changedEntity);
 
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted', 'ACL');
+        $data = $generator->generateForExistingEntity($entity, $diff, 'testaccepted', 'ACL');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(false, $data['pathUpdates']['allowedall']);
@@ -342,6 +322,9 @@ class JsonGeneratorTest extends MockeryTestCase
         );
 
         $entity = $this->createManageEntity(null, null, null, 'production');
+        $changedEntity = $this->createChangedManageEntity();
+        $diff = $entity->diff($changedEntity);
+
         $entity
             ->shouldReceive('isExcludedFromPush')
             ->andReturn(true);
@@ -350,7 +333,7 @@ class JsonGeneratorTest extends MockeryTestCase
             ->shouldReceive('isProduction')
             ->andReturn(true);
 
-        $data = $generator->generateForExistingEntity($entity, 'prodaccepted');
+        $data = $generator->generateForExistingEntity($entity, $diff, 'prodaccepted');
 
         $this->assertEquals('1', $data['pathUpdates']['metaDataFields.coin:exclude_from_push']);
     }
@@ -363,6 +346,9 @@ class JsonGeneratorTest extends MockeryTestCase
             $this->spDashboardMetadataGenerator
         );
         $entity = $this->createManageEntity(null, null, null, 'production');
+        $changedEntity = $this->createChangedManageEntity();
+        $diff = $entity->diff($changedEntity);
+
         $entity
             ->shouldReceive('isExcludedFromPush')
             ->andReturn(false);
@@ -371,7 +357,7 @@ class JsonGeneratorTest extends MockeryTestCase
             ->shouldReceive('isProduction')
             ->andReturn(true);
 
-        $data = $generator->generateForExistingEntity($entity, 'prodaccepted');
+        $data = $generator->generateForExistingEntity($entity, $diff, 'prodaccepted');
 
         $this->assertEquals('0', $data['pathUpdates']['metaDataFields.coin:exclude_from_push']);
     }
@@ -386,8 +372,10 @@ class JsonGeneratorTest extends MockeryTestCase
 
         $idpWhitelist = ['entity-id', 'entity-id2'];
         $entity = $this->createManageEntity(false, $idpWhitelist);
+        $changedEntity = $this->createChangedManageEntity();
+        $diff = $entity->diff($changedEntity);
 
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted', 'ACL');
+        $data = $generator->generateForExistingEntity($entity, $diff, 'testaccepted', 'ACL');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(false, $data['pathUpdates']['allowedall']);
@@ -490,6 +478,19 @@ class JsonGeneratorTest extends MockeryTestCase
                 ->shouldReceive('getEnvironment')
                 ->andReturn($environment);
         }
+        return $entity;
+    }
+
+    private function createChangedManageEntity(): ManageEntity
+    {
+
+        $entity = ManageEntity::fromApiResponse(json_decode(file_get_contents(__DIR__ . '/fixture/saml20_sp_response_changed.json'), true));
+        $service = new Service();
+        $service->setGuid('543b4e5b-76b5-453f-af1e-5648378bb266');
+        $service->setInstitutionId('service-institution-id');
+        $entity->setService($service);
+        $entity->setComments('revisionnote');
+        $entity = m::mock($entity);
         return $entity;
     }
 }

--- a/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
@@ -75,50 +75,34 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
             ->shouldReceive('build')
             ->andReturn(['arp' => 'arp']);
 
-        $data = $generator->generateForNewEntity($this->createManageEntity(), 'testaccepted');
+        $entity = $this->createManageEntity();
+        $changedEntity = $this->createChangedManageEntity();
+        $diff = $entity->diff($changedEntity);
+        $data = $generator->generateForExistingEntity($entity, $diff, 'testaccepted');
         $this->assertEquals(
             [
-                'data' => [
+                'type' => 'oidc10_rp',
+                'id' => 'manageId',
+                'pathUpdates' => [
                     'arp' => ['arp' => 'arp'],
-                    'type' => 'oidc10-rp',
                     'state' => 'testaccepted',
                     'entityid' => 'entityid',
-                    'active' => true,
-                    'allowedEntities' => [],
                     'allowedResourceServers' => [],
-                    'allowedall' => true,
-                    'metaDataFields' => [
-                        'accessTokenValidity' => 3600,
-                        'description:en' => 'description en',
-                        'description:nl' => 'description nl',
-                        'grants' => [
-                            'authorization_code',
-                            'refresh_token',
-                        ],
-                        'isPublicClient' => true,
-                        'name:en' => 'name en',
-                        'name:nl' => 'name nl',
-                        'NameIDFormat' => 'nameidformat',
-                        'contacts:0:contactType' => 'support',
-                        'contacts:0:givenName' => 'givenname',
-                        'contacts:0:surName' => 'surname',
-                        'contacts:0:emailAddress' => 'emailaddress',
-                        'contacts:0:telephoneNumber' => 'telephonenumber',
-                        'OrganizationName:en' => 'orgen',
-                        'OrganizationName:nl' => 'orgnl',
-                        'privacy' => 'privacy',
-                        'redirectUrls' => [
-                            'uri1',
-                            'uri2',
-                            'uri3',
-                        ],
-                        'secret' => 'test',
-                        'coin:institution_id' => 'service-institution-id',
-                        'coin:institution_guid' => '543b4e5b-76b5-453f-af1e-5648378bb266'
+                    'metaDataFields.contacts:2:givenName' => 'John',
+                    'metaDataFields.contacts:2:surName' => 'Doe',
+                    'metaDataFields.OrganizationName:nl' => 'Drop Supplies',
+                    'metaDataFields.OrganizationDisplayName:en' => 'Drop Supplies',
+                    'metaDataFields.grants' => [
+                        0 => 'authorization_code',
+                        1 => 'refresh_token'
+                    ],
+                    'metaDataFields.redirectUrls' => [
+                        0 => 'uri1',
+                        1 => 'uri2',
+                        2 => 'uri3',
                     ],
                     'revisionnote' => 'revisionnote',
                 ],
-                'type' => 'oidc10_rp',
             ],
             $data
         );
@@ -138,7 +122,10 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
             'http://oidc.prod.playground.example.com'
         );
 
-        $data = $generator->generateForExistingEntity($this->createManageEntity(), 'testaccepted');
+        $entity = $this->createManageEntity();
+        $changedEntity = $this->createChangedManageEntity();
+        $diff = $entity->diff($changedEntity);
+        $data = $generator->generateForExistingEntity($entity, $diff, 'testaccepted');
 
         $this->assertEquals(
             array(
@@ -149,36 +136,24 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
                                 'arp' => 'arp',
                             ),
                         'entityid' => 'entityid',
-                        'metaDataFields.accessTokenValidity' => 3600,
-                        'metaDataFields.NameIDFormat' => 'nameidformat',
-                        'metaDataFields.description:en' => 'description en',
-                        'metaDataFields.description:nl' => 'description nl',
-                        'metaDataFields.name:en' => 'name en',
-                        'metaDataFields.name:nl' => 'name nl',
-                        'metaDataFields.contacts:0:contactType' => 'support',
-                        'metaDataFields.contacts:0:givenName' => 'givenname',
-                        'metaDataFields.contacts:0:surName' => 'surname',
-                        'metaDataFields.contacts:0:emailAddress' => 'emailaddress',
-                        'metaDataFields.contacts:0:telephoneNumber' => 'telephonenumber',
-                        'metaDataFields.OrganizationName:en' => 'orgen',
-                        'metaDataFields.OrganizationName:nl' => 'orgnl',
-                        'metaDataFields.privacy' => 'privacy',
-                        'metaDataFields.secret' => 'test',
-                        'metaDataFields.redirectUrls' => [
-                            'uri1',
-                            'uri2',
-                            'uri3',
-                        ],
+                        'metaDataFields.contacts:2:givenName' => 'John',
+                        'metaDataFields.contacts:2:surName' => 'Doe',
+                        'metaDataFields.OrganizationName:nl' => 'Drop Supplies',
+                        'metaDataFields.OrganizationDisplayName:en' => 'Drop Supplies',
                         'metaDataFields.grants' => [
-                            'authorization_code',
-                            'refresh_token',
+                            0 => 'authorization_code',
+                            1 => 'refresh_token'
                         ],
-                        'metaDataFields.isPublicClient' => true,
-                        'revisionnote' => 'revisionnote',
+                        'metaDataFields.redirectUrls' => [
+                            0 => 'uri1',
+                            1 => 'uri2',
+                            2 => 'uri3',
+                        ],
                         'state' => 'testaccepted',
-                        'allowedResourceServers' => [],
-                        'metaDataFields.coin:institution_id' => 'service-institution-id',
-                        'metaDataFields.coin:institution_guid' => '543b4e5b-76b5-453f-af1e-5648378bb266'
+                        'allowedResourceServers' => [
+
+                        ],
+                        'revisionnote' => 'revisionnote',
                     ),
                 'type' => 'oidc10_rp',
                 'id' => 'manageId',
@@ -199,8 +174,10 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
             'http://oidc.test.playground.example.com',
             'http://oidc.prod.playground.example.com'
         );
-
-        $data = $generator->generateForExistingEntity($this->createManageEntity(), 'testaccepted', 'ACL');
+        $entity = $this->createManageEntity();
+        $changedEntity = $this->createChangedManageEntity();
+        $diff = $entity->diff($changedEntity);
+        $data = $generator->generateForExistingEntity($entity, $diff, 'testaccepted', 'ACL');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(true, $data['pathUpdates']['allowedall']);
@@ -223,8 +200,10 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
         );
 
         $entity = $this->createManageEntity(true);
+        $changedEntity = $this->createChangedManageEntity();
+        $diff = $entity->diff($changedEntity);
 
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted', 'ACL');
+        $data = $generator->generateForExistingEntity($entity, $diff, 'testaccepted', 'ACL');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(true, $data['pathUpdates']['allowedall']);
@@ -247,8 +226,10 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
         );
 
         $entity = $this->createManageEntity(false);
+        $changedEntity = $this->createChangedManageEntity();
+        $diff = $entity->diff($changedEntity);
 
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted', 'ACL');
+        $data = $generator->generateForExistingEntity($entity, $diff, 'testaccepted', 'ACL');
 
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
@@ -274,8 +255,9 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
         $entity = $this->createManageEntity(false, [
             'entity-id',
         ]);
-
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted', 'ACL');
+        $changedEntity = $this->createChangedManageEntity();
+        $diff = $entity->diff($changedEntity);
+        $data = $generator->generateForExistingEntity($entity, $diff, 'testaccepted', 'ACL');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(false, $data['pathUpdates']['allowedall']);
@@ -302,8 +284,10 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
             'entity-id',
             'entity-id2',
         ]);
+        $changedEntity = $this->createChangedManageEntity();
+        $diff = $entity->diff($changedEntity);
 
-        $data = $generator->generateForExistingEntity($entity, 'testaccepted', 'ACL');
+        $data = $generator->generateForExistingEntity($entity, $diff, 'testaccepted', 'ACL');
 
         $this->assertArrayHasKey('allowedall', $data['pathUpdates']);
         $this->assertSame(false, $data['pathUpdates']['allowedall']);
@@ -341,6 +325,18 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
                 ->shouldReceive('getEnvironment')
                 ->andReturn($environment);
         }
+        return $entity;
+    }
+
+    private function createChangedManageEntity()
+    {
+        $entity = ManageEntity::fromApiResponse(json_decode(file_get_contents(__DIR__ . '/fixture/oidc10_rp_response_changed.json'), true));
+        $service = new Service();
+        $service->setGuid('543b4e5b-76b5-453f-af1e-5648378bb266');
+        $service->setInstitutionId('service-institution-id');
+        $entity->setService($service);
+        $entity->setComments('revisionnote');
+        $entity = m::mock($entity);
         return $entity;
     }
 }

--- a/tests/unit/Application/Metadata/OidcngResourceServerJsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/OidcngResourceServerJsonGeneratorTest.php
@@ -24,6 +24,7 @@ use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\ArpGener
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\PrivacyQuestionsMetadataGenerator;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\SpDashboardMetadataGenerator;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\OidcngResourceServerJsonGenerator;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\EntityDiff;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use function file_get_contents;
@@ -109,30 +110,18 @@ class OidcngResourceServerJsonGeneratorTest extends MockeryTestCase
             $this->spDashboardMetadataGenerator
         );
 
-        $data = $generator->generateForExistingEntity($this->createManageEntity(), 'testaccepted');
+        $diff = m::mock(EntityDiff::class);
+        $diff->shouldReceive('getDiff')
+            ->andReturn(['metaDataFields.name:en' => 'A new hope']);
+        $data = $generator->generateForExistingEntity($this->createManageEntity(), $diff, 'testaccepted');
 
         $this->assertEquals(
             array(
                 'pathUpdates' =>
                     array(
                         'entityid' => 'entityid',
-                        'metaDataFields.NameIDFormat' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
-                        'metaDataFields.description:en' => 'description en',
-                        'metaDataFields.description:nl' => 'description nl',
-                        'metaDataFields.name:en' => 'name en',
-                        'metaDataFields.name:nl' => 'name nl',
-                        'metaDataFields.contacts:0:contactType' => 'support',
-                        'metaDataFields.contacts:0:givenName' => 'givenname',
-                        'metaDataFields.contacts:0:surName' => 'surname',
-                        'metaDataFields.contacts:0:emailAddress' => 'emailaddress',
-                        'metaDataFields.contacts:0:telephoneNumber' => 'telephonenumber',
-                        'metaDataFields.OrganizationName:en' => 'orgen',
-                        'metaDataFields.OrganizationName:nl' => 'orgnl',
-                        'metaDataFields.secret' => 'test',
+                        'metaDataFields.name:en' => 'A new hope',
                         'state' => 'testaccepted',
-                        'metaDataFields.privacy' => 'privacy',
-                        'metaDataFields.coin:institution_id' => 'service-institution-id',
-                        'metaDataFields.coin:institution_guid' => '543b4e5b-76b5-453f-af1e-5648378bb266',
                         'revisionnote' => 'revisionnote'
                     ),
                 'type' => 'oauth20_rs',

--- a/tests/unit/Application/Metadata/fixture/oidc10_rp_response_changed.json
+++ b/tests/unit/Application/Metadata/fixture/oidc10_rp_response_changed.json
@@ -1,0 +1,72 @@
+{
+  "id": "manageId",
+  "version": 1,
+  "type": "oidc10_rp",
+  "revision": {
+    "number": 1,
+    "created": 1570441986.983,
+    "parentId": null,
+    "updatedBy": "urn:collab:person:example.com:admin",
+    "terminated": null
+  },
+  "data": {
+    "entityid": "entityid",
+    "state": "prodaccepted",
+    "allowedall": true,
+    "arp": {
+      "enabled": true,
+      "attributes": {
+        "urn:mace:dir:attribute-def:displayName": [
+          {
+            "value": "*",
+            "source": "idp",
+            "motivation": ""
+          }
+        ],
+        "urn:mace:dir:attribute-def:uid": [
+          {
+            "value": "*",
+            "source": "idp",
+            "motivation": ""
+          }
+        ]
+      }
+    },
+    "metaDataFields": {
+      "name:en": "name en",
+      "secret": "test",
+      "redirectUrls": [
+        "uri1",
+        "uri2",
+        "uri3"
+      ],
+      "grants": [
+        "authorization_code",
+        "refresh_token"
+      ],
+      "NameIDFormat": "nameidformat",
+      "isResourceServer": false,
+      "contacts:0:emailAddress": "emailaddress",
+      "contacts:0:contactType": "support",
+      "name:nl": "name nl",
+      "description:en": "description en",
+      "coin:service_team_id": "team-UU",
+      "description:nl": "description nl",
+      "contacts:0:givenName": "John",
+      "contacts:0:surName": "Doe",
+      "contacts:0:telephoneNumber": "telephonenumber",
+      "OrganizationName:en": "orgen",
+      "OrganizationDisplayName:en": "Drop Supplies",
+      "OrganizationURL:en": "http://orgen",
+      "OrganizationName:nl": "Drop Supplies",
+      "OrganizationDisplayName:nl": "orgdisnl",
+      "OrganizationURL:nl": "http://orgnl",
+      "isPublicClient": true
+    },
+    "allowedEntities": [],
+    "allowedResourceServers": [],
+    "type": "oidc10-rp",
+    "revisionnote": "Some revision note",
+    "eid": 57
+  }
+}

--- a/tests/unit/Application/Metadata/fixture/saml20_sp_response_changed.json
+++ b/tests/unit/Application/Metadata/fixture/saml20_sp_response_changed.json
@@ -1,0 +1,65 @@
+{
+  "id": "manageId",
+  "version": 0,
+  "type": "saml20_sp",
+  "revision": {
+    "number": 0,
+    "created": 1543851541.752,
+    "parentId": null,
+    "updatedBy": "sp-dashboard",
+    "terminated": null
+  },
+  "data": {
+    "arp": {
+      "attributes": {
+        "urn:mace:dir:attribute-def:displayName": [
+          {
+            "source": "idp",
+            "value": "*",
+            "motivation": "Lorem ipsum dolor sit"
+          }
+        ],
+        "urn:mace:dir:attribute-def:uid": [
+          {
+            "source": "idp",
+            "value": "*",
+            "motivation": "fd fads fdasafd s fdasfda s dfas dfa"
+          }
+        ]
+      },
+      "enabled": true
+    },
+    "entityid": "http:\/\/entityid",
+    "metadataurl": "http:\/\/metadata",
+    "active": true,
+    "allowedEntities": [],
+    "allowedall": true,
+    "state": "testaccepted",
+    "type": "saml20-sp",
+    "metaDataFields": {
+      "AssertionConsumerService:0:Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+      "AssertionConsumerService:0:Location": "http:\/\/acs",
+      "NameIDFormat": "nameidformat",
+      "description:en": "description en",
+      "description:nl": "description nl",
+      "name:en": "Test Entity EN",
+      "name:nl": "Test Entity NL",
+      "coin:signature_method": "http:\/\/www.w3.org\/2001\/04\/xmldsig-more#rsa-sha256",
+      "certData": "certdata",
+      "contacts:0:contactType": "support",
+      "contacts:0:givenName": "John Doe",
+      "contacts:0:surName": "surname",
+      "contacts:0:emailAddress": "emailaddress",
+      "contacts:0:telephoneNumber": "telephonenumber",
+      "OrganizationName:en": "orgen",
+      "OrganizationDisplayName:en": "orgdisen",
+      "OrganizationURL:en": "http:\/\/orgen",
+      "OrganizationName:nl": "orgnl",
+      "OrganizationDisplayName:nl": "orgdisnl",
+      "OrganizationURL:nl": "http://orgnl",
+      "coin:service_team_id": "service-institution-id",
+      "coin:original_metadata_url": "https:\/\/engine.surfconext.nl\/authentication\/sp\/metadata"
+    },
+    "eid": 31
+  }
+}

--- a/tests/unit/Infrastructure/Manage/Dto/EntityDiffTest.php
+++ b/tests/unit/Infrastructure/Manage/Dto/EntityDiffTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\DashboardBundle\Manage\Dto;
+
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\EntityDiff;
+
+class EntityDiffTest extends MockeryTestCase
+{
+    public function test_empty_diff()
+    {
+        $data = [];
+        $compareTo = [];
+        $diff = new EntityDiff($data, $compareTo);
+        $this->assertEmpty($diff->getDiff());
+    }
+
+    public function test_addition()
+    {
+        $data = ['a' => 'is for apple', 'd' => 'is for drums'];
+        $compareTo = ['a' => 'is for apple'];
+        $diff = (new EntityDiff($data, $compareTo))->getDiff();
+        $this->assertCount(1, $diff);
+        $this->assertArrayHasKey('d', $diff);
+    }
+
+    public function test_change()
+    {
+        $data = ['d' => 'is for DRUMS!'];
+        $compareTo = ['d' => 'is for drums'];
+        $diff = (new EntityDiff($data, $compareTo))->getDiff();
+        $this->assertCount(1, $diff);
+        $this->assertArrayHasKey('d', $diff);
+        $this->assertEquals('is for DRUMS!', $diff['d']);
+    }
+
+    public function test_removed()
+    {
+        $data = [];
+        $compareTo = ['d' => 'is for drums'];
+        $diff = (new EntityDiff($data, $compareTo))->getDiff();
+        $this->assertCount(1, $diff);
+        $this->assertArrayHasKey('d', $diff);
+        $this->assertNull($diff['d']);
+    }
+
+    public function test_recursion()
+    {
+        $data = ['a' => 'is for apples', 'd' => ['is for drums', 'is for duck']];
+        $compareTo = ['a' => 'is for apple', 'd' => ['is for drums', 'is for door']];
+        $diff = (new EntityDiff($data, $compareTo))->getDiff();
+
+        $this->assertArrayHasKey('d', $diff);
+        $this->assertArrayHasKey('a', $diff);
+        $this->assertSame([1 => 'is for duck'], $diff['d']);
+    }
+
+    public function test_a_bit_of_everything()
+    {
+        $data = [
+            'a' => 'is for apple',
+            'b' => 'is for balloon',
+            'c' => 'is for crayons',
+        ];
+
+        $compareTo = [
+            'b' => 'is for balloon',
+            'c' => 'is for crayon',
+            'd' => 'is for drums'
+        ];
+
+        $diff = (new EntityDiff($data, $compareTo))->getDiff();
+        $this->assertCount(3, $diff);
+        // added
+        $this->assertArrayHasKey('a', $diff);
+        $this->assertEquals('is for apple', $diff['a']);
+        // changed
+        $this->assertArrayHasKey('c', $diff);
+        $this->assertEquals('is for crayons', $diff['c']);
+        // deleted
+        $this->assertArrayHasKey('d', $diff);
+        $this->assertNull($diff['d']);
+    }
+}

--- a/tests/unit/Infrastructure/Manage/Dto/ManageEntityTest.php
+++ b/tests/unit/Infrastructure/Manage/Dto/ManageEntityTest.php
@@ -61,4 +61,40 @@ class ManageEntityTest extends MockeryTestCase
         $this->assertSame('support@surfconext.nl', $contact->getEmail());
         $this->assertSame('', $contact->getPhone());
     }
+
+    public function test_diff_saml()
+    {
+        $entity = ManageEntity::fromApiResponse(json_decode(file_get_contents(__DIR__ . '/fixture/saml20_sp_contacts_response_1.json'), true));
+        $entity2 = ManageEntity::fromApiResponse(json_decode(file_get_contents(__DIR__ . '/fixture/saml20_sp_contacts_response_2.json'), true));
+
+        $diff = $entity->diff($entity2);
+        $diffResults = $diff->getDiff();
+        $this->assertCount(4, $diffResults);
+        $this->assertEquals('https://monitorstand.example.com', $diffResults['entityid']);
+        $this->assertEquals('https://engine.surfconext.com/authentication/metadata', $diffResults['metadataurl']);
+        $this->assertEquals('John Doe', $diffResults['metaDataFields.contacts:0:givenName']);
+        $this->assertIsArray($diffResults['arp']['attributes']);
+        $this->assertCount(2, $diffResults['arp']['attributes']);
+        $this->assertEquals('Mumbo-jumbo', $diffResults['arp']['attributes']['urn:mace:dir:attribute-def:displayName']['motivation']);
+        $this->assertEquals('sab', $diffResults['arp']['attributes']['urn:mace:dir:attribute-def:uid']['source']);
+    }
+
+    public function test_diff_oidc()
+    {
+        $entity = ManageEntity::fromApiResponse(json_decode(file_get_contents(__DIR__ . '/fixture/oidc_1.json'), true));
+        $entity2 = ManageEntity::fromApiResponse(json_decode(file_get_contents(__DIR__ . '/fixture/oidc_2.json'), true));
+
+        $diff = $entity->diff($entity2);
+        $diffResults = $diff->getDiff();
+        $this->assertCount(5, $diffResults);
+        $this->assertEquals('Teams client credentials client for VOOT and FOOT access', $diffResults['metadataFields.name:en']);
+        $this->assertIsArray($diffResults['allowedEntities']);
+        $this->assertCount(1, $diffResults['allowedEntities']);
+        $this->assertIsArray($diffResults['arp']['attributes']);
+        $this->assertCount(1, $diffResults['arp']['attributes']);
+        $this->assertIsArray($diffResults['metaDataFields.grants']);
+        $this->assertCount(1, $diffResults['metaDataFields.grants']);
+        $this->assertIsArray($diffResults['metaDataFields.redirectUrls']);
+        $this->assertCount(1, $diffResults['metaDataFields.redirectUrls']);
+    }
 }

--- a/tests/unit/Infrastructure/Manage/Dto/ManageEntityTest.php
+++ b/tests/unit/Infrastructure/Manage/Dto/ManageEntityTest.php
@@ -69,14 +69,12 @@ class ManageEntityTest extends MockeryTestCase
 
         $diff = $entity->diff($entity2);
         $diffResults = $diff->getDiff();
-        $this->assertCount(4, $diffResults);
+        $this->assertCount(3, $diffResults);
         $this->assertEquals('https://monitorstand.example.com', $diffResults['entityid']);
         $this->assertEquals('https://engine.surfconext.com/authentication/metadata', $diffResults['metadataurl']);
-        $this->assertEquals('John Doe', $diffResults['metaDataFields.contacts:0:givenName']);
-        $this->assertIsArray($diffResults['arp']['attributes']);
-        $this->assertCount(2, $diffResults['arp']['attributes']);
-        $this->assertEquals('Mumbo-jumbo', $diffResults['arp']['attributes']['urn:mace:dir:attribute-def:displayName']['motivation']);
-        $this->assertEquals('sab', $diffResults['arp']['attributes']['urn:mace:dir:attribute-def:uid']['source']);
+        $this->assertEquals('John Doe', $diffResults['metaDataFields.contacts:1:givenName']);
+        // The ARP is generated in the 'provide everything' fashion, and is not part of the diff.
+        $this->assertArrayNotHasKey('arp', $diffResults);
     }
 
     public function test_diff_oidc()
@@ -86,15 +84,18 @@ class ManageEntityTest extends MockeryTestCase
 
         $diff = $entity->diff($entity2);
         $diffResults = $diff->getDiff();
-        $this->assertCount(5, $diffResults);
-        $this->assertEquals('Teams client credentials client for VOOT and FOOT access', $diffResults['metadataFields.name:en']);
-        $this->assertIsArray($diffResults['allowedEntities']);
-        $this->assertCount(1, $diffResults['allowedEntities']);
-        $this->assertIsArray($diffResults['arp']['attributes']);
-        $this->assertCount(1, $diffResults['arp']['attributes']);
+        $this->assertCount(3, $diffResults);
+        // Allowed entities are not part of the diff. We generate them in the JSON generator
+        $this->assertArrayNotHasKey('allowedEntities', $diffResults);
+        // ARP is not part of the diff. We generate them in the JSON generator
+        $this->assertArrayNotHasKey('arp', $diffResults);
+        $this->assertArrayHasKey('metaDataFields.name:en', $diffResults);
+        $this->assertEquals('Teams client credentials client for VOOT and FOOT access', $diffResults['metaDataFields.name:en']);
         $this->assertIsArray($diffResults['metaDataFields.grants']);
         $this->assertCount(1, $diffResults['metaDataFields.grants']);
         $this->assertIsArray($diffResults['metaDataFields.redirectUrls']);
-        $this->assertCount(1, $diffResults['metaDataFields.redirectUrls']);
+        // Even though only one item is changed, both items are part of the diff as the redirect URLS are set in a
+        // 'provide everything' manner.
+        $this->assertCount(2, $diffResults['metaDataFields.redirectUrls']);
     }
 }

--- a/tests/unit/Infrastructure/Manage/Dto/fixture/oidc_1.json
+++ b/tests/unit/Infrastructure/Manage/Dto/fixture/oidc_1.json
@@ -1,0 +1,46 @@
+{
+  "id": "411f8e0f-87a6-4ea7-8194-66b3e77f97d6",
+  "version": 0,
+  "type": "oidc10_rp",
+  "revision": {
+    "number": 0,
+    "created": 1543851541.752,
+    "parentId": null,
+    "updatedBy": "sp-dashboard",
+    "terminated": null
+  },
+  "data": {
+    "allowedEntities": [
+      {
+        "name": "http://mock-idp"
+      }
+    ],
+    "allowedResourceServers": [
+      {
+        "name": "voot.vm.openconext.org"
+      }
+    ],
+    "allowedall": false,
+    "arp": {
+      "attributes": {},
+      "enabled": true
+    },
+    "entityid": "teams.vm.openconext.org",
+    "metaDataFields": {
+      "OrganizationName:en": "OpenConext",
+      "description:en": "OAuth client to access VOOT for group information",
+      "grants": [
+        "client_credentials",
+        "implicit"
+      ],
+      "name:en": "Teams client credentials client for VOOT access",
+      "redirectUrls": [
+        "https://foobar.com",
+        "https://www.google.com"
+      ],
+      "secret": "$2a$10$dHNcZXXuAOZcqei9y8i5W.lJUERx4XKYYpZkNT8FfaLAc6DwUZNgW"
+    },
+    "state": "prodaccepted",
+    "type": "oidc10-rp"
+  }
+}

--- a/tests/unit/Infrastructure/Manage/Dto/fixture/oidc_2.json
+++ b/tests/unit/Infrastructure/Manage/Dto/fixture/oidc_2.json
@@ -1,0 +1,46 @@
+{
+  "id": "411f8e0f-87a6-4ea7-8194-66b3e77f97d6",
+  "version": 0,
+  "type": "oidc10_rp",
+  "revision": {
+    "number": 0,
+    "created": 1543851541.752,
+    "parentId": null,
+    "updatedBy": "sp-dashboard",
+    "terminated": null
+  },
+  "data": {
+    "allowedEntities" : [
+      {"name" : "http://mock-idp"},
+      {"name" : "http://idp.harderwijk.edu.nl"}
+    ],
+    "allowedResourceServers" : [
+      {"name" : "voot.vm.openconext.org"},
+      {"name" : "foot.vm.openconext.org"}
+    ],
+    "allowedall" : false,
+    "arp" : {
+      "attributes" : {
+        "urn:mace:dir:attribute-def:displayName": [
+          {
+            "source": "idp",
+            "value": "*",
+            "motivation": "Mumbo-jumbo"
+          }
+        ]
+      },
+      "enabled" : true
+    },
+    "entityid" : "teams.vm.openconext.org",
+    "metaDataFields" : {
+      "OrganizationName:en" : "OpenConext",
+      "description:en" : "OAuth client to access VOOT for group information",
+      "grants" : [ "implicit" ],
+      "name:en" : "Teams client credentials client for VOOT and FOOT access",
+      "redirectUrls" : [ "https://foobar.com", "http://idp.harderwijk.edu.nl/redirect" ],
+      "secret" : "$2a$10$dHNcZXXuAOZcqei9y8i5W.lJUERx4XKYYpZkNT8FfaLAc6DwUZNgW"
+    },
+    "state" : "prodaccepted",
+    "type" : "oidc10-rp"
+  }
+}

--- a/tests/unit/Infrastructure/Manage/Dto/fixture/saml20_sp_contacts_response_1.json
+++ b/tests/unit/Infrastructure/Manage/Dto/fixture/saml20_sp_contacts_response_1.json
@@ -1,0 +1,54 @@
+{
+  "id": "411f8e0f-87a6-4ea7-8194-66b3e77f97d5",
+  "version": 0,
+  "type": "saml20_sp",
+  "revision": {
+    "number": 0,
+    "created": 1543851541.752,
+    "parentId": null,
+    "updatedBy": "sp-dashboard",
+    "terminated": null
+  },
+  "data": {
+    "entityid": "https:\/\/monitorstands.example.com",
+    "metadataurl": "https:\/\/engine.surfconext.nl\/authentication\/sp\/metadata",
+    "active": true,
+    "allowedEntities": [],
+    "allowedall": true,
+    "state": "testaccepted",
+    "type": "saml20-sp",
+    "metaDataFields": {
+      "contacts:0:contactType": "invalid",
+      "contacts:0:givenName": "SURFconext",
+      "contacts:0:surName": "Helpdesk",
+      "contacts:0:emailAddress": "help@surfconext.nl",
+      "contacts:1:givenName": "SURFconext",
+      "contacts:1:surName": "Administrative Contact",
+      "contacts:1:emailAddress": "support@surfconext.nl",
+      "contacts:2:contactType": "technical",
+      "contacts:2:givenName": "SURFconext",
+      "contacts:2:surName": "Technical Support",
+      "contacts:2:emailAddress": "support@surfconext.nl"
+    },
+    "arp": {
+      "attributes": {
+        "urn:mace:dir:attribute-def:displayName": [
+          {
+            "source": "idp",
+            "value": "*",
+            "motivation": "asddsafadfsafdsfdasfadsafds dafs ad fsad fsafd saf ds"
+          }
+        ],
+        "urn:mace:dir:attribute-def:uid": [
+          {
+            "source": "idp",
+            "value": "*",
+            "motivation": "fd fads fdasafd s fdasfda s dfas dfa"
+          }
+        ]
+      },
+      "enabled": true
+    },
+    "eid": 31
+  }
+}

--- a/tests/unit/Infrastructure/Manage/Dto/fixture/saml20_sp_contacts_response_2.json
+++ b/tests/unit/Infrastructure/Manage/Dto/fixture/saml20_sp_contacts_response_2.json
@@ -1,0 +1,54 @@
+{
+  "id": "411f8e0f-87a6-4ea7-8194-66b3e77f97d5",
+  "version": 0,
+  "type": "saml20_sp",
+  "revision": {
+    "number": 0,
+    "created": 1543851541.752,
+    "parentId": null,
+    "updatedBy": "sp-dashboard",
+    "terminated": null
+  },
+  "data": {
+    "entityid": "https:\/\/monitorstand.example.com",
+    "metadataurl": "https:\/\/engine.surfconext.com\/authentication\/metadata",
+    "active": true,
+    "allowedEntities": [],
+    "allowedall": true,
+    "state": "testaccepted",
+    "type": "saml20-sp",
+    "metaDataFields": {
+      "contacts:0:contactType": "invalid",
+      "contacts:0:givenName": "SURFconext",
+      "contacts:0:surName": "Helpdesk",
+      "contacts:0:emailAddress": "help@surfconext.nl",
+      "contacts:1:givenName": "SURFconext",
+      "contacts:1:surName": "Administrative Contact",
+      "contacts:1:emailAddress": "support@surfconext.nl",
+      "contacts:2:contactType": "technical",
+      "contacts:2:givenName": "John Doe",
+      "contacts:2:surName": "Technical Support",
+      "contacts:2:emailAddress": "support@surfconext.nl"
+    },
+    "arp": {
+      "attributes": {
+        "urn:mace:dir:attribute-def:displayName": [
+          {
+            "source": "idp",
+            "value": "*",
+            "motivation": "Mumbo-jumbo"
+          }
+        ],
+        "urn:mace:dir:attribute-def:uid": [
+          {
+            "source": "sab",
+            "value": "*",
+            "motivation": "fd fads fdasafd s fdasfda s dfas dfa"
+          }
+        ]
+      },
+      "enabled": true
+    },
+    "eid": 31
+  }
+}

--- a/tests/webtests/Manage/Client/FakePublishEntityClient.php
+++ b/tests/webtests/Manage/Client/FakePublishEntityClient.php
@@ -39,7 +39,7 @@ class FakePublishEntityClient implements PublishEntityRepositoryInterface
         $this->pushOk = false;
     }
 
-    public function publish(ManageEntity $entity, string $part = '')
+    public function publish(ManageEntity $entity, ?ManageEntity $pristineEntity, string $part = '')
     {
         $entityId = $entity->getMetaData()->getEntityId();
         if (!array_key_exists($entityId, $this->publishResponses)) {


### PR DESCRIPTION
A rather big change was drafted in preparation to creating production entity edits. This change updates SP Dashboards behavior when it comes to saving an existing entity. Previously we would use the PUT entity endpoint on Manage providing all metadata. Manage would create a new revision with all changed fields (all). We now only send the actually changed fields. 

This required us to diff the original entity with the one changed on the edit form. The change was done in three stages. 

## Stage 1
1. The Manage Entity is reworked. It can now compare one entity with another. Yielding a diff array that can later be used to store the changed fields in Manage.
2. Tests where added to verify a predictable diff is returned.

## Stage 2
The Json generators are now using the diff output to generate the entity metadata portion. The ACL whitelist data, and the ARP entries are not saved in a `diff` manner. But those data are presented to Manage in a 'provide everything' manner. Note that all entity types are supported/changed.

## Stage 3
The changes are tied together in the Application and infra layers. Tests are modified and new test coverage is created.

See: https://www.pivotaltracker.com/story/show/182413030
See: https://github.com/OpenConext/OpenConext-manage/wiki/API#merge-write