### PR TITLE
Attribute schema validator

### DIFF
--- a/app/Resources/schemas/attributes.scheme.json
+++ b/app/Resources/schemas/attributes.scheme.json
@@ -1,0 +1,166 @@
+{
+	"definitions": {},
+	"$schema": "http://json-schema.org/draft-07/schema#", 
+	"$id": "https://example.com/object1665996754.json", 
+	"title": "Root", 
+	"type": "array",
+	"default": [],
+	"items":{
+		"$id": "#root/items", 
+		"title": "Items", 
+		"type": "object",
+		"required": [
+			"id",
+			"form",
+			"detail",
+			"urns"
+		],
+		"properties": {
+			"id": {
+				"$id": "#root/items/id", 
+				"title": "Id", 
+				"type": "string",
+				"default": "",
+				"examples": [
+					"givenName"
+				],
+				"pattern": "^.*$"
+			},
+			"form": {
+				"$id": "#root/items/form", 
+				"title": "Form", 
+				"type": "object",
+				"required": [
+					"translations"
+				],
+				"properties": {
+					"excludeOnEntityType": {
+						"$id": "#root/items/form/excludeOnEntityType",
+						"title": "Excludeonentitytype",
+						"type": "array",
+						"default": [],
+						"items":{
+							"$id": "#root/items/form/excludeOnEntityType/items",
+							"title": "Items",
+							"type": "string",
+							"default": "",
+							"enum": [
+								"saml20",
+								"oidcng",
+								"oauth20_rs",
+								"oauth20_ccc"
+							],
+							"examples": [
+								"oidcng"
+							],
+							"pattern": "^.*$"
+						}
+					},
+					"translations": {
+						"$id": "#root/items/form/translations",
+						"title": "Translations",
+						"type": "object",
+						"required": [
+							"en"
+						],
+						"patternProperties": {
+							"^en|xy$": {
+								"$id": "#root/items/form/translations/en",
+								"title": "En",
+								"type": "object",
+								"required": [
+									"label",
+									"info"
+								],
+								"properties": {
+									"label": {
+										"$id": "#root/items/form/translations/en/label",
+										"title": "Label",
+										"type": "string",
+										"default": "",
+										"examples": [
+											"Given name attribute"
+										],
+										"pattern": "^.*$"
+									},
+									"info": {
+										"$id": "#root/items/form/translations/en/info",
+										"title": "Info",
+										"type": "string",
+										"default": "",
+										"examples": [
+											"Text should be set in web translations"
+										],
+										"pattern": "^.*$"
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					}
+				}
+			}
+,
+			"detail": {
+				"$id": "#root/items/detail", 
+				"title": "Detail", 
+				"type": "object",
+				"required": [
+					"en"
+				],
+				"patternProperties": {
+					"^en$": {
+						"$id": "#root/items/detail/en", 
+						"title": "En", 
+						"type": "object",
+						"required": [
+							"label",
+							"info"
+						],
+						"properties": {
+							"label": {
+								"$id": "#root/items/detail/en/label", 
+								"title": "Label", 
+								"type": "string",
+								"default": "",
+								"examples": [
+									"Given name attribute"
+								],
+								"pattern": "^.*$"
+							},
+							"info": {
+								"$id": "#root/items/detail/en/info", 
+								"title": "Info", 
+								"type": "string",
+								"default": "",
+								"examples": [
+									"Text should be set in web translations"
+								],
+								"pattern": "^.*$"
+							}
+						}
+					}
+				},
+				"additionalProperties": false
+			}
+,
+			"urns": {
+				"$id": "#root/items/urns", 
+				"title": "Urns", 
+				"type": "array",
+				"default": [],
+				"items":{
+					"$id": "#root/items/urns/items", 
+					"title": "Items", 
+					"type": "string",
+					"default": "",
+					"examples": [
+						"urn:mace:dir:attribute-def:givenName"
+					],
+					"pattern": "^.*$"
+				}
+			}
+		}
+	}
+
+}

--- a/app/Resources/schemas/attributes.scheme.json
+++ b/app/Resources/schemas/attributes.scheme.json
@@ -1,8 +1,7 @@
 {
 	"definitions": {},
 	"$schema": "http://json-schema.org/draft-07/schema#", 
-	"$id": "https://example.com/object1665996754.json", 
-	"title": "Root", 
+	"title": "Root",
 	"type": "array",
 	"default": [],
 	"items":{
@@ -24,7 +23,7 @@
 				"examples": [
 					"givenName"
 				],
-				"pattern": "^.*$"
+				"pattern": "^[a-z][a-zA-Z]*$"
 			},
 			"form": {
 				"$id": "#root/items/form", 
@@ -36,7 +35,7 @@
 				"properties": {
 					"excludeOnEntityType": {
 						"$id": "#root/items/form/excludeOnEntityType",
-						"title": "Excludeonentitytype",
+						"title": "Exclude on entity type",
 						"type": "array",
 						"default": [],
 						"items":{
@@ -49,11 +48,7 @@
 								"oidcng",
 								"oauth20_rs",
 								"oauth20_ccc"
-							],
-							"examples": [
-								"oidcng"
-							],
-							"pattern": "^.*$"
+							]
 						}
 					},
 					"translations": {
@@ -64,7 +59,7 @@
 							"en"
 						],
 						"patternProperties": {
-							"^en|xy$": {
+							"^en$": {
 								"$id": "#root/items/form/translations/en",
 								"title": "En",
 								"type": "object",
@@ -80,18 +75,13 @@
 										"default": "",
 										"examples": [
 											"Given name attribute"
-										],
-										"pattern": "^.*$"
+										]
 									},
 									"info": {
 										"$id": "#root/items/form/translations/en/info",
 										"title": "Info",
 										"type": "string",
-										"default": "",
-										"examples": [
-											"Text should be set in web translations"
-										],
-										"pattern": "^.*$"
+										"default": ""
 									}
 								}
 							}
@@ -125,18 +115,13 @@
 								"default": "",
 								"examples": [
 									"Given name attribute"
-								],
-								"pattern": "^.*$"
+								]
 							},
 							"info": {
 								"$id": "#root/items/detail/en/info", 
 								"title": "Info", 
 								"type": "string",
-								"default": "",
-								"examples": [
-									"Text should be set in web translations"
-								],
-								"pattern": "^.*$"
+								"default": ""
 							}
 						}
 					}
@@ -156,11 +141,9 @@
 					"default": "",
 					"examples": [
 						"urn:mace:dir:attribute-def:givenName"
-					],
-					"pattern": "^.*$"
+					]
 				}
 			}
 		}
 	}
-
 }

--- a/build.xml
+++ b/build.xml
@@ -67,6 +67,15 @@
             <arg path="tests" />
         </exec>
 
+        <echo message="${line.separator}attribute-scheme-validation"/>
+        <exec executable="node_modules/.bin/ajv" failonerror="true">
+            <arg line="compile -s app/Resources/schemas/attributes.scheme.json" />
+        </exec>
+
+        <echo message="${line.separator}attribute-data-validation"/>
+        <exec executable="node_modules/.bin/ajv" failonerror="true">
+            <arg line="validate -s app/Resources/schemas/attributes.scheme.json -d app/config/attributes.json" />
+        </exec>
 
         <echo message="${line.separator}phpcpd:" />
         <exec executable="vendor/bin/phpcpd" failonerror="false">

--- a/docs/arp-attribute-configuration.md
+++ b/docs/arp-attribute-configuration.md
@@ -56,7 +56,9 @@ The available options are: 'saml20' (sp), 'oidcng' (rp), 'oauth20_rs', 'oauth20_
 
 #### `translations`
 An object of translatable form related ui 'components'. The array of translations are keyed on the language it represents.
-The language is to be configured in i18n country codes. At this point we only support English: `en`.
+The language is to be configured in i18n country codes. At this point we only support English: `en`. To support other languages 
+it is sufficient to extend the "patternProperties" for both the form and detail within the attributes.scheme.json. 
+E.g. to extend with Dutch (nl) the following is sufficient: "^en|nl$"
 
 The object in turn is built up out of two properties
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -22,6 +22,7 @@ test code as well as production code;
  - PHP Mess Detector checks a number of metrics, and if they exceed a certain treshold the build will fail;
  - PHP CodeSniffer ensures that the code adheres to the chosen coding standard (PSR-2);
  - PHP Copy-Paste Detector ensures that there is no substantial duplication within the source code.
+ - A JSON schema validator ensures that the JSON-schema is valid and validates the JSON-data against the JSON-schema.
  
 If any of those tools fails, the build will fail and the issue has to be resolved before a pull request can be merged.
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "@symfony/webpack-encore": "^3.1",
     "@types/jest": "^28",
+    "ajv-cli": "^5.0.0",
     "compass-mixins": "^0.12.10",
     "css-loader": "^6.7",
     "import-glob-loader": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1895,6 +1895,19 @@ agent-base@6:
   dependencies:
     debug "4"
 
+ajv-cli@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ajv-cli/-/ajv-cli-5.0.0.tgz#78956ed2934e6dde4c9e696b587be1c2998862e8"
+  integrity sha512-LY4m6dUv44HTyhV+u2z5uX4EhPYTM38Iv1jdgDJJJCyOOuqB8KtZEGjPZ2T+sh5ZIJrXUfgErYx/j3gLd3+PlQ==
+  dependencies:
+    ajv "^8.0.0"
+    fast-json-patch "^2.0.0"
+    glob "^7.1.0"
+    js-yaml "^3.14.0"
+    json-schema-migrate "^2.0.0"
+    json5 "^2.1.3"
+    minimist "^1.2.0"
+
 ajv-formats@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
@@ -3261,6 +3274,11 @@ express@^4.17.3:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -3276,6 +3294,13 @@ fast-glob@^3.2.11, fast-glob@^3.2.2, fast-glob@^3.2.9:
     glob-parent "^5.1.2"
     merge2 "^1.3.0"
     micromatch "^4.0.4"
+
+fast-json-patch@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/fast-json-patch/-/fast-json-patch-2.2.1.tgz#18150d36c9ab65c7209e7d4eb113f4f8eaabe6d9"
+  integrity sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==
+  dependencies:
+    fast-deep-equal "^2.0.1"
 
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
@@ -3507,7 +3532,7 @@ glob@^5.0.13:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4:
+glob@^7.0.3, glob@^7.1.0, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -4508,7 +4533,7 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1:
+js-yaml@^3.13.1, js-yaml@^3.14.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -4578,6 +4603,13 @@ json-parse-even-better-errors@^2.3.0, json-parse-even-better-errors@^2.3.1:
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
+json-schema-migrate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-migrate/-/json-schema-migrate-2.0.0.tgz#335ef5218cd32fcc96c1ddce66c71ba586224496"
+  integrity sha512-r38SVTtojDRp4eD6WsCqiE0eNDt4v1WalBXb9cyZYw9ai5cGtBwzRNWjHzJl38w6TxFkXAIA7h+fyX3tnrAFhQ==
+  dependencies:
+    ajv "^8.0.0"
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -4593,7 +4625,7 @@ json5@^0.5.0:
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
   integrity sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==
 
-json5@^2.1.2, json5@^2.2.1:
+json5@^2.1.2, json5@^2.1.3, json5@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
@@ -4887,6 +4919,11 @@ minimist-options@4.1.0:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
+
+minimist@^1.2.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
+  integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
 
 minimist@^1.2.6:
   version "1.2.6"


### PR DESCRIPTION
When attributes are maintained within the attributes.json some validation has to be done to avoid unwanted errors. An attributes.scheme.json has been added to check to attributes.json against this scheme. The initial version of the scheme is generated by https://extendsclass.com/json-schema-validator.html. Further refinement is done by adding so called 'patternProperties' to support multiple languages easily by extending the pattern "^en$" by e.g. "^en|nl$" to support Dutch. Another adjustment to mention is the enumeration of supported entityt ypes within the excludeOnEntityType property.

see: https://www.pivotaltracker.com/story/show/182219948