### PR TITLE
Remove flash message from production edit action

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityEditController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityEditController.php
@@ -98,7 +98,9 @@ class EntityEditController extends Controller
                         $response = $this->publishEntity($entity, $command, $isProductionEntityEdit, $flashBag);
 
                         if ($response instanceof Response) {
-                            $flashBag->add('info', 'entity.edit.metadata.flash.success');
+                            if ($environment !== Constants::ENVIRONMENT_PRODUCTION) {
+                                $flashBag->add('info', 'entity.edit.metadata.flash.success');
+                            }
                             return $response;
                         }
                     } else {


### PR DESCRIPTION
When a prod entity is saved (change request) sucesfully, we used to add a flash message. Showing the user the save action was a succes. This is no longer the case, as this action would result in showing a thank you page. And having both a flash message and a thank you page is a little too much.

See: https://www.pivotaltracker.com/story/show/182246029/comments/233754893