### PR TITLE
Repair hardcoded saml change request to protocol within the entity

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/ChangeRequestService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/ChangeRequestService.php
@@ -19,6 +19,7 @@
 namespace Surfnet\ServiceProviderDashboard\Application\Service;
 
 use Surfnet\ServiceProviderDashboard\Application\Dto\ChangeRequestDtoCollection;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Protocol;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityChangeRequestRepository;
 
 class ChangeRequestService implements ChangeRequestServiceInterface
@@ -37,9 +38,9 @@ class ChangeRequestService implements ChangeRequestServiceInterface
     /**
      * @throws \Exception
      */
-    public function findById(string $id): ChangeRequestDtoCollection
+    public function findByIdAndProtocol(string $id, Protocol $protocol): ChangeRequestDtoCollection
     {
-        $values = $this->repository->getChangeRequest($id);
+        $values = $this->repository->getChangeRequest($id, $protocol);
         return new ChangeRequestDtoCollection($values);
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/ChangeRequestService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/ChangeRequestService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright 2022 SURFnet B.V.
  *
@@ -18,7 +20,6 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Service;
 
-use Exception;
 use Surfnet\ServiceProviderDashboard\Application\Dto\ChangeRequestDtoCollection;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Protocol;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityChangeRequestRepository;
@@ -36,19 +37,9 @@ class ChangeRequestService implements ChangeRequestServiceInterface
         $this->repository = $repository;
     }
 
-    /**
-     * @param string $id
-     * @param Protocol $protocol
-     * @return ChangeRequestDtoCollection|Exception
-     */
     public function findByIdAndProtocol(string $id, Protocol $protocol): ChangeRequestDtoCollection
     {
-        $values = [];
-        try {
-            $values = $this->repository->getChangeRequest($id, $protocol);
-        } catch (Exception $exception) {
-            throwException($exception);
-        }
+        $values = $this->repository->getChangeRequest($id, $protocol);
         return new ChangeRequestDtoCollection($values);
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/ChangeRequestService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/ChangeRequestService.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Service;
 
+use Exception;
 use Surfnet\ServiceProviderDashboard\Application\Dto\ChangeRequestDtoCollection;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Protocol;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityChangeRequestRepository;
@@ -36,11 +37,18 @@ class ChangeRequestService implements ChangeRequestServiceInterface
     }
 
     /**
-     * @throws \Exception
+     * @param string $id
+     * @param Protocol $protocol
+     * @return ChangeRequestDtoCollection|Exception
      */
     public function findByIdAndProtocol(string $id, Protocol $protocol): ChangeRequestDtoCollection
     {
-        $values = $this->repository->getChangeRequest($id, $protocol);
+        $values = [];
+        try {
+            $values = $this->repository->getChangeRequest($id, $protocol);
+        } catch (Exception $exception) {
+            throwException($exception);
+        }
         return new ChangeRequestDtoCollection($values);
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/ChangeRequestServiceInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/ChangeRequestServiceInterface.php
@@ -19,8 +19,9 @@
 namespace Surfnet\ServiceProviderDashboard\Application\Service;
 
 use Surfnet\ServiceProviderDashboard\Application\Dto\ChangeRequestDtoCollection;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Protocol;
 
 interface ChangeRequestServiceInterface
 {
-    public function findById(string $id): ChangeRequestDtoCollection;
+    public function findByIdAndProtocol(string $id, Protocol $protocol): ChangeRequestDtoCollection;
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Protocol.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Protocol.php
@@ -77,4 +77,9 @@ class Protocol implements Comparable
             'type' => $this->getProtocol(),
         ];
     }
+
+    public function getManagedProtocol(): string
+    {
+        return array_search($this->protocol, self::$protocolMapping);
+    }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Protocol.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Protocol.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 
+use Exception;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Comparable;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Webmozart\Assert\Assert;
@@ -78,8 +79,21 @@ class Protocol implements Comparable
         ];
     }
 
+    /**
+     * @throws Exception
+     */
     public function getManagedProtocol(): string
     {
-        return array_search($this->protocol, self::$protocolMapping);
+        /**
+         * An exception to the rule on 'oauth20_ccc'
+         */
+        if ($this->protocol === Constants::TYPE_OAUTH_CLIENT_CREDENTIAL_CLIENT) {
+            return self::OIDC10_RP;
+        }
+
+        if (in_array($this->protocol, self::$protocolMapping)) {
+            return array_search($this->protocol, self::$protocolMapping);
+        }
+        throw new Exception(sprintf('The protocol \'%s\' is not supported', $this->protocol));
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Protocol.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Protocol.php
@@ -21,6 +21,7 @@ namespace Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Exception;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Comparable;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
+use Surfnet\ServiceProviderDashboard\Domain\Exception\ProtocolNotFoundException;
 use Webmozart\Assert\Assert;
 
 class Protocol implements Comparable
@@ -94,6 +95,7 @@ class Protocol implements Comparable
         if (in_array($this->protocol, self::$protocolMapping)) {
             return array_search($this->protocol, self::$protocolMapping);
         }
-        throw new Exception(sprintf('The protocol \'%s\' is not supported', $this->protocol));
+
+        throw new ProtocolNotFoundException(sprintf('The protocol \'%s\' is not supported', $this->protocol));
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Exception/ProtocolNotFoundException.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Exception/ProtocolNotFoundException.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Domain\Exception;
+
+use Exception;
+
+class ProtocolNotFoundException extends Exception
+{
+}

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Repository/EntityChangeRequestRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Repository/EntityChangeRequestRepository.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Domain\Repository;
 
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Protocol;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 
@@ -31,5 +32,5 @@ interface EntityChangeRequestRepository
     /**
      * Get outstanding change request from manage
      */
-    public function getChangeRequest(string $id): array;
+    public function getChangeRequest(string $id, Protocol $protocol): array;
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityChangeRequestController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityChangeRequestController.php
@@ -20,10 +20,8 @@ namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Contro
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
 use Surfnet\ServiceProviderDashboard\Application\Service\ChangeRequestService;
 use Surfnet\ServiceProviderDashboard\Application\ViewObject\EntityActions;
-use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\QueryServiceProviderException;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -35,6 +33,7 @@ class EntityChangeRequestController extends Controller
     /**
      * @Method({"GET", "POST"})
      * @Route("/entity/change-request/{environment}/{manageId}/{serviceId}", name="entity_published_change_request")
+     * @throws \Exception
      */
     public function changeRequestAction(
         Request $request,
@@ -54,7 +53,7 @@ class EntityChangeRequestController extends Controller
             );
         }
 
-        $changeRequests = $service->findById($manageId);
+        $changeRequests = $service->findByIdAndProtocol($manageId, $entity->getProtocol());
 
         $actions = new EntityActions(
             $manageId,

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityChangeRequestController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityChangeRequestController.php
@@ -33,7 +33,6 @@ class EntityChangeRequestController extends Controller
     /**
      * @Method({"GET", "POST"})
      * @Route("/entity/change-request/{environment}/{manageId}/{serviceId}", name="entity_published_change_request")
-     * @throws \Exception
      */
     public function changeRequestAction(
         Request $request,

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -475,7 +475,6 @@ services:
     Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\EntityChangeRequestClient:
         arguments:
             $client: '@surfnet.manage.http.http_client.prod_environment'
-            $manageConfig: '@surfnet.manage.configuration.production'
 
     surfnet.teams.http.http_client:
         class: Surfnet\ServiceProviderDashboard\Infrastructure\Teams\TeamsClient

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/changeRequest.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/changeRequest.html.twig
@@ -32,7 +32,17 @@
                     {% for index, pathUpdate in changeRequest.pathUpdates %}
                     <tr>
                             <td>{{ index }}</td>
-                            <td>{{ pathUpdate }}</td>
+                            <td>
+                            {% if pathUpdate is iterable %}
+                                <ul>
+                                    {%  for name, value in pathUpdate %}
+                                        <li>{{ name }}: {{ value }}</li>
+                                    {% endfor %}
+                                </ul>
+                            {% else %}
+                                {{ pathUpdate }}
+                            {% endif %}
+                        </td>
                     </tr>
                     {%  endfor %}
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/changeRequest.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/changeRequest.html.twig
@@ -35,8 +35,8 @@
                             <td>
                             {% if pathUpdate is iterable %}
                                 <ul>
-                                    {%  for name, value in pathUpdate %}
-                                        <li>{{ name }}: {{ value }}</li>
+                                    {%  for value in pathUpdate %}
+                                        <li>{{ value }}</li>
                                     {% endfor %}
                                 </ul>
                             {% else %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/EntityChangeRequestClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/EntityChangeRequestClient.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client;
 
+use Exception;
 use Psr\Log\LoggerInterface;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGeneratorStrategy;
 use Surfnet\ServiceProviderDashboard\Application\ViewObject\Apis\ApiConfig;
@@ -80,12 +81,15 @@ class EntityChangeRequestClient implements EntityChangeRequestRepository
         return $response;
     }
 
+    /**
+     * @throws Exception
+     */
     public function getChangeRequest(string $id, Protocol $protocol): array
     {
         $this->logger->info(sprintf('Get outstanding change requests from manage for entity "%s"', $id));
 
         return $this->client->read(
-            '/manage/api/internal/change-requests/' . $protocol->getManagedProtocol() . '/' . $id
+            sprintf('/manage/api/internal/change-requests/%s/%s', $protocol->getManagedProtocol(), $id)
         );
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/EntityChangeRequestClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/EntityChangeRequestClient.php
@@ -18,10 +18,8 @@
 
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client;
 
-use Exception;
 use Psr\Log\LoggerInterface;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGeneratorStrategy;
-use Surfnet\ServiceProviderDashboard\Application\ViewObject\Apis\ApiConfig;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Protocol;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
@@ -46,20 +44,13 @@ class EntityChangeRequestClient implements EntityChangeRequestRepository
      */
     private $logger;
 
-    /**
-     * @var ApiConfig
-     */
-    private $manageConfig;
-
     public function __construct(
         HttpClientInterface $client,
         JsonGeneratorStrategy $generator,
-        ApiConfig $manageConfig,
         LoggerInterface $logger
     ) {
         $this->client = $client;
         $this->generator = $generator;
-        $this->manageConfig = $manageConfig;
         $this->logger = $logger;
     }
 
@@ -81,9 +72,6 @@ class EntityChangeRequestClient implements EntityChangeRequestRepository
         return $response;
     }
 
-    /**
-     * @throws Exception
-     */
     public function getChangeRequest(string $id, Protocol $protocol): array
     {
         $this->logger->info(sprintf('Get outstanding change requests from manage for entity "%s"', $id));

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/EntityChangeRequestClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/EntityChangeRequestClient.php
@@ -22,6 +22,7 @@ use Psr\Log\LoggerInterface;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGeneratorStrategy;
 use Surfnet\ServiceProviderDashboard\Application\ViewObject\Apis\ApiConfig;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Protocol;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityChangeRequestRepository;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\PublishMetadataException;
@@ -79,12 +80,12 @@ class EntityChangeRequestClient implements EntityChangeRequestRepository
         return $response;
     }
 
-    public function getChangeRequest(string $id): array
+    public function getChangeRequest(string $id, Protocol $protocol): array
     {
         $this->logger->info(sprintf('Get outstanding change requests from manage for entity "%s"', $id));
 
         return $this->client->read(
-            '/manage/api/internal/change-requests/saml20_sp/' . $id
+            '/manage/api/internal/change-requests/' . $protocol->getManagedProtocol() . '/' . $id
         );
     }
 }

--- a/tests/unit/Domain/Entity/Entity/ProtocolTest.php
+++ b/tests/unit/Domain/Entity/Entity/ProtocolTest.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Domain\Entity\Entity;
 
+use Exception;
 use PHPUnit\Framework\TestCase;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Protocol;
 
@@ -37,6 +38,22 @@ class ProtocolTest extends TestCase
         }
     }
 
+    /**
+     * @dataProvider provideProtocolManagedTestData
+     */
+    public function test_it_accepts_the_managed_protocol(Protocol $protocol, string $expectedProtocol)
+    {
+        self::assertEquals($expectedProtocol, $protocol->getManagedProtocol());
+    }
+
+    public function test_it_throws_exception_on_invalid_managed_protocol()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('The protocol \'fantasy\' is not supported');
+        $protocol = new Protocol('fantasy');
+        $protocol->getManagedProtocol();
+    }
+    
     public function provideProtocolTestData()
     {
         yield [
@@ -48,6 +65,26 @@ class ProtocolTest extends TestCase
             new Protocol('saml20'),
             new Protocol(null),
             new Protocol(null),
+        ];
+    }
+
+    public function provideProtocolManagedTestData()
+    {
+        yield [
+            new Protocol('saml20'),
+            'saml20_sp'
+        ];
+        yield [
+            new Protocol('oidcng'),
+            'oidc10_rp',
+        ];
+        yield [
+            new Protocol('oauth20_rs'),
+            'oauth20_rs',
+        ];
+        yield [
+            new Protocol('oauth20_ccc'),
+            'oidc10_rp',
         ];
     }
 }

--- a/tests/unit/Domain/Entity/Entity/ProtocolTest.php
+++ b/tests/unit/Domain/Entity/Entity/ProtocolTest.php
@@ -18,9 +18,9 @@
 
 namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Domain\Entity\Entity;
 
-use Exception;
 use PHPUnit\Framework\TestCase;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Protocol;
+use Surfnet\ServiceProviderDashboard\Domain\Exception\ProtocolNotFoundException;
 
 class ProtocolTest extends TestCase
 {
@@ -48,7 +48,7 @@ class ProtocolTest extends TestCase
 
     public function test_it_throws_exception_on_invalid_managed_protocol()
     {
-        $this->expectException(Exception::class);
+        $this->expectException(ProtocolNotFoundException::class);
         $this->expectExceptionMessage('The protocol \'fantasy\' is not supported');
         $protocol = new Protocol('fantasy');
         $protocol->getManagedProtocol();

--- a/tests/webtests/EntityEditTest.php
+++ b/tests/webtests/EntityEditTest.php
@@ -258,7 +258,7 @@ class EntityEditTest extends WebTestCase
         $value = $crawler->filter('td')->first();
         $this->assertEquals('metaDataFields.description:en', $value->text());
         $data = $crawler->filter('td')->last();
-        $this->assertEquals('https://nice', $data->text());
+        $this->assertEquals('https://nice', trim($data->text()));
     }
 
     public function test_it_allows_publication_change_requests()

--- a/tests/webtests/Manage/Client/FakeEntityChangeRequestClient.php
+++ b/tests/webtests/Manage/Client/FakeEntityChangeRequestClient.php
@@ -19,6 +19,7 @@
 namespace Surfnet\ServiceProviderDashboard\Webtests\Manage\Client;
 
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Protocol;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityChangeRequestRepository;
 
@@ -29,7 +30,7 @@ class FakeEntityChangeRequestClient implements EntityChangeRequestRepository
         return ['id' => 'the-entity-id-uuid'];
     }
 
-    public function getChangeRequest(string $id): array
+    public function getChangeRequest(string $id, Protocol $protocol): array
     {
         $changeRequests = [];
 


### PR DESCRIPTION
The protocol was hardcoded to saml_sp. Now the protocol used within the entity is used when requesting the changes from manage.

see: https://www.pivotaltracker.com/story/show/182411816