### PR TITLE
Set only email on custom reporter Jira field

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Factory/IssueFieldFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Factory/IssueFieldFactory.php
@@ -90,7 +90,7 @@ class IssueFieldFactory
             ->setSummary($this->translateSummary($ticket))
             ->setIssueType($ticket->getIssueType())
             ->setPriorityName($this->priority)
-            ->addCustomField($this->reporterFieldName, sprintf('%s, (%s)', $ticket->getApplicantName(), $ticket->getApplicantEmail()))
+            ->addCustomField($this->reporterFieldName, $ticket->getApplicantEmail())
             ->addCustomField($this->entityIdFieldName, $ticket->getEntityId())
             ->addCustomField($this->manageIdFieldName, $ticket->getManageId())
         ;

--- a/tests/unit/Infrastructure/Jira/Factory/IssueFieldFactoryTest.php
+++ b/tests/unit/Infrastructure/Jira/Factory/IssueFieldFactoryTest.php
@@ -87,7 +87,7 @@ class IssueFieldFactoryTest extends TestCase
         $this->assertEquals('Description', $issueField->description);
         // The custom field is used for saving the entity id.
         $this->assertEquals('https://example.com', $issueField->customFields['customfield_10107']);
-        $this->assertEquals('John Doe, (john@example.com)', $issueField->customFields['customfield_99999']);
+        $this->assertEquals('john@example.com', $issueField->customFields['customfield_99999']);
         $this->assertEquals('arbitrary-issue-type', $ticket->getIssueType());
         $this->assertEquals('Critical', $issueField->priority->name);
     }


### PR DESCRIPTION
Previously we would also show the reporter name on that field. But this field can only be a mail address