### PR TITLE
Clear selected service on service switcher when serving sp dashboard

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -128,6 +128,7 @@ class ServiceController extends Controller
     {
         $allowedServices = $this->authorizationService->getAllowedServiceNamesById();
         $services = $this->serviceService->getServicesByAllowedServices($allowedServices);
+        $this->authorizationService->resetService();
 
         if (empty($services)) {
             return $this->redirectToRoute('service_add');

--- a/tests/webtests/ServiceSwitcherTest.php
+++ b/tests/webtests/ServiceSwitcherTest.php
@@ -122,4 +122,27 @@ class ServiceSwitcherTest extends WebTestCase
 
         $this->assertEquals('SURFnet [surf.nl]', $selectedService->text(), "Service 'SURFnet' should be selected");
     }
+
+    public function test_switcher_has_no_selected_option_when_overview_is_selected()
+    {
+        $this->logIn('ROLE_ADMINISTRATOR');
+        $this->loadFixtures();
+
+        $crawler = $this->client->request('GET', '/service/create');
+        $form = $crawler->filter('.service-switcher form')
+            ->form();
+
+        $form['service_switcher[selected_service_id]']->select(
+            $this->getServiceRepository()->findByName('SURFnet')->getId()
+        );
+
+        $this->client->submit($form);
+
+        $this->client->followRedirect();
+
+        $crawler = $this->client->request('GET', '/');
+        $selectedService = $crawler->filter('select#service-switcher option:selected')->first();
+
+        $this->assertCount(0, $selectedService);
+    }
 }


### PR DESCRIPTION
As soon as you go to spdashboard you will come to the Service overview page. When you select a service and click on the logo the  selected service is cleared and allows you to select any service from the service switcher.

see: https://www.pivotaltracker.com/story/show/182233103