### PR TITLE
Create a Jira ticket after creating an entity change request

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -78,6 +78,7 @@ parameters:
     jira_issue_priority: Medium
     jira_issue_type: spd-delete-production-entity
     jira_issue_type_publication_request: spd-request-production-entity
+    jira_issue_type_entity_change_request: spd-request-change-request-prod
     jira_issue_entityid_fieldname: customfield_13018
     jira_issue_manageid_fieldname: customfield_13401
     # The label that is set for the manage id field, used to compose the JQL which identifies a custom field by its label

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/EntityChangeRequestCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/EntityChangeRequestCommandHandler.php
@@ -31,7 +31,6 @@ use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityChangeRequestReposi
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Ticket;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\PublishMetadataException;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
-use Webmozart\Assert\Assert;
 
 class EntityChangeRequestCommandHandler implements CommandHandler
 {
@@ -88,7 +87,9 @@ class EntityChangeRequestCommandHandler implements CommandHandler
         LoggerInterface $logger,
         string $issueType
     ) {
-        Assert::stringNotEmpty($issueType, 'Please set "jira_issue_type_entity_change_request" in parameters.yml');
+        if (empty($issueType)) {
+            throw new Exception('Please set "jira_issue_type_entity_change_request" in parameters.yml');
+        }
         $this->repository = $repository;
         $this->entityService = $entityService;
         $this->ticketService = $ticketService;

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityProductionCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityProductionCommandHandler.php
@@ -32,7 +32,6 @@ use Surfnet\ServiceProviderDashboard\Domain\Repository\PublishEntityRepository;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Ticket;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\PublishMetadataException;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
-use Webmozart\Assert\Assert;
 
 class PublishEntityProductionCommandHandler implements CommandHandler
 {
@@ -89,7 +88,9 @@ class PublishEntityProductionCommandHandler implements CommandHandler
         LoggerInterface $logger,
         string $issueType
     ) {
-        Assert::stringNotEmpty($issueType, 'Please set "jira_issue_type_publication_request" in parameters.yml');
+        if (empty($issueType)) {
+            throw new Exception('Please set "jira_issue_type_publication_request" in parameters.yml');
+        }
         $this->publishClient = $publishClient;
         $this->entityService = $entityService;
         $this->ticketService = $ticketService;

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityProductionCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityProductionCommandHandler.php
@@ -24,20 +24,16 @@ use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityPro
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishProductionCommandInterface;
 use Surfnet\ServiceProviderDashboard\Application\CommandHandler\CommandHandler;
 use Surfnet\ServiceProviderDashboard\Application\Service\EntityServiceInterface;
+use Surfnet\ServiceProviderDashboard\Application\Service\MailService;
 use Surfnet\ServiceProviderDashboard\Application\Service\TicketService;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
-use Surfnet\ServiceProviderDashboard\Domain\Mailer\Mailer;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\PublishEntityRepository;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Ticket;
-use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Factory\MailMessageFactory;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\PublishMetadataException;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Webmozart\Assert\Assert;
 
-/**
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
- */
 class PublishEntityProductionCommandHandler implements CommandHandler
 {
     /**
@@ -65,14 +61,9 @@ class PublishEntityProductionCommandHandler implements CommandHandler
     private $issueType;
 
     /**
-     * @var MailMessageFactory
+     * @var MailService
      */
-    private $mailFactory;
-
-    /**
-     * @var Mailer
-     */
-    private $mailer;
+    private $mailService;
 
     /**
      * @var string
@@ -94,8 +85,7 @@ class PublishEntityProductionCommandHandler implements CommandHandler
         EntityServiceInterface $entityService,
         TicketService $ticketService,
         FlashBagInterface $flashBag,
-        MailMessageFactory $mailFactory,
-        Mailer $mailer,
+        MailService $mailer,
         LoggerInterface $logger,
         string $issueType
     ) {
@@ -103,8 +93,7 @@ class PublishEntityProductionCommandHandler implements CommandHandler
         $this->publishClient = $publishClient;
         $this->entityService = $entityService;
         $this->ticketService = $ticketService;
-        $this->mailFactory = $mailFactory;
-        $this->mailer = $mailer;
+        $this->mailService = $mailer;
         $this->flashBag = $flashBag;
         $this->logger = $logger;
         $this->issueType = $issueType;
@@ -181,9 +170,7 @@ class PublishEntityProductionCommandHandler implements CommandHandler
         } catch (Exception $e) {
             $this->logger->critical('Unable to create the Jira issue.', [$e->getMessage()]);
 
-            // Inform the service desk of the unavailability of Jira
-            $message = $this->mailFactory->buildJiraIssueFailedMessage($e, $entity);
-            $this->mailer->send($message);
+            $this->mailService->sendErrorReport($entity, $e);
 
             // Customer is presented an error message with the invitation to try again at a later stage
             $this->flashBag->add('error', 'entity.edit.error.publish');

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/MailService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/MailService.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Service;
+
+use Exception;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
+use Surfnet\ServiceProviderDashboard\Domain\Mailer\Mailer;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Factory\MailMessageFactory;
+
+class MailService
+{
+    /** @var MailMessageFactory */
+    private $mailFactory;
+    /** @var Mailer */
+    private $mailer;
+
+    public function __construct(MailMessageFactory $mailFactory, Mailer $mailer)
+    {
+        $this->mailer = $mailer;
+        $this->mailFactory = $mailFactory;
+    }
+
+    public function sendErrorReport(ManageEntity $entity, Exception $exception)
+    {
+        $message = $this->mailFactory->buildJiraIssueFailedMessage($exception, $entity);
+        $this->mailer->send($message);
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/TicketService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/TicketService.php
@@ -18,6 +18,12 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Service;
 
+use Psr\Log\LoggerInterface;
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishEntityProductionCommand;
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishProductionCommandInterface;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Issue;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Ticket;
 
 class TicketService implements TicketServiceInterface
@@ -28,11 +34,17 @@ class TicketService implements TicketServiceInterface
     private $issueRepository;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param TicketServiceInterface $repository
      */
-    public function __construct(TicketServiceInterface $repository)
+    public function __construct(TicketServiceInterface $repository, LoggerInterface $logger)
     {
         $this->issueRepository = $repository;
+        $this->logger = $logger;
     }
 
     public function createIssueFrom(Ticket $ticket)
@@ -61,5 +73,54 @@ class TicketService implements TicketServiceInterface
     public function findByManageIdAndIssueType($manageId, $issueType)
     {
         return $this->issueRepository->findByManageIdAndIssueType($manageId, $issueType);
+    }
+
+    public function createJiraTicket(
+        ManageEntity $entity,
+        PublishProductionCommandInterface $command,
+        string $issueType,
+        string $summaryTranslationKey,
+        string $descriptionTranslationKey
+    ): Issue {
+        $ticket = $this->createTicketFromManageResponse(
+            $command,
+            $entity,
+            $issueType,
+            $summaryTranslationKey,
+            $descriptionTranslationKey
+        );
+
+        $this->logger->info(
+            sprintf('Creating a %s Jira issue for "%s".', $issueType, $entity->getMetaData()->getNameEn())
+        );
+        $issue = null;
+        if ($entity->getId()) {
+            // Before creating an issue, test if we didn't previously create this ticket (users can apply changes to
+            // requested published entities).
+            $issue = $this->findByManageIdAndIssueType($entity->getId(), $issueType);
+        }
+        if (is_null($issue)) {
+            $issue = $this->createIssueFrom($ticket);
+            $this->logger->info(sprintf('Created Jira issue with key: %s', $issue->getKey()));
+            return $issue;
+        }
+        $this->logger->info(sprintf('Found existing Jira issue with key: %s', $issue->getKey()));
+        return $issue;
+    }
+
+    private function createTicketFromManageResponse(
+        PublishProductionCommandInterface $command,
+        ManageEntity $entity,
+        string $issueType,
+        string $summaryTranslationKey,
+        string $descriptionTranslationKey
+    ) {
+        return Ticket::fromManageResponse(
+            $entity,
+            $command->getApplicant(),
+            $issueType,
+            $summaryTranslationKey,
+            $descriptionTranslationKey
+        );
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/TicketServiceInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/TicketServiceInterface.php
@@ -18,6 +18,8 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Service;
 
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishProductionCommandInterface;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Issue;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\IssueCollection;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Ticket;
@@ -59,4 +61,12 @@ interface TicketServiceInterface
      * @param string $issueKey
      */
     public function delete($issueKey);
+
+    public function createJiraTicket(
+        ManageEntity $entity,
+        PublishProductionCommandInterface $command,
+        string $issueType,
+        string $summaryTranslationKey,
+        string $descriptionTranslationKey
+    ): Issue;
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/MetaData.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/MetaData.php
@@ -270,11 +270,13 @@ class MetaData implements Comparable
             'metaDataFields.name:en' => $this->getNameEn(),
         ];
 
-        foreach ($this->getAcsLocations() as $index => $location) {
-            $location = sprintf('metaDataFields.AssertionConsumerService:%d:Location', $index);
-            $binding = sprintf('metaDataFields.AssertionConsumerService:%d:Binding', $index);
-            $data[$location] = $location;
-            $data[$binding] = Constants::BINDING_HTTP_POST;
+        if ($this->getAcsLocations()) {
+            foreach ($this->getAcsLocations() as $index => $location) {
+                $location = sprintf('metaDataFields.AssertionConsumerService:%d:Location', $index);
+                $binding = sprintf('metaDataFields.AssertionConsumerService:%d:Binding', $index);
+                $data[$location] = $location;
+                $data[$binding] = Constants::BINDING_HTTP_POST;
+            }
         }
 
         $data += $this->coin->asArray();

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DependencyInjection/Compiler/IssueRepositoryCompilerPass.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DependencyInjection/Compiler/IssueRepositoryCompilerPass.php
@@ -48,13 +48,6 @@ class IssueRepositoryCompilerPass implements CompilerPassInterface
 
         $isTestModeEnabled = (bool) $container->getParameter(self::ENABLE_TEST_MODE_FEATURE_FLAG);
 
-        $kernelEnv = $container->getParameter('kernel.environment');
-
-        // Web tests, ironically for now do not utilize the test stand-in.
-        if ($kernelEnv === 'test' && $isTestModeEnabled) {
-            $isTestModeEnabled = false;
-        }
-
         if ($isTestModeEnabled) {
             $this->configureServiceInTestMode($container);
         } else {

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -91,7 +91,7 @@ services:
     Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\EntityChangeRequestCommandHandler:
         arguments:
             $repository: '@Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\EntityChangeRequestClient'
-            $issueType: 'TODO create configurable parameter'
+            $issueType: '%jira_issue_type_entity_change_request%'
         tags:
             - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Entity\EntityChangeRequestCommand }
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -467,6 +467,13 @@ entity.publish.request.ticket.description: "h2. Details
 *Applicant email*: %applicant_email%.
 *Entity name (en)*: %entity_name%."
 
+entity.change_request.ticket.summary: "Request for changes for %entity_name%"
+entity.change_request.ticket.description: "h2. Details
+
+*Applicant name*: %applicant_name%
+*Applicant email*: %applicant_email%.
+*Entity name (en)*: %entity_name%."
+
 entity.published_production.text.html: "Thanks for publishing \"%entityName%\" to our production environment."
 entity.published_production.title: "Successfully published the entity to production"
 entity.published_test.text.html: "Thanks for publishing \"%entityName%\" to our test environment."

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Factory/IssueFieldFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Factory/IssueFieldFactory.php
@@ -90,6 +90,7 @@ class IssueFieldFactory
             ->setSummary($this->translateSummary($ticket))
             ->setIssueType($ticket->getIssueType())
             ->setPriorityName($this->priority)
+            ->setReporterName(sprintf('%s, (%s)', $ticket->getApplicantName(), $ticket->getApplicantEmail()))
             ->addCustomField($this->entityIdFieldName, $ticket->getEntityId())
             ->addCustomField($this->manageIdFieldName, $ticket->getManageId())
         ;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/DevelopmentIssueRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/DevelopmentIssueRepository.php
@@ -20,7 +20,9 @@ namespace Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Repository;
 
 use JiraRestApi\JiraException;
 use RuntimeException;
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishProductionCommandInterface;
 use Surfnet\ServiceProviderDashboard\Application\Service\TicketServiceInterface;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Issue;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\IssueCollection;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Ticket;
@@ -64,6 +66,16 @@ class DevelopmentIssueRepository implements TicketServiceInterface
             }
         }
         return new IssueCollection($result);
+    }
+
+    public function createJiraTicket(
+        ManageEntity $entity,
+        PublishProductionCommandInterface $command,
+        string $issueType,
+        string $summaryTranslationKey,
+        string $descriptionTranslationKey
+    ): Issue {
+        return new Issue('KEY-27', 'fake-type', Issue::STATUS_OPEN);
     }
 
     public function findByManageId($manageId)

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/IssueRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/IssueRepository.php
@@ -18,7 +18,9 @@
 
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Repository;
 
+use Surfnet\ServiceProviderDashboard\Application\Command\Entity\PublishProductionCommandInterface;
 use Surfnet\ServiceProviderDashboard\Application\Service\TicketServiceInterface;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Issue;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\IssueCollection;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Ticket;
@@ -158,5 +160,15 @@ class IssueRepository implements TicketServiceInterface
     {
         $issueService = $this->jiraFactory->buildIssueService();
         $issueService->deleteIssue($issueKey);
+    }
+
+    public function createJiraTicket(
+        ManageEntity $entity,
+        PublishProductionCommandInterface $command,
+        string $issueType,
+        string $summaryTranslationKey,
+        string $descriptionTranslationKey
+    ): Issue {
+        // Nothing to do here.
     }
 }

--- a/tests/integration/Application/CommandHandler/Entity/RequestDeletePublishedEntityCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/RequestDeletePublishedEntityCommandHandlerTest.php
@@ -81,7 +81,7 @@ class RequestDeletePublishedEntityCommandHandlerTest extends MockeryTestCase
 
         // As part of the integration test,
         // the TicketService and IssueFieldFactory is not mocked but included in the test.
-        $this->ticketService = new TicketService($this->issueRepository);
+        $this->ticketService = new TicketService($this->issueRepository, $this->logger);
 
         $this->flashBag = m::mock(FlashBagInterface::class);
 

--- a/tests/webtests/EntityDeleteTest.php
+++ b/tests/webtests/EntityDeleteTest.php
@@ -20,10 +20,14 @@ namespace Surfnet\ServiceProviderDashboard\Webtests;
 
 use GuzzleHttp\Psr7\Response;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Protocol;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Repository\DevelopmentIssueRepository;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class EntityDeleteTest extends WebTestCase
 {
+    /** @var DevelopmentIssueRepository */
+    private $ticketService;
+
     public function setUp()
     {
         parent::setUp();
@@ -32,7 +36,7 @@ class EntityDeleteTest extends WebTestCase
         $this->logIn('ROLE_ADMINISTRATOR');
 
         $this->service = $this->getServiceRepository()->findByName('SURFnet');
-
+        $this->ticketService = $this->client->getContainer()->get('surfnet.dashboard.repository.issue');
         $this->switchToService('SURFnet');
     }
 
@@ -106,6 +110,7 @@ class EntityDeleteTest extends WebTestCase
      */
     public function test_request_delete_a_published_production_entity_jira_not_available()
     {
+        $this->ticketService->shouldFailCreateIssue();
         $this->registerManageEntity(
             'production',
             'saml20_sp',


### PR DESCRIPTION
A Jira ticket with a distinctive issue type is created. The actual issue type is yet to be determined, but can be set in the parameters.yml during deployment.

The title and description of the Ticket have been made translatable, a default was added to the default translations file.

See: https://www.pivotaltracker.com/story/show/182411800
See: https://www.pivotaltracker.com/story/show/179749372