### PR TITLE
Provide host.docker.internal friendly xdebug setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.vagrant/
 /ansible/*.retry
 /app/config/parameters.yml
+docker-compose.override.yml
 app/js/coverage
 /build/
 /var/*

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ An entry in your hostsfile is still required for things to work. An example entr
 127.0.0.1 welcome.vm.openconext.org static.vm.openconext.org mujina-sp.vm.openconext.org mujina-idp.vm.openconext.org engine-api.vm.openconext.org oidc.vm.openconext.org manage.vm.openconext.org spdashboard.vm.openconext.org
 ```
 
+Is your host system on an ARM based archetecture CPU, and are you running a docker solution in a VM? Chances are 
+you are not going to be able to step debug with XDebug. To achieve this you will need to use a slightly different
+XDebug setting. In order to deliver those settings into the `php-fpm` container we suggest you a
+`docker-compose.overrides.yml` file based on the dist file you will find in the docroot. You might need to do some
+additional changes to your IDE. [This Jetbrains Blogpost](https://blog.jetbrains.com/phpstorm/2018/08/quickstart-with-docker-in-phpstorm/) 
+might aid in that area.
 
 **Deprecation warning!**
 The Ansible playbook for SP Dashboard depends on some roles from

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -1,0 +1,15 @@
+services:
+  php-fpm:
+    volumes:
+      - .:/var/www/html/
+      - ./docker/conf/override/xdebug.override.ini:/usr/local/etc/php/conf.d/15-docker-php-ext-xdebug.ini
+  openconext:
+    volumes:
+      - spdashboard_mysql:/var/lib/mysql
+      - spdashboard_mongo:/var/lib/mongo
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    cap_add:
+      - SYS_ADMIN
+    tmpfs: /run
+    environment:
+      - container=docker

--- a/docker/conf/override/xdebug.override.ini
+++ b/docker/conf/override/xdebug.override.ini
@@ -1,0 +1,2 @@
+xdebug.client_host=host.docker.internal
+xdebug.client_port=9003


### PR DESCRIPTION
Modern macos docker implementations use a vm to run containers in. Nothing wrong with that. In order to use xdebug step debugging, the xdebug config needs some tweaking to get it working. By providing this docker compose override, we can adjust the setup in the php-fpm container without messing with the base images.

See: https://www.pivotaltracker.com/story/show/183285237
See: https://blog.jetbrains.com/phpstorm/2018/08/quickstart-with-docker-in-phpstorm/