### PR TITLE
Add a change request overview for production entities

### DIFF
--- a/app/scss/pages/change_request.scss
+++ b/app/scss/pages/change_request.scss
@@ -1,4 +1,4 @@
-.table--th-data-width {
-    width: 24rem;
+table.change-request-overview th:first-child {
+    width: 24em;
     overflow: hidden;
 }

--- a/app/scss/pages/change_request.scss
+++ b/app/scss/pages/change_request.scss
@@ -1,0 +1,4 @@
+.table--th-data-width {
+    width: 24rem;
+    overflow: hidden;
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/Dto/ChangeRequestDto.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Dto/ChangeRequestDto.php
@@ -19,6 +19,9 @@
 namespace Surfnet\ServiceProviderDashboard\Application\Dto;
 
 use DateTime;
+use Exception;
+use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidDateTimeException;
+use Webmozart\Assert\Assert;
 
 class ChangeRequestDto
 {
@@ -39,7 +42,7 @@ class ChangeRequestDto
 
     private $pathUpdates = [];
 
-    private function __construct(string $id, ?string $note, DateTime $created, array $pathUpdates)
+    private function __construct(string $id, string $note, DateTime $created, array $pathUpdates)
     {
         $this->id = $id;
         $this->note = $note;
@@ -47,12 +50,26 @@ class ChangeRequestDto
         $this->pathUpdates = $pathUpdates;
     }
 
+    /**
+     * @throws InvalidDateTimeException
+     */
     public static function fromChangeRequest(array $changeRequest): ?ChangeRequestDto
     {
-        $created = new DateTime($changeRequest['created']);
+        Assert::isArray($changeRequest);
+        Assert::keyExists($changeRequest, 'id', 'No id specified');
+        Assert::keyExists($changeRequest, 'created', 'No create datetime specified');
+        Assert::keyExists($changeRequest, 'pathUpdates', 'No pathUpdates specified');
+        Assert::isNonEmptyMap($changeRequest['pathUpdates'], 'No pathUpdates available');
+
+        try {
+            $created = new DateTime($changeRequest['created']);
+        } catch (Exception $e) {
+            throw new InvalidDateTimeException();
+        }
+        $note = $changeRequest['note'] ?? '';
 
         return new self($changeRequest['id'],
-            $changeRequest['note'],
+            $note,
             $created,
             $changeRequest['pathUpdates']);
     }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Dto/ChangeRequestDto.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Dto/ChangeRequestDto.php
@@ -22,6 +22,7 @@ use DateTime;
 use Exception;
 use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidDateTimeException;
 use Webmozart\Assert\Assert;
+use function array_key_exists;
 
 class ChangeRequestDto
 {
@@ -68,10 +69,26 @@ class ChangeRequestDto
         }
         $note = $changeRequest['note'] ?? '';
 
+        self::flattenArp($changeRequest);
+
         return new self($changeRequest['id'],
             $note,
             $created,
             $changeRequest['pathUpdates']);
+    }
+
+    private static function flattenArp(&$changeRequest)
+    {
+        if (array_key_exists('arp', $changeRequest['pathUpdates'])) {
+            $arp = $changeRequest['pathUpdates']['arp'];
+            if (array_key_exists('attributes', $arp) && !empty($arp['attributes'])) {
+                foreach ($arp['attributes'] as $urn => $attribute) {
+                    // Include ARP entries in the pathupdates, not in pathUpdates/arp
+                    $changeRequest['pathUpdates'][$urn] = $attribute[0]['motivation'];
+                }
+            }
+            unset($changeRequest['pathUpdates']['arp']);
+        }
     }
 
     public function getId(): string

--- a/src/Surfnet/ServiceProviderDashboard/Application/Dto/ChangeRequestDto.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Dto/ChangeRequestDto.php
@@ -29,11 +29,6 @@ class ChangeRequestDto
     /**
      * @var string
      */
-    private $id;
-
-    /**
-     * @var string
-     */
     private $note;
 
     /**
@@ -43,9 +38,8 @@ class ChangeRequestDto
 
     private $pathUpdates = [];
 
-    private function __construct(string $id, string $note, DateTime $created, array $pathUpdates)
+    private function __construct(string $note, DateTime $created, array $pathUpdates)
     {
-        $this->id = $id;
         $this->note = $note;
         $this->created = $created;
         $this->pathUpdates = $pathUpdates;
@@ -57,7 +51,6 @@ class ChangeRequestDto
     public static function fromChangeRequest(array $changeRequest): ?ChangeRequestDto
     {
         Assert::isArray($changeRequest);
-        Assert::keyExists($changeRequest, 'id', 'No id specified');
         Assert::keyExists($changeRequest, 'created', 'No create datetime specified');
         Assert::keyExists($changeRequest, 'pathUpdates', 'No pathUpdates specified');
         Assert::isNonEmptyMap($changeRequest['pathUpdates'], 'No pathUpdates available');
@@ -71,10 +64,7 @@ class ChangeRequestDto
 
         self::flattenArp($changeRequest);
 
-        return new self($changeRequest['id'],
-            $note,
-            $created,
-            $changeRequest['pathUpdates']);
+        return new self($note, $created, $changeRequest['pathUpdates']);
     }
 
     private static function flattenArp(&$changeRequest)
@@ -89,11 +79,6 @@ class ChangeRequestDto
             }
             unset($changeRequest['pathUpdates']['arp']);
         }
-    }
-
-    public function getId(): string
-    {
-        return $this->id;
     }
 
     public function getNote(): ?string

--- a/src/Surfnet/ServiceProviderDashboard/Application/Dto/ChangeRequestDto.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Dto/ChangeRequestDto.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Dto;
+
+use DateTime;
+
+class ChangeRequestDto
+{
+    /**
+     * @var string
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    private $note;
+
+    /**
+     * @var datetime
+     */
+    private $created;
+
+    private $pathUpdates = [];
+
+    private function __construct(string $id, ?string $note, DateTime $created, array $pathUpdates)
+    {
+        $this->id = $id;
+        $this->note = $note;
+        $this->created = $created;
+        $this->pathUpdates = $pathUpdates;
+    }
+
+    public static function fromChangeRequest(array $changeRequest): ?ChangeRequestDto
+    {
+        $created = new DateTime($changeRequest['created']);
+
+        return new self($changeRequest['id'],
+            $changeRequest['note'],
+            $created,
+            $changeRequest['pathUpdates']);
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getNote(): ?string
+    {
+        return $this->note;
+    }
+
+    public function getCreated(): DateTime
+    {
+        return $this->created;
+    }
+
+    public function getPathUpdates(): array
+    {
+        return $this->pathUpdates;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/Dto/ChangeRequestDtoCollection.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Dto/ChangeRequestDtoCollection.php
@@ -31,7 +31,6 @@ class ChangeRequestDtoCollection
     public function __construct(array $changeRequests)
     {
         Assert::isArray($changeRequests);
-        Assert::isNonEmptyList($changeRequests, 'No change requests available');
 
         foreach ($changeRequests as $id => $changeRequest) {
             $this->changeRequests[$id] = ChangeRequestDto::fromChangeRequest($changeRequest);

--- a/src/Surfnet/ServiceProviderDashboard/Application/Dto/ChangeRequestDtoCollection.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Dto/ChangeRequestDtoCollection.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Dto;
+
+class ChangeRequestDtoCollection
+{
+    /**
+     * @var ChangeRequestDto[]
+     */
+    private $changeRequests = [];
+
+    public function __construct(array $changeRequests)
+    {
+        foreach ($changeRequests as $id => $changeRequest) {
+            $this->changeRequests[$id] = ChangeRequestDto::fromChangeRequest($changeRequest);
+        }
+        array_multisort($this->changeRequests, SORT_ASC, SORT_REGULAR);
+    }
+
+    public function getChangeRequests(): array
+    {
+        return $this->changeRequests;
+    }
+
+    public function count(): int
+    {
+        return count($this->changeRequests);
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/Dto/ChangeRequestDtoCollection.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Dto/ChangeRequestDtoCollection.php
@@ -18,6 +18,9 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Dto;
 
+use Webmozart\Assert\Assert;
+use Surfnet\ServiceProviderDashboard\Application\Dto\ChangeRequestDtoComparer;
+
 class ChangeRequestDtoCollection
 {
     /**
@@ -27,19 +30,17 @@ class ChangeRequestDtoCollection
 
     public function __construct(array $changeRequests)
     {
+        Assert::isArray($changeRequests);
+        Assert::isNonEmptyList($changeRequests, 'No change requests available');
+
         foreach ($changeRequests as $id => $changeRequest) {
             $this->changeRequests[$id] = ChangeRequestDto::fromChangeRequest($changeRequest);
         }
-        array_multisort($this->changeRequests, SORT_ASC, SORT_REGULAR);
+        usort($this->changeRequests, [ChangeRequestDtoComparer::class, 'compareCreatedDescending']);
     }
 
     public function getChangeRequests(): array
     {
         return $this->changeRequests;
-    }
-
-    public function count(): int
-    {
-        return count($this->changeRequests);
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Dto/ChangeRequestDtoComparer.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Dto/ChangeRequestDtoComparer.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Dto;
+
+use DateTime;
+
+class ChangeRequestDtoComparer
+{
+    public static function compareCreatedDescending(ChangeRequestDto $a, ChangeRequestDto $b): int
+    {
+        return $b->getCreated()->getTimestamp() <=> $a->getCreated()->getTimestamp();
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/Exception/InvalidDateTimeException.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Exception/InvalidDateTimeException.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Exception;
+
+use Exception;
+
+class InvalidDateTimeException extends Exception
+{
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/ChangeRequestService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/ChangeRequestService.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Service;
+
+use Surfnet\ServiceProviderDashboard\Application\Dto\ChangeRequestDtoCollection;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityChangeRequestRepository;
+
+class ChangeRequestService implements ChangeRequestServiceInterface
+{
+    /**
+     * @var EntityChangeRequestRepository
+     */
+    private $repository;
+
+    public function __construct(
+        EntityChangeRequestRepository $repository
+    ) {
+        $this->repository = $repository;
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function findById(string $id): ChangeRequestDtoCollection
+    {
+        $values = $this->repository->getChangeRequest($id);
+        return new ChangeRequestDtoCollection($values);
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/ChangeRequestServiceInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/ChangeRequestServiceInterface.php
@@ -16,20 +16,11 @@
  * limitations under the License.
  */
 
-namespace Surfnet\ServiceProviderDashboard\Domain\Repository;
+namespace Surfnet\ServiceProviderDashboard\Application\Service;
 
-use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
+use Surfnet\ServiceProviderDashboard\Application\Dto\ChangeRequestDtoCollection;
 
-interface EntityChangeRequestRepository
+interface ChangeRequestServiceInterface
 {
-    /**
-     * Open an entity change request in manage
-     */
-    public function openChangeRequest(ManageEntity $entity, ?ManageEntity $pristineEntity, Contact $contact): array;
-
-    /**
-     * Get outstanding change request from manage
-     */
-    public function getChangeRequest(string $id): array;
+    public function findById(string $id): ChangeRequestDtoCollection;
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityActions.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityActions.php
@@ -169,7 +169,7 @@ class EntityActions
 
     public function allowChangeRequestAction(): bool
     {
-        if ($this->readOnly) {
+        if ($this->readOnly || $this->environment !== Constants::ENVIRONMENT_PRODUCTION) {
             return false;
         }
         return $this->status == Constants::STATE_PUBLISHED;

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityActions.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityActions.php
@@ -167,6 +167,15 @@ class EntityActions
         return $meetsProtocolRequirement && $meetsPublicationStatusRequirement;
     }
 
+    public function allowChangeRequestAction(): bool
+    {
+        if ($this->readOnly) {
+            return false;
+        }
+        return $this->status == Constants::STATE_PUBLISHED;
+    }
+
+
     public function isPublishedToProduction()
     {
         return $this->status == Constants::STATE_PUBLISHED && $this->environment == Constants::ENVIRONMENT_PRODUCTION;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityChangeRequestController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityChangeRequestController.php
@@ -22,6 +22,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
 use Surfnet\ServiceProviderDashboard\Application\Service\ChangeRequestService;
+use Surfnet\ServiceProviderDashboard\Application\ViewObject\EntityActions;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\QueryServiceProviderException;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -55,9 +56,24 @@ class EntityChangeRequestController extends Controller
 
         $changeRequests = $service->findById($manageId);
 
+        $actions = new EntityActions(
+            $manageId,
+            $entity->getService()->getId(),
+            $entity->getStatus(),
+            $entity->getEnvironment(),
+            $entity->getProtocol()->getProtocol(),
+            true
+        );
+
         return $this->render(
             '@Dashboard/EntityPublished/changeRequest.html.twig',
-            ['changeRequests' => $changeRequests]
+            [
+                'changeRequests' => $changeRequests,
+                'entity' => $entity,
+                'serviceId' => $serviceId,
+                'actions' => $actions,
+                'isAdmin' => $this->authorizationService->isAdministrator(),
+            ]
         );
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityChangeRequestController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityChangeRequestController.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Surfnet\ServiceProviderDashboard\Application\Service\ChangeRequestService;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EntityChangeRequestController extends Controller
+{
+    use EntityControllerTrait;
+
+    /**
+     * @Method({"GET", "POST"})
+     * @Route("/entity/change-request/{environment}/{manageId}/{serviceId}", name="entity_published_change_request")
+     */
+    public function changeRequestAction(
+        Request $request,
+        ChangeRequestService $service,
+        int $serviceId,
+        string $manageId,
+        string $environment
+    ): Response {
+    
+        $changeRequests = $service->findById($manageId);
+
+        return $this->render(
+            '@Dashboard/EntityPublished/changeRequest.html.twig',
+            ['changeRequests' => $changeRequests]
+        );
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -331,6 +331,10 @@ services:
             - '@Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient'
             - '@surfnet.manage.client.query_client.prod_environment'
 
+    Surfnet\ServiceProviderDashboard\Application\Service\ChangeRequestService:
+        arguments:
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\EntityChangeRequestClient'
+
     Surfnet\ServiceProviderDashboard\Application\Service\EntityAclService:
         arguments:
             - '@surfnet.manage.client.identity_provider_client.test_environment'

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -170,6 +170,7 @@ entity.list.action.copy: Copy
 entity.list.action.delete: Delete
 entity.list.action.copy_to_production: Copy to production
 entity.list.action.reset_secret: Reset client secret
+entity.list.action.change.request: Change Request
 entity.list.modal.oidc_confirmation:
   title: Confirmation
   client_id:
@@ -363,6 +364,11 @@ entity.edit.attributes.oauth20_rs.html: "
 "
 entity.change_requested.title: Your change request has been submitted for review
 entity.change_requested.text.html: "<p>As you where editing a production entity, we have taken your changes under review.</p>"
+entity.change_request.title: Change request overview
+entity.change_request.value: Value
+entity.change_request.data: Data
+entity.change_request.text.html: "<p>All outstanding change requests</p>"
+entity.change_request.none.text.html: "<p>No outstanding change requests</p>"
 entity.edit.comments.title: Comments
 entity.edit.comments.html: "<p>If there are any questions regarding your SURFconext connection or this form, please leave them here.</p>"
 entity.edit.oidcngResourceServers.title: Select the OIDC Resource Servers(s) that belong to this Client

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityActions/actionsForList.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityActions/actionsForList.html.twig
@@ -4,4 +4,5 @@
     {% include "@Dashboard/EntityActions/aclAction.html.twig" with {action: entity} %}
     {% include "@Dashboard/EntityActions/secretResetAction.html.twig" with {action: entity} %}
     {% include "@Dashboard/EntityActions/deleteAction.html.twig" with {action: entity} %}
+    {% include "@Dashboard/EntityActions/changeRequestAction.html.twig" with {action: entity} %}
 </ul>

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityActions/changeRequestAction.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityActions/changeRequestAction.html.twig
@@ -1,0 +1,8 @@
+{% if action.allowChangeRequestAction %}
+<li>
+    <a href="{{ path('entity_published_change_request', {manageId: action.id, environment: action.environment, serviceId: action.serviceId}) }}">
+        <i class="fa fa-eye" aria-hidden="true"></i>
+        {{ 'entity.list.action.change.request'|trans }}
+    </a>
+</li>
+{% endif %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/changeRequest.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/changeRequest.html.twig
@@ -3,6 +3,11 @@
 {% block page_heading %}{{ 'entity.change_request.title'|trans }}{%endblock%}
 {% block body %}
 
+
+    <div class="fieldset card action">
+        {% include '@Dashboard/EntityActions/actionsForDetail.html.twig' with {entity: actions, isAdmin: isAdmin} %}
+    </div>
+
     {% if changeRequests.getChangeRequests()|length %}
         {{ 'entity.change_request.text.html'|trans|wysiwyg }}
     {% else %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/changeRequest.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/changeRequest.html.twig
@@ -1,39 +1,42 @@
 {% extends '::base.html.twig' %}
 
-{% block page_heading %}{{ 'entity.change_request.title'|trans }}{%endblock%}
-{% block body %}
-
+{% block body_container %}
+    <h1>{% block page_heading %}{{ 'entity.change_request.title'|trans }}{%endblock%}</h1>
 
     <div class="fieldset card action">
         {% include '@Dashboard/EntityActions/actionsForDetail.html.twig' with {entity: actions, isAdmin: isAdmin} %}
     </div>
 
-    {% if changeRequests.getChangeRequests()|length %}
-        {{ 'entity.change_request.text.html'|trans|wysiwyg }}
-    {% else %}
-        {{ 'entity.change_request.none.text.html'|trans|wysiwyg }}
-    {% endif %}
+    <div class="fieldset card">
+        {% if changeRequests.getChangeRequests()|length %}
+            <div class="wysiwyg">{{ 'entity.change_request.text.html'|trans|wysiwyg }}</div>
+        {% else %}
+            <div class="wysiwyg">{{ 'entity.change_request.none.text.html'|trans|wysiwyg }}</div>
+        {% endif %}
+    </div>
 
     {%  for changeRequest in changeRequests.getChangeRequests() %}
 
-        <h2>{{ changeRequest.created|date }}</h2>
+        <div class="fieldset card">
+            <h2>{{ changeRequest.created|date }}</h2>
 
-        {% if changeRequest.note is not null %}
-            <p>{{ changeRequest.note }}</p>
-        {% endif %}
+            {% if changeRequest.note is not null %}
+                <p>{{ changeRequest.note }}</p>
+            {% endif %}
 
-        <table>
-            <tr>
-                <th>{{ 'entity.change_request.value'|trans }}</th>
-                <th>{{ 'entity.change_request.data'|trans }}</th>
-            </tr>
-                {% for index, pathUpdate in changeRequest.pathUpdates %}
+            <table>
                 <tr>
-                        <td>{{ index }}</td>
-                        <td>{{ pathUpdate }}</td>
+                    <th>{{ 'entity.change_request.value'|trans }}</th>
+                    <th class="table--th-data-width">{{ 'entity.change_request.data'|trans }}</th>
                 </tr>
-                {%  endfor %}
+                    {% for index, pathUpdate in changeRequest.pathUpdates %}
+                    <tr>
+                            <td>{{ index }}</td>
+                            <td>{{ pathUpdate }}</td>
+                    </tr>
+                    {%  endfor %}
 
-        </table>
+            </table>
+        </div>
     {% endfor %}
 {% endblock %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/changeRequest.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/changeRequest.html.twig
@@ -24,10 +24,10 @@
                 <p>{{ changeRequest.note }}</p>
             {% endif %}
 
-            <table>
+            <table  class="change-request-overview">
                 <tr>
                     <th>{{ 'entity.change_request.value'|trans }}</th>
-                    <th class="table--th-data-width">{{ 'entity.change_request.data'|trans }}</th>
+                    <th>{{ 'entity.change_request.data'|trans }}</th>
                 </tr>
                     {% for index, pathUpdate in changeRequest.pathUpdates %}
                     <tr>

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/changeRequest.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/changeRequest.html.twig
@@ -1,0 +1,34 @@
+{% extends '::base.html.twig' %}
+
+{% block page_heading %}{{ 'entity.change_request.title'|trans }}{%endblock%}
+{% block body %}
+
+    {% if changeRequests.count() %}
+        {{ 'entity.change_request.text.html'|trans|wysiwyg }}
+    {% else %}
+        {{ 'entity.change_request.none.text.html'|trans|wysiwyg }}
+    {% endif %}
+
+    {%  for changeRequest in changeRequests.getChangeRequests() %}
+
+        <h2>{{ changeRequest.created|date }}</h2>
+
+        {% if changeRequest.note is not null %}
+            <h2>{{ changeRequest.note }}</h2>
+        {% endif %}
+
+        <table>
+            <tr>
+                <th>{{ 'entity.change_request.value'|trans }}</th>
+                <th>{{ 'entity.change_request.data'|trans }}</th>
+            </tr>
+                {% for index, pathUpdate in changeRequest.pathUpdates %}
+                <tr>
+                        <td>{{ index }}</td>
+                        <td>{{ pathUpdate }}</td>
+                </tr>
+                {%  endfor %}
+
+        </table>
+    {% endfor %}
+{% endblock %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/changeRequest.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/changeRequest.html.twig
@@ -3,7 +3,7 @@
 {% block page_heading %}{{ 'entity.change_request.title'|trans }}{%endblock%}
 {% block body %}
 
-    {% if changeRequests.count() %}
+    {% if changeRequests.getChangeRequests()|length %}
         {{ 'entity.change_request.text.html'|trans|wysiwyg }}
     {% else %}
         {{ 'entity.change_request.none.text.html'|trans|wysiwyg }}
@@ -14,7 +14,7 @@
         <h2>{{ changeRequest.created|date }}</h2>
 
         {% if changeRequest.note is not null %}
-            <h2>{{ changeRequest.note }}</h2>
+            <p>{{ changeRequest.note }}</p>
         {% endif %}
 
         <table>

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/EntityChangeRequestClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/EntityChangeRequestClient.php
@@ -78,4 +78,13 @@ class EntityChangeRequestClient implements EntityChangeRequestRepository
 
         return $response;
     }
+
+    public function getChangeRequest(string $id): array
+    {
+        $this->logger->info(sprintf('Get outstanding change requests from manage for entity "%s"', $id));
+
+        return $this->client->read(
+            '/manage/api/internal/change-requests/saml20_sp/' . $id
+        );
+    }
 }

--- a/tests/integration/Application/ViewObject/EntityActionsTest.php
+++ b/tests/integration/Application/ViewObject/EntityActionsTest.php
@@ -168,11 +168,25 @@ class EntityActionsTest extends TestCase
             'manage-id',
             1,
             Constants::STATE_PUBLISHED,
-            Constants::ENVIRONMENT_TEST,
+            Constants::ENVIRONMENT_PRODUCTION,
             Constants::TYPE_SAML,
             false
         );
 
         $this->assertTrue($actions->allowChangeRequestAction());
+    }
+
+    public function test_change_request_action_is_not_allowed()
+    {
+        $actions = new EntityActions(
+            'manage-id',
+            1,
+            Constants::STATE_PUBLISHED,
+            Constants::ENVIRONMENT_TEST,
+            Constants::TYPE_SAML,
+            false
+        );
+
+        $this->assertFalse($actions->allowChangeRequestAction());
     }
 }

--- a/tests/integration/Application/ViewObject/EntityActionsTest.php
+++ b/tests/integration/Application/ViewObject/EntityActionsTest.php
@@ -161,4 +161,18 @@ class EntityActionsTest extends TestCase
         );
         $this->assertTrue($shouldBeEditable2->allowEditAction());
     }
+
+    public function test_change_request_action_is_allowed()
+    {
+        $actions = new EntityActions(
+            'manage-id',
+            1,
+            Constants::STATE_PUBLISHED,
+            Constants::ENVIRONMENT_TEST,
+            Constants::TYPE_SAML,
+            false
+        );
+
+        $this->assertTrue($actions->allowChangeRequestAction());
+    }
 }

--- a/tests/unit/Domain/ValueObject/ChangeRequestDtoCollectionTest.php
+++ b/tests/unit/Domain/ValueObject/ChangeRequestDtoCollectionTest.php
@@ -85,16 +85,5 @@ class ChangeRequestDtoCollectionTest extends TestCase
         $this->assertEquals('2022-09-21 17:00:00', ($collection->getChangeRequests()[0])->getCreated()->format('Y-m-d H:i:s'));
         $this->assertEquals('2022-09-21 16:00:00', ($collection->getChangeRequests()[1])->getCreated()->format('Y-m-d H:i:s'));
         $this->assertEquals('2022-09-21 15:00:00', ($collection->getChangeRequests()[2])->getCreated()->format('Y-m-d H:i:s'));
-        $this->assertEquals(3, ($collection->getChangeRequests()[0])->getId());
-        $this->assertEquals(1, ($collection->getChangeRequests()[1])->getId());
-        $this->assertEquals(2, ($collection->getChangeRequests()[2])->getId());
-    }
-
-    public function test_it_handles_empty_changes()
-    {
-        $changes = [];
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('No change requests available');
-        new ChangeRequestDtoCollection($changes);
     }
 }

--- a/tests/unit/Domain/ValueObject/ChangeRequestDtoCollectionTest.php
+++ b/tests/unit/Domain/ValueObject/ChangeRequestDtoCollectionTest.php
@@ -18,39 +18,83 @@
 
 namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Domain\ValueObject;
 
-use Exception;
 use PHPUnit\Framework\TestCase;
-use Surfnet\ServiceProviderDashboard\Application\Dto\ChangeRequestDto;
 use Surfnet\ServiceProviderDashboard\Application\Dto\ChangeRequestDtoCollection;
+use Webmozart\Assert\InvalidArgumentException;
 
 class ChangeRequestDtoCollectionTest extends TestCase
 {
     public function test_it_is_created()
     {
-        $changes[] = [
-            'id' => 1,
-            'note' => 'a cracked note',
-            'created' => '2022-09-21 15:00:00',
-            'pathUpdates' => [
-                'metaDataFields.description:nl' => 'description nl',
-                'metaDataFields.description:en' => 'description en'
-            ]
-        ];
-        $changes[] = [
-            'id' => 1,
-            'note' => 'another cracked note',
-            'created' => '2022-09-21 16:00:00',
-            'pathUpdates' => [
-                'metaDataFields.name:nl' => 'change nl 2',
-                'metaDataFields.name:en' => 'change en 2'
+        $changes = [
+            [
+                'id' => 1,
+                'note' => 'a cracked note',
+                'created' => '2022-09-21 15:00:00',
+                'pathUpdates' => [
+                    'metaDataFields.description:nl' => 'description nl',
+                    'metaDataFields.description:en' => 'description en'
+                ]
+            ],
+            [
+                'id' => 1,
+                'note' => 'another cracked note',
+                'created' => '2022-09-21 16:00:00',
+                'pathUpdates' => [
+                    'metaDataFields.name:nl' => 'change nl 2',
+                    'metaDataFields.name:en' => 'change en 2'
+                ]
             ]
         ];
 
         $collection = new ChangeRequestDtoCollection($changes);
 
         $this->assertIsArray($collection->getChangeRequests());
-        $this->assertEquals(2, $collection->count());
         $this->assertCount(2, $collection->getChangeRequests());
     }
-}
 
+    public function test_it_sorts_on_created_date_time_descending()
+    {
+        $changes = [
+            [
+                'id' => 1,
+                'created' => '2022-09-21 16:00:00',
+                'pathUpdates' => [
+                    'metaDataFields.description:nl' => 'description nl',
+                ]
+            ],
+            [
+                'id' => 2,
+                'created' => '2022-09-21 15:00:00',
+                'pathUpdates' => [
+                    'metaDataFields.description:nl' => 'description en',
+                    ]
+            ],
+            [
+                'id' => 3,
+                'created' => '2022-09-21 17:00:00',
+                'pathUpdates' => [
+                    'metaDataFields.description:nl' => 'description de',
+                    ]
+            ]
+        ];
+        $collection = new ChangeRequestDtoCollection($changes);
+
+        $this->assertIsArray($collection->getChangeRequests());
+        $this->assertCount(3, $collection->getChangeRequests());
+        $this->assertEquals('2022-09-21 17:00:00', ($collection->getChangeRequests()[0])->getCreated()->format('Y-m-d H:i:s'));
+        $this->assertEquals('2022-09-21 16:00:00', ($collection->getChangeRequests()[1])->getCreated()->format('Y-m-d H:i:s'));
+        $this->assertEquals('2022-09-21 15:00:00', ($collection->getChangeRequests()[2])->getCreated()->format('Y-m-d H:i:s'));
+        $this->assertEquals(3, ($collection->getChangeRequests()[0])->getId());
+        $this->assertEquals(1, ($collection->getChangeRequests()[1])->getId());
+        $this->assertEquals(2, ($collection->getChangeRequests()[2])->getId());
+    }
+
+    public function test_it_handles_empty_changes()
+    {
+        $changes = [];
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No change requests available');
+        new ChangeRequestDtoCollection($changes);
+    }
+}

--- a/tests/unit/Domain/ValueObject/ChangeRequestDtoCollectionTest.php
+++ b/tests/unit/Domain/ValueObject/ChangeRequestDtoCollectionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Domain\ValueObject;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Surfnet\ServiceProviderDashboard\Application\Dto\ChangeRequestDto;
+use Surfnet\ServiceProviderDashboard\Application\Dto\ChangeRequestDtoCollection;
+
+class ChangeRequestDtoCollectionTest extends TestCase
+{
+    public function test_it_is_created()
+    {
+        $changes[] = [
+            'id' => 1,
+            'note' => 'a cracked note',
+            'created' => '2022-09-21 15:00:00',
+            'pathUpdates' => [
+                'metaDataFields.description:nl' => 'description nl',
+                'metaDataFields.description:en' => 'description en'
+            ]
+        ];
+        $changes[] = [
+            'id' => 1,
+            'note' => 'another cracked note',
+            'created' => '2022-09-21 16:00:00',
+            'pathUpdates' => [
+                'metaDataFields.name:nl' => 'change nl 2',
+                'metaDataFields.name:en' => 'change en 2'
+            ]
+        ];
+
+        $collection = new ChangeRequestDtoCollection($changes);
+
+        $this->assertIsArray($collection->getChangeRequests());
+        $this->assertEquals(2, $collection->count());
+        $this->assertCount(2, $collection->getChangeRequests());
+    }
+}
+

--- a/tests/unit/Domain/ValueObject/ChangeRequestDtoTest.php
+++ b/tests/unit/Domain/ValueObject/ChangeRequestDtoTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Domain\ValueObject;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Surfnet\ServiceProviderDashboard\Application\Dto\ChangeRequestDto;
+
+class ChangeRequestDtoTest extends TestCase
+{
+    public function test_it_is_created()
+    {
+        $changes = [
+            'id' => 1,
+            'note' => 'a cracked note',
+            'created' => '2022-09-21 15:00:00',
+            'pathUpdates' => [
+                'metaDataFields.description:nl' => 'description nl',
+                'metaDataFields.description:en' => 'description en'
+            ]
+        ];
+
+        $changeRequest = ChangeRequestDto::fromChangeRequest($changes);
+
+        $this->assertEquals(1, $changeRequest->getId());
+        $this->assertEquals('a cracked note', $changeRequest->getNote());
+        $this->assertEquals('2022-09-21 15:00:00', $changeRequest->getCreated()->format('Y-m-d H:i:s'));
+        $this->assertIsArray($changeRequest->getPathUpdates());
+        $this->assertEquals(2, count($changeRequest->getPathUpdates()));
+    }
+
+    public function test_it_throw_exception_on_invalid_date_time()
+    {
+        $changes = [
+            'id' => 1,
+            'note' => 'a cracked note',
+            'created' => '20220-31-12 15:00:00',
+            'pathUpdates' => [
+                'metaDataFields.description:nl' => 'description nl',
+                'metaDataFields.description:en' => 'description en'
+            ]
+        ];
+
+        $this->expectException(Exception::class);
+        ChangeRequestDto::fromChangeRequest($changes);
+    }
+
+    public function test_it_allows_an_null_note()
+    {
+        $changes = [
+            'id' => 1,
+            'note' => null,
+            'created' => '2022-09-21 15:00:00',
+            'pathUpdates' => [
+                'metaDataFields.description:nl' => 'description nl',
+                'metaDataFields.description:en' => 'description en'
+            ]
+        ];
+        $changeRequest = ChangeRequestDto::fromChangeRequest($changes);
+        $this->assertEquals(null, $changeRequest->getNote());
+    }
+}
+

--- a/tests/unit/Domain/ValueObject/ChangeRequestDtoTest.php
+++ b/tests/unit/Domain/ValueObject/ChangeRequestDtoTest.php
@@ -119,4 +119,54 @@ class ChangeRequestDtoTest extends TestCase
         $this->expectExceptionMessage('No pathUpdates specified');
         ChangeRequestDto::fromChangeRequest($changes);
     }
+
+    public function test_it_flattens_arp_values()
+    {
+        $changes = [
+            'id' => 1,
+            'created' => '2022-09-21 15:00:00',
+            'pathUpdates' => [
+                'metaDataFields.description:nl' => 'description nl',
+                'metaDataFields.description:en' => 'description en',
+                'arp' => array (
+                    'attributes' =>
+                        array (
+                            'urn:mace:dir:attribute-def:eduPersonScopedAffiliation' =>
+                                array (
+                                    0 =>
+                                        array (
+                                            'source' => 'idp',
+                                            'value' => '*',
+                                            'motivation' => 'Test',
+                                        ),
+                                ),
+                            'urn:mace:dir:attribute-def:mail' =>
+                                array (
+                                    0 =>
+                                        array (
+                                            'source' => 'idp',
+                                            'value' => '*',
+                                            'motivation' => 'Handy attribute to contact our customer, but why? We do not know',
+                                        ),
+                                ),
+                            'urn:mace:dir:attribute-def:cn' =>
+                                array (
+                                    0 =>
+                                        array (
+                                            'source' => 'idp',
+                                            'value' => '*',
+                                            'motivation' => 'Test',
+                                        ),
+                                ),
+                        ),
+                    'enabled' => true,
+                )
+            ]
+        ];
+        $changeRequest = ChangeRequestDto::fromChangeRequest($changes);
+        $this->assertCount(5, $changeRequest->getPathUpdates());
+        $this->assertArrayHasKey('urn:mace:dir:attribute-def:eduPersonScopedAffiliation', $changeRequest->getPathUpdates());
+        $this->assertArrayHasKey('urn:mace:dir:attribute-def:mail', $changeRequest->getPathUpdates());
+        $this->assertArrayHasKey('urn:mace:dir:attribute-def:cn', $changeRequest->getPathUpdates());
+    }
 }

--- a/tests/unit/Domain/ValueObject/ChangeRequestDtoTest.php
+++ b/tests/unit/Domain/ValueObject/ChangeRequestDtoTest.php
@@ -39,7 +39,6 @@ class ChangeRequestDtoTest extends TestCase
 
         $changeRequest = ChangeRequestDto::fromChangeRequest($changes);
 
-        $this->assertEquals(1, $changeRequest->getId());
         $this->assertEquals('a cracked note', $changeRequest->getNote());
         $this->assertEquals('2022-09-21 15:00:00', $changeRequest->getCreated()->format('Y-m-d H:i:s'));
         $this->assertIsArray($changeRequest->getPathUpdates());
@@ -91,19 +90,9 @@ class ChangeRequestDtoTest extends TestCase
         $this->assertEquals('', $changeRequest->getNote());
     }
 
-    public function test_it_handles_invalid_input()
-    {
-        $changes = [];
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('No id specified');
-        ChangeRequestDto::fromChangeRequest($changes);
-    }
-
     public function test_it_throws_exception_on_missing_create_date_time()
     {
-        $changes = [
-            'id' => 1,
-        ];
+        $changes = [];
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('No create datetime specified');
         ChangeRequestDto::fromChangeRequest($changes);

--- a/tests/webtests/EntityEditTest.php
+++ b/tests/webtests/EntityEditTest.php
@@ -237,7 +237,7 @@ class EntityEditTest extends WebTestCase
 
     public function test_it_renders_the_change_request_form()
     {
-        $crawler = $this->client->request('GET', "/entity/change-request/{environment}/{$this->manageId}/1");
+        $crawler = $this->client->request('GET', "/entity/change-request/test/{$this->manageId}/1");
         self::assertEquals(200, $this->client->getResponse()->getStatusCode());
 
         $title = $crawler->filter('.page-container h1');
@@ -246,12 +246,12 @@ class EntityEditTest extends WebTestCase
 
     public function test_it_renders_the_change_request()
     {
-        $crawler = $this->client->request('GET', "/entity/change-request/{environment}/{$this->manageId}/620f904ab451045ee60eda74");
+        $crawler = $this->client->request('GET', "/entity/change-request/test/{$this->manageId}/1");
         self::assertEquals(200, $this->client->getResponse()->getStatusCode());
 
         $date = $crawler->filter('h2')->first();
         $this->assertEquals('September 21, 2022 13:32', $date->text());
-        $note = $crawler->filter('h2')->last();
+        $note = $crawler->filter('p')->last();
         $this->assertEquals('Optional note describing the reason for this change', $note->text());
         $value = $crawler->filter('td')->first();
         $this->assertEquals('metaDataFields.description:en', $value->text());

--- a/tests/webtests/EntityEditTest.php
+++ b/tests/webtests/EntityEditTest.php
@@ -235,6 +235,30 @@ class EntityEditTest extends WebTestCase
         );
     }
 
+    public function test_it_renders_the_change_request_form()
+    {
+        $crawler = $this->client->request('GET', "/entity/change-request/{environment}/{$this->manageId}/1");
+        self::assertEquals(200, $this->client->getResponse()->getStatusCode());
+
+        $title = $crawler->filter('.page-container h1');
+        $this->assertEquals('Change request overview', $title->text());
+    }
+
+    public function test_it_renders_the_change_request()
+    {
+        $crawler = $this->client->request('GET', "/entity/change-request/{environment}/{$this->manageId}/620f904ab451045ee60eda74");
+        self::assertEquals(200, $this->client->getResponse()->getStatusCode());
+
+        $date = $crawler->filter('h2')->first();
+        $this->assertEquals('September 21, 2022 13:32', $date->text());
+        $note = $crawler->filter('h2')->last();
+        $this->assertEquals('Optional note describing the reason for this change', $note->text());
+        $value = $crawler->filter('td')->first();
+        $this->assertEquals('metaDataFields.description:en', $value->text());
+        $data = $crawler->filter('td')->last();
+        $this->assertEquals('https://nice', $data->text());
+    }
+
     public function test_it_allows_publication_change_requests()
     {
         $crawler = $this->client->request('GET', "/entity/edit/production/9628d851-abd1-2283-a8f1-a29ba5036174/1");

--- a/tests/webtests/EntityEditTest.php
+++ b/tests/webtests/EntityEditTest.php
@@ -250,7 +250,9 @@ class EntityEditTest extends WebTestCase
         self::assertEquals(200, $this->client->getResponse()->getStatusCode());
 
         $date = $crawler->filter('h2')->first();
-        $this->assertEquals('September 21, 2022 13:32', $date->text());
+        // Note the timezone difference here compared to the time found in the fixture.
+        // The times in the fixture (in manage) are UTC. We are on Europe/Amsterdam (+2)
+        $this->assertEquals('September 21, 2022 15:32', $date->text());
         $note = $crawler->filter('p')->last();
         $this->assertEquals('Optional note describing the reason for this change', $note->text());
         $value = $crawler->filter('td')->first();

--- a/tests/webtests/Manage/Client/FakeEntityChangeRequestClient.php
+++ b/tests/webtests/Manage/Client/FakeEntityChangeRequestClient.php
@@ -28,4 +28,17 @@ class FakeEntityChangeRequestClient implements EntityChangeRequestRepository
     {
         return ['id' => 'the-entity-id-uuid'];
     }
+
+    public function getChangeRequest(string $id): array
+    {
+        $changeRequests = [];
+
+        switch ($id) {
+            case '9729d851-cfdd-4283-a8f1-a29ba5036261':
+                $changeRequests[] = json_decode(file_get_contents(
+                    __DIR__ . '/../../fixtures/change-request/manage-change-request-with-note.json'
+                ), true, 512);
+        }
+        return $changeRequests;
+    }
 }

--- a/tests/webtests/fixtures/change-request/manage-change-request-with-note.json
+++ b/tests/webtests/fixtures/change-request/manage-change-request-with-note.json
@@ -1,0 +1,22 @@
+{
+  "id" : "620f904ab451045ee60eda74",
+  "metaDataId" : "1",
+  "type" : "saml20_sp",
+  "pathUpdates" : {
+    "metaDataFields.description:en" : "New description",
+    "metaDataFields.coin:application_url" : "https://nice"
+  },
+  "auditData" : {
+    "user" : "jdoe",
+    "userName" : "sp-portal",
+    "apiUser" : true
+  },
+  "note": "Optional note describing the reason for this change",
+  "created" : "2022-09-21T13:32:46.032Z",
+  "metaDataSummary" : {
+    "organizationName" : "Organization name en",
+    "name" : "OpenConext Valid SP",
+    "entityid" : "Duis ad do",
+    "state" : "testaccepted"
+  }
+}


### PR DESCRIPTION
This branch was previously under scrutiny in https://github.com/SURFnet/sp-dashboard/pull/525

That PR got merged into a branch that later ditched the change request overview changes. And that resulted in the feature not landing into `develop`.

This PR should set the record straight. No code changes where made, so this will be merged once the automated tests pass.