### PR TITLE
Filter out resolved Jira tickets

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/IssueRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/IssueRepository.php
@@ -134,7 +134,7 @@ class IssueRepository implements TicketServiceInterface
         // Search CTX: "$issueType" issues with manage id as provided in the $manageId parameter
         $issues = $issueService->search(
             sprintf(
-                'project = %s AND issuetype = %s AND "%s" ~ %s',
+                'project = %s AND issuetype = %s AND resolution = Unresolved AND "%s" ~ %s',
                 $this->projectKey,
                 $issueType,
                 $this->manageIdFieldLabel,


### PR DESCRIPTION
When finding Jira tickets by manage id and an issue type (when looking for a specific ticket for a specific entity). The `resolution` was not taken into account. Resulting in opening no new ticket when a ticket was previously resolved in Jira.

See: https://www.pivotaltracker.com/story/show/182411807/comments/233832245