### PR TITLE
Manage the entity attributes commands

### DIFF
--- a/app/config/attributes.json
+++ b/app/config/attributes.json
@@ -210,7 +210,7 @@
     ]
   },
   {
-    "id": "scopedaffiliation",
+    "id": "scopedAffiliation",
     "form" : {
       "translations" : {
         "en": {

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveSamlEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveSamlEntityCommand.php
@@ -25,6 +25,7 @@ use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints as SpDashboardAssert;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
  * @SuppressWarnings(PHPMD.TooManyFields)
@@ -222,12 +223,41 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
     {
     }
 
+    /**
+     * @Assert\Callback()
+     */
+    public function validate(ExecutionContextInterface $context, $payload)
+    {
+        foreach ($this->attributes as $name => $attribute) {
+            if (isset($attribute) && !($attribute instanceof Attribute)) {
+                $context->buildViolation(sprintf('entity.edit.attribute.invalid', $name))
+                    ->atPath('attribute')
+                    ->addViolation();
+            }
+        }
+    }
+
+    /**
+     * The magic getters and setters are consulted by the saml form builder.
+     * Another option would be to implement a dataMapper on the
+     * form or attribute container, but this might lead to needless complexity.
+     */
     public function __set(string $property, ?Attribute $value)
+    {
+        $this->setAttribute($property, $value);
+    }
+
+    public function __get(string $property): ?Attribute
+    {
+        return $this->getAttribute($property);
+    }
+
+    public function setAttribute(string $property, ?Attribute $value)
     {
         $this->attributes[$property] = $value;
     }
 
-    public function __get(string $property): ?Attribute
+    public function getAttribute(string $property): ?Attribute
     {
         if (array_key_exists($property, $this->attributes)) {
             return $this->attributes[$property];
@@ -235,15 +265,6 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
         return null;
     }
 
-    public function setAttribute(string $property, ?Attribute $value)
-    {
-        $this->__set($property, $value);
-    }
-
-    public function getAttribute(string $property): ?Attribute
-    {
-        return $this->__get($property);
-    }
     /**
      * @param Service $service
      * @return SaveSamlEntityCommand

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/LoadMetadataCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/LoadMetadataCommandHandler.php
@@ -24,10 +24,16 @@ use Surfnet\ServiceProviderDashboard\Application\CommandHandler\CommandHandler;
 use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\FetcherInterface;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\ParserInterface;
+use Surfnet\ServiceProviderDashboard\Application\Service\AttributeNameServiceInterface;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Metadata;
 
 class LoadMetadataCommandHandler implements CommandHandler
 {
+    /**
+     * @var AttributeNameServiceInterface
+     */
+    private $attributeNameService;
+
     /**
      * @var FetcherInterface
      */
@@ -43,9 +49,11 @@ class LoadMetadataCommandHandler implements CommandHandler
      * @param ParserInterface $parser
      */
     public function __construct(
+        AttributeNameServiceInterface $attributeNameService,
         FetcherInterface $metadataFetcher,
         ParserInterface $parser
     ) {
+        $this->attributeNameService = $attributeNameService;
         $this->metadataFetcher = $metadataFetcher;
         $this->metadataParser = $parser;
     }
@@ -107,26 +115,13 @@ class LoadMetadataCommandHandler implements CommandHandler
 
     private function mapAttributes(SaveSamlEntityCommand $command, Metadata $metadata)
     {
-        $map = [
-            'emailAddressAttribute' => ['getEmailAddressAttribute', 'setEmailAddressAttribute'],
-            'displayNameAttribute' => ['getDisplayNameAttribute', 'setDisplayNameAttribute'],
-            'affiliationAttribute' => ['getAffiliationAttribute', 'setAffiliationAttribute'],
-            'givenNameAttribute' => ['getGivenNameAttribute', 'setGivenNameAttribute'],
-            'surNameAttribute' => ['getSurNameAttribute', 'setSurNameAttribute'],
-            'commonNameAttribute' => ['getCommonNameAttribute', 'setCommonNameAttribute'],
-            'entitlementAttribute' => ['getEntitlementAttribute', 'setEntitlementAttribute'],
-            'organizationAttribute' => ['getOrganizationAttribute', 'setOrganizationAttribute'],
-            'organizationTypeAttribute' => ['getOrganizationTypeAttribute', 'setOrganizationTypeAttribute'],
-            'organizationUnitAttribute' => ['getOrganizationUnitAttribute', 'setOrganizationUnitAttribute'],
-            'principleNameAttribute' => ['getPrincipleNameAttribute', 'setPrincipleNameAttribute'],
-            'uidAttribute' => ['getUidAttribute', 'setUidAttribute'],
-            'preferredLanguageAttribute' => ['getPreferredLanguageAttribute', 'setPreferredLanguageAttribute'],
-            'personalCodeAttribute' => ['getPersonalCodeAttribute', 'setPersonalCodeAttribute'],
-            'eduPersonTargetedIDAttribute' => ['getEduPersonTargetedIDAttribute', 'setEduPersonTargetedIDAttribute'],
-            'scopedAffiliationAttribute' => ['getScopedAffiliationAttribute', 'setScopedAffiliationAttribute'],
-        ];
+        $attributeNames = $this->attributeNameService->getAttributeTypeNames();
 
-        $this->map($map, $command, $metadata);
+        foreach ($attributeNames as $attributeName) {
+            if (property_exists($metadata, $attributeName)) {
+                $command->setAttribute($attributeName, $metadata->$attributeName);
+            }
+        }
     }
 
     private function mapContacts(SaveSamlEntityCommand $command, Metadata $metadata)

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
@@ -44,7 +44,7 @@ class ArpGenerator implements MetadataGenerator
         $attributes = [];
         $entityAttributes = $entity->getAttributes();
         foreach ($this->attributeRepository->findAll() as $definition) {
-            $urns = $definition->getUrns();
+            $urns = $definition->urns;
             $urn = reset($urns);
             $attributeList = $entityAttributes->findAllByUrn($urn);
             // Only add the attributes with a motivation
@@ -80,8 +80,8 @@ class ArpGenerator implements MetadataGenerator
 
     private function addManageOnlyAttributes(array &$attributes, ManageEntity $entity)
     {
-        $spDashboardTracked = $this->attributeRepository->findAllNameSpaceIdentifiers();
         $originalAttributes = $entity->getAttributes()->getOriginalAttributes();
+        $spDashboardTracked = $this->attributeRepository->findAllNameSpaceIdentifiers();
         $nonTrackedUrns = array_diff(array_keys($originalAttributes), $spDashboardTracked);
 
         foreach ($nonTrackedUrns as $urn) {

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
@@ -19,6 +19,7 @@
 namespace Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator;
 
 use stdClass;
+use Surfnet\ServiceProviderDashboard\Application\Service\AttributeServiceInterface;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\AttributeRepository;
 use function array_diff;
@@ -30,22 +31,20 @@ use function array_keys;
 class ArpGenerator implements MetadataGenerator
 {
     /**
-     * @var AttributeRepository
+     * @var AttributeServiceInterface
      */
-    private $attributeRepository;
+    private $attributeService;
 
-    public function __construct(AttributeRepository $repository)
+    public function __construct(AttributeServiceInterface $attributeService)
     {
-        $this->attributeRepository = $repository;
+        $this->attributeService = $attributeService;
     }
 
     public function build(ManageEntity $entity): array
     {
         $attributes = [];
         $entityAttributes = $entity->getAttributes();
-        foreach ($this->attributeRepository->findAll() as $definition) {
-            $urns = $definition->urns;
-            $urn = reset($urns);
+        foreach ($this->attributeService->getUrns() as $urn) {
             $attributeList = $entityAttributes->findAllByUrn($urn);
             // Only add the attributes with a motivation
             foreach ($attributeList as $attribute) {
@@ -81,7 +80,7 @@ class ArpGenerator implements MetadataGenerator
     private function addManageOnlyAttributes(array &$attributes, ManageEntity $entity)
     {
         $originalAttributes = $entity->getAttributes()->getOriginalAttributes();
-        $spDashboardTracked = $this->attributeRepository->findAllNameSpaceIdentifiers();
+        $spDashboardTracked = $this->attributeService->getUrns();
         $nonTrackedUrns = array_diff(array_keys($originalAttributes), $spDashboardTracked);
 
         foreach ($nonTrackedUrns as $urn) {

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/AttributeNameService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/AttributeNameService.php
@@ -41,7 +41,7 @@ class AttributeNameService implements AttributeNameServiceInterface
 
         $attributeNames = [];
         foreach ($attributes ?? [] as $attribute) {
-            $attributeNames[] = $attribute->id . Constants::ATTRIBUTE_NAME_SUFFIX;
+            $attributeNames[] = $attribute->id . AttributeNameServiceInterface::ATTRIBUTE_NAME_SUFFIX;
         }
         return $attributeNames;
     }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/AttributeNameService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/AttributeNameService.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Service;
+
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\AttributeRepository;
+
+class AttributeNameService implements AttributeNameServiceInterface
+{
+    /**
+     * @var AttributeRepository
+     */
+    private $attributeRepository;
+
+    public function __construct(AttributeRepository $attributeRepository)
+    {
+        $this->attributeRepository = $attributeRepository;
+    }
+
+    public function getAttributeTypeNames(): array
+    {
+        $attributes = $this->attributeRepository->findAll();
+
+        $attributeNames = [];
+        foreach ($attributes ?? [] as $attribute) {
+            $attributeNames[] = $attribute->id . Constants::ATTRIBUTE_NAME_SUFFIX;
+        }
+        return $attributeNames;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/AttributeNameServiceInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/AttributeNameServiceInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Service;
+
+interface AttributeNameServiceInterface
+{
+    public function getAttributeTypeNames(): array;
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/AttributeNameServiceInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/AttributeNameServiceInterface.php
@@ -22,5 +22,7 @@ namespace Surfnet\ServiceProviderDashboard\Application\Service;
 
 interface AttributeNameServiceInterface
 {
+    const ATTRIBUTE_NAME_SUFFIX = 'Attribute';
+
     public function getAttributeTypeNames(): array;
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/AttributeService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/AttributeService.php
@@ -74,4 +74,14 @@ class AttributeService implements AttributeServiceInterface
         }
         return $entityMergeAttributes;
     }
+
+    public function getUrns(): array
+    {
+        $urns = [];
+        $attributes = $this->getAttributeTypeAttributes();
+        foreach ($attributes as $attribute) {
+            $urns[] = $attribute->getUrns()[0];
+        }
+        return $urns;
+    }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/AttributeService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/AttributeService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright 2022 SURFnet B.V.
  *
@@ -19,6 +21,7 @@
 namespace Surfnet\ServiceProviderDashboard\Application\Service;
 
 use Surfnet\ServiceProviderDashboard\Application\ViewObject\Attribute;
+use Surfnet\ServiceProviderDashboard\Application\Service\ValueObject\EntityMergeAttribute;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\AttributeRepository;
 
 class AttributeService implements AttributeServiceInterface
@@ -47,9 +50,28 @@ class AttributeService implements AttributeServiceInterface
             $attributes = $this->attributeRepository->findAll();
 
             foreach ($attributes as $value) {
-                $this->attributes[$value->id] = Attribute::fromAttribute($value, $value->form->languages[$this->language]);
+                $this->attributes[$value->id] = Attribute::fromAttribute(
+                    $value,
+                    $value->form->languages[$this->language]
+                );
             }
         }
         return $this->attributes;
+    }
+
+    /**
+     * @return EntityMergeAttribute[]
+     */
+    public function getEntityMergeAttributes(): array
+    {
+        $entityMergeAttributes = [];
+        $attributes = $this->getAttributeTypeAttributes();
+        foreach ($attributes as $attribute) {
+            $entityMergeAttributes[] = EntityMergeAttribute::fromAttribute(
+                $attribute->getName(),
+                $attribute->getUrns()[0]
+            );
+        }
+        return $entityMergeAttributes;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/AttributeServiceInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/AttributeServiceInterface.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Service;
 
+use Surfnet\ServiceProviderDashboard\Application\Service\ValueObject\EntityMergeAttribute;
 use Surfnet\ServiceProviderDashboard\Application\ViewObject\Attribute;
 
 interface AttributeServiceInterface
@@ -26,4 +27,11 @@ interface AttributeServiceInterface
      * @return Attribute[]
      */
     public function getAttributeTypeAttributes(): array;
+
+    /**
+     * @return EntityMergeAttribute[]
+     */
+    public function getEntityMergeAttributes(): array;
+
+    public function getUrns(): array;
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityMergeService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityMergeService.php
@@ -39,7 +39,6 @@ use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\MetaData;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\NullSecret;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Secret;
-use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\AttributeRepository;
 use function in_array;
 
 /**
@@ -48,9 +47,9 @@ use function in_array;
 class EntityMergeService
 {
     /**
-     * @var AttributeRepository
+     * @var AttributeServiceInterface
      */
-    private $attributeRepository;
+    private $attributeService;
 
     /**
      * @var string
@@ -63,11 +62,11 @@ class EntityMergeService
     private $playGroundUriProd;
 
     public function __construct(
-        AttributeRepository $attributeRepository,
+        AttributeServiceInterface $attributeService,
         string $oidcPlaygroundUriTest,
         string $oidcPlaygroundUriProd
     ) {
-        $this->attributeRepository = $attributeRepository;
+        $this->attributeService = $attributeService;
         $this->playGroundUriTest = $oidcPlaygroundUriTest;
         $this->playGroundUriProd = $oidcPlaygroundUriProd;
     }
@@ -177,7 +176,7 @@ class EntityMergeService
             return $attributeList;
         }
 
-        foreach ($this->attributeRepository->findAll() as $definition) {
+        foreach ($this->attributeService->getAttributeTypeAttributes() as $definition) {
             $attributeName = $definition->getName();
 
             if ($command->getAttribute($attributeName)) {

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityMergeService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityMergeService.php
@@ -124,14 +124,14 @@ class EntityMergeService
                 $command->getAccessTokenValidity(),
                 $command->getOidcngResourceServers()
             );
-        } else if ($protocol->getProtocol() === Constants::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER) {
+        } elseif ($protocol->getProtocol() === Constants::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER) {
             /** @var SaveOidcngResourceServerEntityCommand  $command */
             $oidcClient = new OidcngResourceServerClient(
                 $command->getClientId(),
                 $secret->getSecret(),
                 []
             );
-        } else if ($protocol->getProtocol() === Constants::TYPE_OAUTH_CLIENT_CREDENTIAL_CLIENT) {
+        } elseif ($protocol->getProtocol() === Constants::TYPE_OAUTH_CLIENT_CREDENTIAL_CLIENT) {
             /** @var SaveOauthClientCredentialClientCommand $command */
             $oidcClient = new OauthClientCredentialsClientClient(
                 $command->getClientId(),
@@ -176,14 +176,15 @@ class EntityMergeService
             return $attributeList;
         }
 
-        foreach ($this->attributeService->getAttributeTypeAttributes() as $definition) {
-            $attributeName = $definition->getName();
-
-            if ($command->getAttribute($attributeName)) {
-                $commandAttribute = $command->getAttribute($attributeName);
-                $urns = $definition->getUrns();
-                $urn = reset($urns);
-                $attributeList->add(new Attribute($urn, '', 'idp', $commandAttribute->getMotivation()));
+        foreach ($this->attributeService->getEntityMergeAttributes() as $entityMergeAttribute) {
+            if ($command->getAttribute($entityMergeAttribute->getName())) {
+                $commandAttribute = $command->getAttribute($entityMergeAttribute->getName());
+                $attributeList->add(new Attribute(
+                    $entityMergeAttribute->getUrn(),
+                    '',
+                    'idp',
+                    $commandAttribute->getMotivation()
+                ));
             }
         }
         return $attributeList;

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/ValueObject/EntityMergeAttribute.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/ValueObject/EntityMergeAttribute.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Surfnet\ServiceProviderDashboard\Application\Service\ValueObject;
+
+class EntityMergeAttribute
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $urn;
+
+    public function __construct(
+        string $name,
+        string $urn
+    ) {
+        $this->name = $name;
+        $this->urn = $urn;
+    }
+
+    public static function fromAttribute(
+        $name,
+        $urn
+    ): EntityMergeAttribute {
+
+        return new self(
+            $name,
+            $urn
+        );
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getUrn(): string
+    {
+        return $this->urn;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Constants.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Constants.php
@@ -46,8 +46,6 @@ class Constants
 
     const OIDC_SECRET_LENGTH = 20;
 
-    const ATTRIBUTE_NAME_SUFFIX = 'Attribute';
-
     public static function getValidNameIdFormats()
     {
         return [

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Constants.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Constants.php
@@ -46,6 +46,8 @@ class Constants
 
     const OIDC_SECRET_LENGTH = 20;
 
+    const ATTRIBUTE_NAME_SUFFIX = 'Attribute';
+
     public static function getValidNameIdFormats()
     {
         return [

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/MetaData.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/MetaData.php
@@ -257,6 +257,18 @@ class MetaData implements Comparable
         return $acsLocations;
     }
 
+    private function asArrayAcsLocations(): array
+    {
+        $data = [];
+        foreach ($this->getAcsLocations() ?? [] as $index => $location) {
+            $location = sprintf('metaDataFields.AssertionConsumerService:%d:Location', $index);
+            $binding = sprintf('metaDataFields.AssertionConsumerService:%d:Binding', $index);
+            $data[$location] = $location;
+            $data[$binding] = Constants::BINDING_HTTP_POST;
+        }
+        return $data;
+    }
+
     public function asArray(): array
     {
         $data = [
@@ -270,15 +282,7 @@ class MetaData implements Comparable
             'metaDataFields.name:en' => $this->getNameEn(),
         ];
 
-        if ($this->getAcsLocations()) {
-            foreach ($this->getAcsLocations() as $index => $location) {
-                $location = sprintf('metaDataFields.AssertionConsumerService:%d:Location', $index);
-                $binding = sprintf('metaDataFields.AssertionConsumerService:%d:Binding', $index);
-                $data[$location] = $location;
-                $data[$binding] = Constants::BINDING_HTTP_POST;
-            }
-        }
-
+        $data += $this->asArrayAcsLocations();
         $data += $this->coin->asArray();
         $data += $this->contacts->asArray();
         $data += $this->logo->asArray();

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/AttributeTypeFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/AttributeTypeFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright 2022 SURFnet B.V.
  *
@@ -20,7 +22,6 @@ namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\E
 
 use \Surfnet\ServiceProviderDashboard\Application\Service\AttributeServiceInterface;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormTypeInterface;
 
 class AttributeTypeFactory
 {

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
@@ -19,10 +19,8 @@
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity;
 
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngEntityCommand;
-use Surfnet\ServiceProviderDashboard\Application\Service\AttributeServiceInterface;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\OidcngClient;
-use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
@@ -29,7 +29,6 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Repository/AttributeRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Repository/AttributeRepository.php
@@ -51,13 +51,4 @@ class AttributeRepository implements AttributeRepositoryInterface
     {
         return $this->getAttributes();
     }
-
-    public function findAllNameSpaceIdentifiers(): array
-    {
-        $nameSpaceIdentifiers = [];
-        foreach ($this->getAttributes() as $attribute) {
-            $nameSpaceIdentifiers[] = $attribute->urns[0];
-        }
-        return $nameSpaceIdentifiers;
-    }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -70,6 +70,7 @@ services:
         class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\LoadMetadataCommandHandler
         public: true
         arguments:
+            - '@Surfnet\ServiceProviderDashboard\Application\Service\AttributeNameService'
             - '@Surfnet\ServiceProviderDashboard\Legacy\Metadata\Fetcher'
             - '@Surfnet\ServiceProviderDashboard\Legacy\Metadata\Parser'
         tags:
@@ -333,6 +334,10 @@ services:
         arguments:
             - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\AttributeRepository'
             - '%locale%'
+
+    Surfnet\ServiceProviderDashboard\Application\Service\AttributeNameService:
+        arguments:
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\AttributeRepository'
 
     Surfnet\ServiceProviderDashboard\Application\Service\LoadEntityService:
         arguments:

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -361,6 +361,7 @@ entity.edit.attributes.oauth20_rs.html: "
 
 <p><i>Identity Providers will be informed about the attributes your service requests and must agree to the release of these attributes to your entity.</i></p>
 "
+entity.edit.attribute.invalid: The provided attribute % is invalid
 entity.change_requested.title: Your change request has been submitted for review
 entity.change_requested.text.html: "<p>As you where editing a production entity, we have taken your changes under review.</p>"
 entity.edit.comments.title: Comments

--- a/src/Surfnet/ServiceProviderDashboard/Legacy/Metadata/Parser.php
+++ b/src/Surfnet/ServiceProviderDashboard/Legacy/Metadata/Parser.php
@@ -24,10 +24,10 @@ use SimpleXMLElement;
 use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\CertificateParserInterface;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\ParserInterface;
+use Surfnet\ServiceProviderDashboard\Application\Service\AttributeService;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Metadata;
-use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\AttributeRepository;
 use Surfnet\ServiceProviderDashboard\Legacy\Metadata\Exception\ParserException;
 
 class Parser implements ParserInterface
@@ -53,9 +53,9 @@ class Parser implements ParserInterface
     private $certParser;
 
     /**
-     * @var AttributeRepository
+     * @var AttributeService
      */
-    private $attributeRepository;
+    private $attributeService;
 
     /**
      * @var string
@@ -69,12 +69,12 @@ class Parser implements ParserInterface
 
     public function __construct(
         CertificateParserInterface $certParser,
-        AttributesRepository $attributeRepository,
+        AttributeService $attributeService,
         string $schemaLocation,
         LoggerInterface $logger
     ) {
         $this->certParser = $certParser;
-        $this->attributeRepository = $attributeRepository;
+        $this->attributeService = $attributeService;
         $this->schemaLocation = $schemaLocation;
         $this->logger = $logger;
     }
@@ -325,14 +325,14 @@ class Parser implements ParserInterface
      */
     private function parseAttributes($descriptor, Metadata $metadata)
     {
-        foreach ($descriptor->AttributeConsumingService->RequestedAttribute as $attribute) {
+        foreach ($descriptor->AttributeConsumingService->RequestedAttribute as $requestedAttribute) {
             $attr = new Attribute();
             $attr->setRequested(true);
             $attr->setMotivation('');
 
-            $attributes = $attribute->attributes();
+            $attributes = $requestedAttribute->attributes();
 
-            foreach ($this->attributeRepository->findAll() as $attribute) {
+            foreach ($this->attributeService->getAttributeTypeAttributes() as $attribute) {
                 if (in_array($attributes['Name'], $attribute->getUrns())) {
                     $metadata->{$attribute->getName()} = $attr;
                 }

--- a/tests/integration/Legacy/Metadata/ParserTest.php
+++ b/tests/integration/Legacy/Metadata/ParserTest.php
@@ -44,7 +44,7 @@ class ParserTest extends MockeryTestCase
         $this->logger = m::mock(LoggerInterface::class);
 
         $rootDir = __DIR__.'/../../../../app/Resources/';
-        $attributeRepository = new AttributeRepository(__DIR__ . '/../../../../app/config/attributes.json');
+        $attributeRepository = new AttributeRepository(__DIR__ . '/fixture/attributes.json');
         $this->parser = new Parser(
             new CertificateParser(),
             new AttributeService($attributeRepository, 'en'),

--- a/tests/integration/Legacy/Metadata/ParserTest.php
+++ b/tests/integration/Legacy/Metadata/ParserTest.php
@@ -22,9 +22,10 @@ use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Psr\Log\LoggerInterface;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Metadata;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\AttributeRepository;
+use Surfnet\ServiceProviderDashboard\Application\Service\AttributeService;
 use Surfnet\ServiceProviderDashboard\Legacy\Metadata\CertificateParser;
 use Surfnet\ServiceProviderDashboard\Legacy\Metadata\Parser;
-use Surfnet\ServiceProviderDashboard\Legacy\Repository\AttributesMetadataRepository;
 
 class ParserTest extends MockeryTestCase
 {
@@ -43,9 +44,10 @@ class ParserTest extends MockeryTestCase
         $this->logger = m::mock(LoggerInterface::class);
 
         $rootDir = __DIR__.'/../../../../app/Resources/';
+        $attributeRepository = new AttributeRepository(__DIR__ . '/../../../../app/config/attributes.json');
         $this->parser = new Parser(
             new CertificateParser(),
-            new AttributesMetadataRepository($rootDir),
+            new AttributeService($attributeRepository, 'en'),
             $rootDir,
             $this->logger
         );

--- a/tests/integration/Legacy/Metadata/fixture/attributes.json
+++ b/tests/integration/Legacy/Metadata/fixture/attributes.json
@@ -1,0 +1,245 @@
+[
+  {
+    "id": "givenName",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Given name attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:givenName",
+      "urn:oid:2.5.4.42"
+    ]
+  },
+  {
+    "id": "surName",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Sur name attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:sn",
+      "urn:oid:2.5.4.4"
+    ]
+  },
+  {
+    "id": "commonName",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Common name attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:cn",
+      "urn:oid:2.5.4.3"
+    ]
+  },
+  {
+    "id": "displayName",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Display name attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:displayName",
+      "urn:oid:2.16.840.1.113730.3.1.241"
+    ]
+  },
+  {
+    "id": "emailAddress",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Email address attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:mail",
+      "urn:oid:0.9.2342.19200300.100.1.3"
+    ]
+  },
+  {
+    "id": "organization",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Organization attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:terena.org:attribute-def:schacHomeOrganization",
+      "urn:oid:1.3.6.1.4.1.25178.1.2.9"
+    ]
+  },
+  {
+    "id": "organizationType",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Organization  type attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:terena.org:attribute-def:schacHomeOrganizationType",
+      "urn:oid:1.3.6.1.4.1.25178.1.2.10"
+    ]
+  },
+  {
+    "id": "organizationUnit",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Organization unit attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:ou",
+      "urn:oid:1.3.6.1.4.1.25178.1.2.10"
+    ]
+  },
+  {
+    "id": "affiliation",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Affiliation attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:eduPersonAffiliation",
+      "urn:oid:1.3.6.1.4.1.5923.1.1.1.1"
+    ]
+  },
+  {
+    "id": "entitlement",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Entitlement attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:eduPersonEntitlement",
+      "urn:oid:1.3.6.1.4.1.5923.1.1.1.7"
+    ]
+  },
+  {
+    "id": "principleName",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Principle name attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:eduPersonPrincipalName",
+      "urn:oid:1.3.6.1.4.1.5923.1.1.1.6"
+    ]
+  },
+  {
+    "id": "uid",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Uid attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:uid",
+      "urn:oid:0.9.2342.19200300.100.1.1"
+    ]
+  },
+  {
+    "id": "preferredLanguage",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Preferred language attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:preferredLanguage",
+      "urn:oid:2.16.840.1.113730.3.1.39"
+    ]
+  },
+  {
+    "id": "personalCode",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Personal code attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:schac:attribute-def:schacPersonalUniqueCode",
+      "urn:oid:1.3.6.1.4.1.1466.155.121.1.15"
+    ]
+  },
+  {
+    "id": "scopedAffiliation",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Scoped affiliation attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:eduPersonScopedAffiliation",
+      "urn:oid:1.3.6.1.4.1.5923.1.1.1.9"
+    ]
+  },
+  {
+    "id": "eduPersonTargetedID",
+    "form" : {
+      "excludeOnEntityType": [
+        "oidcng"
+      ],
+      "translations" : {
+        "en": {
+          "label": "Edu person targeted ID attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:eduPersonTargetedID",
+      "urn:oid:1.3.6.1.4.1.5923.1.1.1.10"
+    ]
+  }
+]

--- a/tests/unit/Application/Metadata/JsonGenerator/ArpGeneratorTest.php
+++ b/tests/unit/Application/Metadata/JsonGenerator/ArpGeneratorTest.php
@@ -36,7 +36,7 @@ class ArpGeneratorTest extends MockeryTestCase
 
     public function setUp()
     {
-        $this->attributeRepository = new AttributeRepository(__DIR__ . '/../../../../../app/Resources/metadata');
+        $this->attributeRepository = new AttributeRepository(__DIR__ . '/../../../../../app/config/attributes.json');
     }
     public function test_it_can_build_arp_metadata()
     {

--- a/tests/unit/Application/Metadata/JsonGenerator/ArpGeneratorTest.php
+++ b/tests/unit/Application/Metadata/JsonGenerator/ArpGeneratorTest.php
@@ -36,7 +36,7 @@ class ArpGeneratorTest extends MockeryTestCase
 
     public function setUp()
     {
-        $this->attributeRepository = new AttributeRepository(__DIR__ . '/../../../../../app/config/attributes.json');
+        $this->attributeRepository = new AttributeRepository(__DIR__ . '/../fixture/attributes.json');
     }
     public function test_it_can_build_arp_metadata()
     {

--- a/tests/unit/Application/Metadata/JsonGenerator/ArpGeneratorTest.php
+++ b/tests/unit/Application/Metadata/JsonGenerator/ArpGeneratorTest.php
@@ -22,6 +22,7 @@ use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use stdClass;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\ArpGenerator;
+use Surfnet\ServiceProviderDashboard\Application\Service\AttributeService;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Attribute;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
@@ -34,9 +35,15 @@ class ArpGeneratorTest extends MockeryTestCase
      */
     private $attributeRepository;
 
+    /**
+     * @return AttributeService
+     */
+    private $attributeService;
+
     public function setUp()
     {
         $this->attributeRepository = new AttributeRepository(__DIR__ . '/../fixture/attributes.json');
+        $this->attributeService = new AttributeService($this->attributeRepository, 'en');
     }
     public function test_it_can_build_arp_metadata()
     {
@@ -59,7 +66,7 @@ class ArpGeneratorTest extends MockeryTestCase
         $entity->shouldReceive('getAttributes->getOriginalAttributes')->andReturn([]);
         $entity->shouldReceive('getAttributes->findAllByUrn')->andReturn([]);
 
-        $factory = new ArpGenerator($this->attributeRepository);
+        $factory = new ArpGenerator($this->attributeService);
 
         $metadata = $factory->build($entity);
 
@@ -71,7 +78,7 @@ class ArpGeneratorTest extends MockeryTestCase
 
     public function test_does_not_override_existing_manage_attributes_and_sources()
     {
-        $factory = new ArpGenerator($this->attributeRepository);
+        $factory = new ArpGenerator($this->attributeService);
         $manageEntity = $this->getManageEntity();
         $metadata = $factory->build($manageEntity);
 
@@ -95,7 +102,7 @@ class ArpGeneratorTest extends MockeryTestCase
     {
         $entity = $this->getManageEntity(Constants::TYPE_OPENID_CONNECT_TNG, false);
 
-        $factory = new ArpGenerator($this->attributeRepository);
+        $factory = new ArpGenerator($this->attributeService);
 
         $metadata = $factory->build($entity);
 

--- a/tests/unit/Application/Metadata/fixture/attributes.json
+++ b/tests/unit/Application/Metadata/fixture/attributes.json
@@ -1,0 +1,245 @@
+[
+  {
+    "id": "givenName",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Given name attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:givenName",
+      "urn:oid:2.5.4.42"
+    ]
+  },
+  {
+    "id": "surName",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Sur name attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:sn",
+      "urn:oid:2.5.4.4"
+    ]
+  },
+  {
+    "id": "commonName",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Common name attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:cn",
+      "urn:oid:2.5.4.3"
+    ]
+  },
+  {
+    "id": "displayName",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Display name attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:displayName",
+      "urn:oid:2.16.840.1.113730.3.1.241"
+    ]
+  },
+  {
+    "id": "emailAddress",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Email address attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:mail",
+      "urn:oid:0.9.2342.19200300.100.1.3"
+    ]
+  },
+  {
+    "id": "organization",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Organization attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:terena.org:attribute-def:schacHomeOrganization",
+      "urn:oid:1.3.6.1.4.1.25178.1.2.9"
+    ]
+  },
+  {
+    "id": "organizationType",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Organization  type attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:terena.org:attribute-def:schacHomeOrganizationType",
+      "urn:oid:1.3.6.1.4.1.25178.1.2.10"
+    ]
+  },
+  {
+    "id": "organizationUnit",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Organization unit attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:ou",
+      "urn:oid:1.3.6.1.4.1.25178.1.2.10"
+    ]
+  },
+  {
+    "id": "affiliation",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Affiliation attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:eduPersonAffiliation",
+      "urn:oid:1.3.6.1.4.1.5923.1.1.1.1"
+    ]
+  },
+  {
+    "id": "entitlement",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Entitlement attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:eduPersonEntitlement",
+      "urn:oid:1.3.6.1.4.1.5923.1.1.1.7"
+    ]
+  },
+  {
+    "id": "principleName",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Principle name attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:eduPersonPrincipalName",
+      "urn:oid:1.3.6.1.4.1.5923.1.1.1.6"
+    ]
+  },
+  {
+    "id": "uid",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Uid attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:uid",
+      "urn:oid:0.9.2342.19200300.100.1.1"
+    ]
+  },
+  {
+    "id": "preferredLanguage",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Preferred language attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:preferredLanguage",
+      "urn:oid:2.16.840.1.113730.3.1.39"
+    ]
+  },
+  {
+    "id": "personalCode",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Personal code attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:schac:attribute-def:schacPersonalUniqueCode",
+      "urn:oid:1.3.6.1.4.1.1466.155.121.1.15"
+    ]
+  },
+  {
+    "id": "scopedAffiliation",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Scoped affiliation attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:eduPersonScopedAffiliation",
+      "urn:oid:1.3.6.1.4.1.5923.1.1.1.9"
+    ]
+  },
+  {
+    "id": "eduPersonTargetedID",
+    "form" : {
+      "excludeOnEntityType": [
+        "oidcng"
+      ],
+      "translations" : {
+        "en": {
+          "label": "Edu person targeted ID attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:eduPersonTargetedID",
+      "urn:oid:1.3.6.1.4.1.5923.1.1.1.10"
+    ]
+  }
+]

--- a/tests/unit/Application/Service/EntityMergeServiceTest.php
+++ b/tests/unit/Application/Service/EntityMergeServiceTest.php
@@ -36,7 +36,7 @@ class EntityMergeServiceTest extends TestCase
 
     protected function setUp()
     {
-        $attributeRepository = new AttributeRepository(__DIR__ . '/../../../../app/config/attributes.json');
+        $attributeRepository = new AttributeRepository(__DIR__ . '/fixture/attributes.json');
         $attributeService = new AttributeService($attributeRepository, 'en');
         $this->service = new EntityMergeService($attributeService, 'test', 'prod');
         parent::setUp();

--- a/tests/unit/Application/Service/EntityMergeServiceTest.php
+++ b/tests/unit/Application/Service/EntityMergeServiceTest.php
@@ -21,7 +21,7 @@ namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Application\Service;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveSamlEntityCommand;
-use Surfnet\ServiceProviderDashboard\Application\Service\AttributeServiceInterface;
+use Surfnet\ServiceProviderDashboard\Application\Service\AttributeService;
 use Surfnet\ServiceProviderDashboard\Application\Service\EntityMergeService;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
@@ -36,14 +36,15 @@ class EntityMergeServiceTest extends TestCase
 
     protected function setUp()
     {
-        $attributeRepository = new AttributeRepository(__DIR__ . '/../../../../app/Resources/metadata');
-        $this->service = new EntityMergeService($attributeRepository, 'test', 'prod');
+        $attributeRepository = new AttributeRepository(__DIR__ . '/../../../../app/config/attributes.json');
+        $attributeService = new AttributeService($attributeRepository, 'en');
+        $this->service = new EntityMergeService($attributeService, 'test', 'prod');
         parent::setUp();
     }
 
     public function test_can_create_service()
     {
-        $service = new EntityMergeService(m::mock(AttributeRepository::class), 'test', 'prod');
+        $service = new EntityMergeService(m::mock(AttributeService::class), 'test', 'prod');
         self::assertInstanceOf(EntityMergeService::class, $service);
     }
 

--- a/tests/unit/Application/Service/fixture/attributes.json
+++ b/tests/unit/Application/Service/fixture/attributes.json
@@ -1,0 +1,245 @@
+[
+  {
+    "id": "givenName",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Given name attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:givenName",
+      "urn:oid:2.5.4.42"
+    ]
+  },
+  {
+    "id": "surName",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Sur name attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:sn",
+      "urn:oid:2.5.4.4"
+    ]
+  },
+  {
+    "id": "commonName",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Common name attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:cn",
+      "urn:oid:2.5.4.3"
+    ]
+  },
+  {
+    "id": "displayName",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Display name attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:displayName",
+      "urn:oid:2.16.840.1.113730.3.1.241"
+    ]
+  },
+  {
+    "id": "emailAddress",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Email address attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:mail",
+      "urn:oid:0.9.2342.19200300.100.1.3"
+    ]
+  },
+  {
+    "id": "organization",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Organization attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:terena.org:attribute-def:schacHomeOrganization",
+      "urn:oid:1.3.6.1.4.1.25178.1.2.9"
+    ]
+  },
+  {
+    "id": "organizationType",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Organization  type attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:terena.org:attribute-def:schacHomeOrganizationType",
+      "urn:oid:1.3.6.1.4.1.25178.1.2.10"
+    ]
+  },
+  {
+    "id": "organizationUnit",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Organization unit attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:ou",
+      "urn:oid:1.3.6.1.4.1.25178.1.2.10"
+    ]
+  },
+  {
+    "id": "affiliation",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Affiliation attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:eduPersonAffiliation",
+      "urn:oid:1.3.6.1.4.1.5923.1.1.1.1"
+    ]
+  },
+  {
+    "id": "entitlement",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Entitlement attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:eduPersonEntitlement",
+      "urn:oid:1.3.6.1.4.1.5923.1.1.1.7"
+    ]
+  },
+  {
+    "id": "principleName",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Principle name attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:eduPersonPrincipalName",
+      "urn:oid:1.3.6.1.4.1.5923.1.1.1.6"
+    ]
+  },
+  {
+    "id": "uid",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Uid attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:uid",
+      "urn:oid:0.9.2342.19200300.100.1.1"
+    ]
+  },
+  {
+    "id": "preferredLanguage",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Preferred language attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:preferredLanguage",
+      "urn:oid:2.16.840.1.113730.3.1.39"
+    ]
+  },
+  {
+    "id": "personalCode",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Personal code attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:schac:attribute-def:schacPersonalUniqueCode",
+      "urn:oid:1.3.6.1.4.1.1466.155.121.1.15"
+    ]
+  },
+  {
+    "id": "scopedAffiliation",
+    "form" : {
+      "translations" : {
+        "en": {
+          "label": "Scoped affiliation attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:eduPersonScopedAffiliation",
+      "urn:oid:1.3.6.1.4.1.5923.1.1.1.9"
+    ]
+  },
+  {
+    "id": "eduPersonTargetedID",
+    "form" : {
+      "excludeOnEntityType": [
+        "oidcng"
+      ],
+      "translations" : {
+        "en": {
+          "label": "Edu person targeted ID attribute",
+          "info": "Text should be set in web translations"
+        }
+      }
+    },
+    "urns": [
+      "urn:mace:dir:attribute-def:eduPersonTargetedID",
+      "urn:oid:1.3.6.1.4.1.5923.1.1.1.10"
+    ]
+  }
+]

--- a/tests/unit/Infrastructure/DashboardBundle/Dto/AttributeTypeInformationTest.php
+++ b/tests/unit/Infrastructure/DashboardBundle/Dto/AttributeTypeInformationTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\DashboardBundle\Dto;
+
+use PHPUnit\Framework\TestCase;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Dto\AttributeTypeInformation;
+
+class AttributeTypeInformationTest extends TestCase
+{
+    public function test_it_is_created()
+    {
+        $en = [
+                'label' => 'emailAddressAttribute',
+                'info' => 'Description is placed here'
+        ];
+        $language = AttributeTypeInformation::fromLanguage($en, 'en');
+
+        $this->assertEquals('emailAddressAttribute', $language->label);
+        $this->assertEquals('Description is placed here', $language->info);
+    }
+}


### PR DESCRIPTION
The existing saml and oidc entity forms let loose their data into corresponding Command objects. These objects now also enumerate every possible Attribute.  Now these attributes are removed from the commands and replaces by an Attribute array which is loaded from the attributes.json config. 

The saml and oidc form use the magic setter and getter of the command objects. On their turn these magic getter and setter use a more readable and useful local setter and getter. Perhaps a more elegant solution is possible after migration of the project to version 5 or higher by using PropertyAccessors in the form, or the 'getter' and 'setter' features of the form builder. Ideally the magic getter and setter could possibly be removed.

Some simple validation is done on the attributes by using a assertion call back on the properties of the saml and oidc commands.

see: https://www.pivotaltracker.com/story/show/182220241