### PR TITLE
Transform Jira reporter name to custom field

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -83,6 +83,7 @@ parameters:
     jira_issue_manageid_fieldname: customfield_13401
     # The label that is set for the manage id field, used to compose the JQL which identifies a custom field by its label
     jira_issue_manageid_field_label: Manage entity ID
+    jira_issue_reporter_fieldname: customfield_99999
     jira_issue_project_key: CXT
 
     # Playground uri's for OIDC entities

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -500,6 +500,7 @@ services:
         arguments:
             - '%jira_issue_entityid_fieldname%'
             - '%jira_issue_manageid_fieldname%'
+            - '%jira_issue_reporter_fieldname%'
             - '%jira_issue_priority%'
             - '%jira_issue_project_key%'
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Factory/IssueFieldFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Factory/IssueFieldFactory.php
@@ -38,6 +38,11 @@ class IssueFieldFactory
     /**
      * @var string
      */
+    private $reporterFieldName;
+
+    /**
+     * @var string
+     */
     private $priority;
 
     /**
@@ -50,18 +55,12 @@ class IssueFieldFactory
      */
     private $translator;
 
-    /**
-     * @param string $entityIdFieldName
-     * @param string $manageIdFieldName
-     * @param string $priority
-     * @param string $projectKey
-     * @param TranslatorInterface $translator
-     */
     public function __construct(
-        $entityIdFieldName,
-        $manageIdFieldName,
-        $priority,
-        $projectKey,
+        string $entityIdFieldName,
+        string $manageIdFieldName,
+        string $reporterFieldName,
+        string $priority,
+        string $projectKey,
         TranslatorInterface $translator
     ) {
         Assert::stringNotEmpty(
@@ -77,12 +76,13 @@ class IssueFieldFactory
 
         $this->entityIdFieldName = $entityIdFieldName;
         $this->manageIdFieldName = $manageIdFieldName;
+        $this->reporterFieldName = $reporterFieldName;
         $this->priority = $priority;
         $this->projectKey = $projectKey;
         $this->translator = $translator;
     }
 
-    public function fromTicket(Ticket $ticket)
+    public function fromTicket(Ticket $ticket): IssueField
     {
         $issueField = new IssueField();
         $issueField->setProjectKey($this->projectKey)
@@ -90,7 +90,7 @@ class IssueFieldFactory
             ->setSummary($this->translateSummary($ticket))
             ->setIssueType($ticket->getIssueType())
             ->setPriorityName($this->priority)
-            ->setReporterName(sprintf('%s, (%s)', $ticket->getApplicantName(), $ticket->getApplicantEmail()))
+            ->addCustomField($this->reporterFieldName, sprintf('%s, (%s)', $ticket->getApplicantName(), $ticket->getApplicantEmail()))
             ->addCustomField($this->entityIdFieldName, $ticket->getEntityId())
             ->addCustomField($this->manageIdFieldName, $ticket->getManageId())
         ;
@@ -98,7 +98,7 @@ class IssueFieldFactory
         return $issueField;
     }
 
-    private function translateDescription(Ticket $ticket)
+    private function translateDescription(Ticket $ticket): string
     {
         return $this->translator->trans($ticket->getDescriptionTranslationKey(), [
             '%applicant_name%' => $ticket->getApplicantName(),
@@ -107,7 +107,7 @@ class IssueFieldFactory
         ]);
     }
 
-    private function translateSummary(Ticket $ticket)
+    private function translateSummary(Ticket $ticket): string
     {
         return $this->translator->trans($ticket->getSummaryTranslationKey(), [
             '%entity_name%' => $ticket->getEntityName()

--- a/tests/unit/Infrastructure/Jira/Factory/IssueFieldFactoryTest.php
+++ b/tests/unit/Infrastructure/Jira/Factory/IssueFieldFactoryTest.php
@@ -42,6 +42,7 @@ class IssueFieldFactoryTest extends TestCase
         $this->factory = new IssueFieldFactory(
             'customfield_10107',
             'customfield_10108',
+            'customfield_99999',
             'Critical',
             'SPD',
             $this->translator
@@ -86,6 +87,7 @@ class IssueFieldFactoryTest extends TestCase
         $this->assertEquals('Description', $issueField->description);
         // The custom field is used for saving the entity id.
         $this->assertEquals('https://example.com', $issueField->customFields['customfield_10107']);
+        $this->assertEquals('John Doe, (john@example.com)', $issueField->customFields['customfield_99999']);
         $this->assertEquals('arbitrary-issue-type', $ticket->getIssueType());
         $this->assertEquals('Critical', $issueField->priority->name);
     }


### PR DESCRIPTION
The Reporter in Jira needs to be a known Jira user for the organisation that subscribes to Jira. In this case we fill it with a name/mail address of a Service contact person. And that person wil most probably not be known in Jira. Yielding a big fat error.

The solution is to use a custom field (that is already provisioned in the SURF Jira setup). That field is then filled with the Name/Email combination.

This goal was reached by following the existing pattern that was already in place for the ManageId and the EntityId custom fields.

A fixup for: https://github.com/SURFnet/sp-dashboard/pull/523 See https://www.pivotaltracker.com/story/show/179749372/comments/233715744