### PR TITLE
Load manage entity attributes using dynamic attributes

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/LoadMetadataCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/LoadMetadataCommandHandler.php
@@ -25,6 +25,7 @@ use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentExcept
 use Surfnet\ServiceProviderDashboard\Application\Metadata\FetcherInterface;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\ParserInterface;
 use Surfnet\ServiceProviderDashboard\Application\Service\AttributeNameServiceInterface;
+use Surfnet\ServiceProviderDashboard\Domain\Exception\AttributeNotFoundException;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Metadata;
 
 class LoadMetadataCommandHandler implements CommandHandler
@@ -118,7 +119,11 @@ class LoadMetadataCommandHandler implements CommandHandler
         $attributeNames = $this->attributeNameService->getAttributeTypeNames();
 
         foreach ($attributeNames as $attributeName) {
-            $command->setAttribute($attributeName, $metadata->getAttribute($attributeName));
+            try {
+                $command->setAttribute($attributeName, $metadata->getAttribute($attributeName));
+            } catch (AttributeNotFoundException $ignored) {
+                // just continue, apparently attribute is not available at the metadata
+            }
         }
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/LoadMetadataCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/LoadMetadataCommandHandler.php
@@ -118,9 +118,7 @@ class LoadMetadataCommandHandler implements CommandHandler
         $attributeNames = $this->attributeNameService->getAttributeTypeNames();
 
         foreach ($attributeNames as $attributeName) {
-            if (property_exists($metadata, $attributeName)) {
-                $command->setAttribute($attributeName, $metadata->$attributeName);
-            }
+            $command->setAttribute($attributeName, $metadata->getAttribute($attributeName));
         }
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Exception/AttributeNotFoundException.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Exception/AttributeNotFoundException.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Domain\Exception;
+
+use Exception;
+
+class AttributeNotFoundException extends Exception
+{
+}

--- a/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Metadata.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Metadata.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 
 namespace Surfnet\ServiceProviderDashboard\Domain\ValueObject;
 
+use Surfnet\ServiceProviderDashboard\Domain\Exception\AttributeNotFoundException;
+
 /**
  * @SuppressWarnings(PHPMD.TooManyFields)
  */
@@ -132,11 +134,14 @@ class Metadata
         $this->attributes[$property] = $value;
     }
 
+    /**
+     * @throws AttributeNotFoundException
+     */
     public function getAttribute(string $property): Attribute
     {
         if (array_key_exists($property, $this->attributes)) {
             return $this->attributes[$property];
         }
-        return new Attribute();
+        throw new AttributeNotFoundException(sprintf('Invalid attribute \'%s\' requested', $property));
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Metadata.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Metadata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright 2017 SURFnet B.V.
  *
@@ -18,9 +20,6 @@
 
 namespace Surfnet\ServiceProviderDashboard\Domain\ValueObject;
 
-/**
- * @SuppressWarnings(PHPMD.TooManyFields)
- */
 class Metadata
 {
     /**
@@ -93,80 +92,7 @@ class Metadata
      */
     public $technicalContact;
 
-    /**
-     * @var Attribute
-     */
-    public $givenNameAttribute;
-
-    /**
-     * @var Attribute
-     */
-    public $surNameAttribute;
-
-    /**
-     * @var Attribute
-     */
-    public $commonNameAttribute;
-
-    /**
-     * @var Attribute
-     */
-    public $displayNameAttribute;
-
-    /**
-     * @var Attribute
-     */
-    public $emailAddressAttribute;
-
-    /**
-     * @var Attribute
-     */
-    public $organizationAttribute;
-
-    /**
-     * @var Attribute
-     */
-    public $organizationTypeAttribute;
-
-    /**
-     * @var Attribute
-     */
-    public $affiliationAttribute;
-
-    /**
-     * @var Attribute
-     */
-    public $entitlementAttribute;
-
-    /**
-     * @var Attribute
-     */
-    public $principleNameAttribute;
-
-    /**
-     * @var Attribute
-     */
-    public $uidAttribute;
-
-    /**
-     * @var Attribute
-     */
-    public $preferredLanguageAttribute;
-
-    /**
-     * @var Attribute
-     */
-    public $personalCodeAttribute;
-
-    /**
-     * @var Attribute
-     */
-    public $scopedAffiliationAttribute;
-
-    /**
-     * @var Attribute
-     */
-    public $eduPersonTargetedIDAttribute;
+    public $attributes = [];
 
     /**
      * @var string
@@ -197,4 +123,17 @@ class Metadata
      * @var string
      */
     public $organizationUrlNl;
+
+    public function setAttribute(string $property, Attribute $value)
+    {
+        $this->attributes[$property] = $value;
+    }
+
+    public function getAttribute(string $property): Attribute
+    {
+        if (array_key_exists($property, $this->attributes)) {
+            return $this->attributes[$property];
+        }
+        return new Attribute();
+    }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Metadata.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Metadata.php
@@ -20,6 +20,9 @@ declare(strict_types=1);
 
 namespace Surfnet\ServiceProviderDashboard\Domain\ValueObject;
 
+/**
+ * @SuppressWarnings(PHPMD.TooManyFields)
+ */
 class Metadata
 {
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -362,6 +362,8 @@ entity.edit.attributes.oauth20_rs.html: "
 <p><i>Identity Providers will be informed about the attributes your service requests and must agree to the release of these attributes to your entity.</i></p>
 "
 entity.edit.attribute.invalid: The provided attribute % is invalid
+entity.change_requested.title: Your change request has been submitted for review
+entity.change_requested.text.html: "<p>As you where editing a production entity, we have taken your changes under review.</p>"
 entity.edit.comments.title: Comments
 entity.edit.comments.html: "<p>If there are any questions regarding your SURFconext connection or this form, please leave them here.</p>"
 entity.edit.oidcngResourceServers.title: Select the OIDC Resource Servers(s) that belong to this Client

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -468,6 +468,12 @@ entity.publish.request.ticket.description: "h2. Details
 *Applicant email*: %applicant_email%.
 *Entity name (en)*: %entity_name%."
 
+entity.change_request.ticket.summary: "Request for changes for %entity_name%"
+entity.change_request.ticket.description: "h2. Details
+*Applicant name*: %applicant_name%
+*Applicant email*: %applicant_email%.
+*Entity name (en)*: %entity_name%."
+
 entity.published_production.text.html: "Thanks for publishing \"%entityName%\" to our production environment."
 entity.published_production.title: "Successfully published the entity to production"
 entity.published_test.text.html: "Thanks for publishing \"%entityName%\" to our test environment."

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -362,8 +362,6 @@ entity.edit.attributes.oauth20_rs.html: "
 <p><i>Identity Providers will be informed about the attributes your service requests and must agree to the release of these attributes to your entity.</i></p>
 "
 entity.edit.attribute.invalid: The provided attribute % is invalid
-entity.change_requested.title: Your change request has been submitted for review
-entity.change_requested.text.html: "<p>As you where editing a production entity, we have taken your changes under review.</p>"
 entity.edit.comments.title: Comments
 entity.edit.comments.html: "<p>If there are any questions regarding your SURFconext connection or this form, please leave them here.</p>"
 entity.edit.oidcngResourceServers.title: Select the OIDC Resource Servers(s) that belong to this Client
@@ -463,13 +461,6 @@ entity.acl.entity-id.title: Entity ID
 entity.acl.error.publish: "Unable to publish the entity, try again later"
 entity.publish.request.ticket.summary: "Request to publish %entity_name% to production"
 entity.publish.request.ticket.description: "h2. Details
-
-*Applicant name*: %applicant_name%
-*Applicant email*: %applicant_email%.
-*Entity name (en)*: %entity_name%."
-
-entity.change_request.ticket.summary: "Request for changes for %entity_name%"
-entity.change_request.ticket.description: "h2. Details
 
 *Applicant name*: %applicant_name%
 *Applicant email*: %applicant_email%.

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -470,6 +470,7 @@ entity.publish.request.ticket.description: "h2. Details
 
 entity.change_request.ticket.summary: "Request for changes for %entity_name%"
 entity.change_request.ticket.description: "h2. Details
+
 *Applicant name*: %applicant_name%
 *Applicant email*: %applicant_email%.
 *Entity name (en)*: %entity_name%."

--- a/src/Surfnet/ServiceProviderDashboard/Legacy/Metadata/Parser.php
+++ b/src/Surfnet/ServiceProviderDashboard/Legacy/Metadata/Parser.php
@@ -334,7 +334,7 @@ class Parser implements ParserInterface
 
             foreach ($this->attributeService->getAttributeTypeAttributes() as $attribute) {
                 if (in_array($attributes['Name'], $attribute->getUrns())) {
-                    $metadata->{$attribute->getName()} = $attr;
+                    $metadata->setAttribute($attribute->getName(), $attr);
                 }
             }
         }

--- a/tests/integration/Legacy/Metadata/ParserTest.php
+++ b/tests/integration/Legacy/Metadata/ParserTest.php
@@ -140,19 +140,19 @@ oLtcUeUILPXB
 CER
         );
 
-        $this->assertTrue($metadata->emailAddressAttribute->isRequested());
-        $this->assertTrue($metadata->displayNameAttribute->isRequested());
-        $this->assertTrue($metadata->affiliationAttribute->isRequested());
-        $this->assertTrue($metadata->commonNameAttribute->isRequested());
-        $this->assertTrue($metadata->entitlementAttribute->isRequested());
-        $this->assertTrue($metadata->givenNameAttribute->isRequested());
-        $this->assertTrue($metadata->organizationAttribute->isRequested());
-        $this->assertTrue($metadata->organizationTypeAttribute->isRequested());
-        $this->assertTrue($metadata->principleNameAttribute->isRequested());
-        $this->assertTrue($metadata->surNameAttribute->isRequested());
-        $this->assertTrue($metadata->uidAttribute->isRequested());
-        $this->assertTrue($metadata->preferredLanguageAttribute->isRequested());
-        $this->assertTrue($metadata->personalCodeAttribute->isRequested());
+        $this->assertTrue($metadata->getAttribute('emailAddressAttribute')->isRequested());
+        $this->assertTrue($metadata->getAttribute('displayNameAttribute')->isRequested());
+        $this->assertTrue($metadata->getAttribute('affiliationAttribute')->isRequested());
+        $this->assertTrue($metadata->getAttribute('commonNameAttribute')->isRequested());
+        $this->assertTrue($metadata->getAttribute('entitlementAttribute')->isRequested());
+        $this->assertTrue($metadata->getAttribute('givenNameAttribute')->isRequested());
+        $this->assertTrue($metadata->getAttribute('organizationAttribute')->isRequested());
+        $this->assertTrue($metadata->getAttribute('organizationTypeAttribute')->isRequested());
+        $this->assertTrue($metadata->getAttribute('principleNameAttribute')->isRequested());
+        $this->assertTrue($metadata->getAttribute('surNameAttribute')->isRequested());
+        $this->assertTrue($metadata->getAttribute('uidAttribute')->isRequested());
+        $this->assertTrue($metadata->getAttribute('preferredLanguageAttribute')->isRequested());
+        $this->assertTrue($metadata->getAttribute('personalCodeAttribute')->isRequested());
     }
 
     /**

--- a/tests/unit/Domain/ValueObject/MetadataTest.php
+++ b/tests/unit/Domain/ValueObject/MetadataTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Copyright 2020 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Domain\ValueObject;
+
+use PHPUnit\Framework\TestCase;
+use Surfnet\ServiceProviderDashboard\Domain\Exception\AttributeNotFoundException;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Metadata;
+
+class MetadataTest extends TestCase
+{
+    public function test_it_throws_invalid_attribute_argument()
+    {
+        $metadata = new Metadata();
+        $metadata->attributes = ['attribute1', 'attribute2'];
+
+        $this->expectException(AttributeNotFoundException::class);
+        $this->expectExceptionMessage('Invalid attribute \'attribute3\' requested');
+        $metadata->getAttribute('attribute3');
+    }
+}

--- a/tests/unit/Domain/ValueObject/MetadataTest.php
+++ b/tests/unit/Domain/ValueObject/MetadataTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2020 SURFnet B.V.
+ * Copyright 2022 SURFnet B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
From a SAML url the $descriptor->AttributeConsumingService->RequestedAttribute the metadata and attributes can be loaded into the form. The metadata attributes are no longer hard coded and will use a getter and setter to get set its attributes. 
The attributeNameService provides the available names within the SPD system and is used to setup the metadata attributes requested values.

see: https://www.pivotaltracker.com/story/show/182220241 ### 4. LoadMetadataCommandHandler changes