### PR TITLE
Show an overview of open Jira tickets concerning connection requests

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/ChangeRequestService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/ChangeRequestService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright 2022 SURFnet B.V.
  *
@@ -18,7 +20,6 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Service;
 
-use Exception;
 use Surfnet\ServiceProviderDashboard\Application\Dto\ChangeRequestDtoCollection;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Protocol;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityChangeRequestRepository;
@@ -36,19 +37,9 @@ class ChangeRequestService implements ChangeRequestServiceInterface
         $this->repository = $repository;
     }
 
-    /**
-     * @param string $id
-     * @param Protocol $protocol
-     * @return ChangeRequestDtoCollection|Exception
-     */
     public function findByIdAndProtocol(string $id, Protocol $protocol): ChangeRequestDtoCollection
     {
-        $values = [];
-        try {
-            $values = $this->repository->getChangeRequest($id, $protocol);
-        } catch (Exception $exception) {
-            throwException($exception);
-        }
+        $values = $this->repository->getChangeRequest($id, $protocol);
         return new ChangeRequestDtoCollection($values);
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/ConnectionRequestService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/ConnectionRequestService.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Service;
+
+use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityConnectionRequestRepository;
+
+class ConnectionRequestService implements ConnectionRequestServiceInterface
+{
+    /**
+     * @var EntityConnectionRequestRepository
+     */
+    private $repository;
+
+    public function __construct(EntityConnectionRequestRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function getOpenConnectionRequests(string $id): array
+    {
+        return $this->repository->getOpenConnectionRequest($id);
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/ConnectionRequestServiceInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/ConnectionRequestServiceInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Service;
+
+interface ConnectionRequestServiceInterface
+{
+    public function getOpenConnectionRequests(string $id): array;
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityActions.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityActions.php
@@ -55,8 +55,15 @@ class EntityActions
      */
     private $readOnly;
 
-    public function __construct(string $id, int $serviceId, string $status, string $environment, string $protocol, bool $isReadOnly)
-    {
+    public function __construct(
+        string $id,
+        int $serviceId,
+        string $status,
+        string $environment,
+        string $protocol,
+        bool $isReadOnly
+    ) {
+    
         $this->id = $id;
         $this->serviceId = $serviceId;
         $this->status = $status;
@@ -163,7 +170,8 @@ class EntityActions
         $meetsProtocolRequirement = $protocol == Constants::TYPE_OPENID_CONNECT_TNG ||
             $protocol == Constants::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER ||
             $protocol == Constants::TYPE_OAUTH_CLIENT_CREDENTIAL_CLIENT;
-        $meetsPublicationStatusRequirement = ($status == Constants::STATE_PUBLISHED || $status == Constants::STATE_PUBLICATION_REQUESTED);
+        $meetsPublicationStatusRequirement = ($status == Constants::STATE_PUBLISHED ||
+            $status == Constants::STATE_PUBLICATION_REQUESTED);
         return $meetsProtocolRequirement && $meetsPublicationStatusRequirement;
     }
 
@@ -175,6 +183,17 @@ class EntityActions
         return $this->status == Constants::STATE_PUBLISHED;
     }
 
+    public function allowOpenConnectionRequestAction(): bool
+    {
+        if ($this->readOnly || $this->environment !== Constants::ENVIRONMENT_PRODUCTION) {
+            return false;
+        }
+        $protocol = $this->protocol;
+        $meetsProtocolRequirement = $protocol == Constants::TYPE_SAML ||
+            $protocol == Constants::TYPE_OPENID_CONNECT_TNG;
+
+        return $meetsProtocolRequirement && $this->status == Constants::STATE_PUBLISHED;
+    }
 
     public function isPublishedToProduction()
     {

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Protocol.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Protocol.php
@@ -21,6 +21,7 @@ namespace Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
 use Exception;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Comparable;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
+use Surfnet\ServiceProviderDashboard\Domain\Exception\ProtocolNotFoundException;
 use Webmozart\Assert\Assert;
 
 class Protocol implements Comparable
@@ -94,6 +95,7 @@ class Protocol implements Comparable
         if (in_array($this->protocol, self::$protocolMapping)) {
             return array_search($this->protocol, self::$protocolMapping);
         }
-        throw new Exception(sprintf('The protocol \'%s\' is not supported', $this->protocol));
+
+        throw new ProtocolNotFoundException(sprintf('The protocol \'%s\' is not supported', $this->protocol));
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Exception/ProtocolNotFoundException.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Exception/ProtocolNotFoundException.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Domain\Exception;
+
+use Exception;
+
+class ProtocolNotFoundException extends Exception
+{
+}

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Repository/EntityConnectionRequestRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Repository/EntityConnectionRequestRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Domain\Repository;
+
+interface EntityConnectionRequestRepository
+{
+    /**
+     * Get outstanding connection requests from Jira
+     */
+    public function getOpenConnectionRequest(string $id): array;
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityOpenConnectionRequestController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityOpenConnectionRequestController.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Surfnet\ServiceProviderDashboard\Application\Service\ConnectionRequestService;
+use Surfnet\ServiceProviderDashboard\Application\ViewObject\EntityActions;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EntityOpenConnectionRequestController extends Controller
+{
+    use EntityControllerTrait;
+
+    /**
+     * @Method({"GET", "POST"})
+     * @Route("/entity/open-connection-request/{environment}/{manageId}/{serviceId}", name="entity_published_open_connection_request")
+     * @throws \Exception
+     */
+    public function changeRequestAction(
+        Request $request,
+        ConnectionRequestService $service,
+        int $serviceId,
+        string $manageId,
+        string $environment
+    ): Response {
+        $entity = $this->entityService->getManageEntityById($manageId, $environment);
+        $entityServiceId = $entity->getService()->getId();
+        // Verify the Entity Service Id is one of the logged in users services
+        $this->authorizationService->assertServiceIdAllowed($entityServiceId);
+        // Don't trust the url provided service id, check it against the Service Id associated with the entity
+        if ($entityServiceId !== $serviceId) {
+            throw $this->createAccessDeniedException(
+                'You are not allowed to view an Entity from another Service'
+            );
+        }
+
+        $actions = new EntityActions(
+            $manageId,
+            $entity->getService()->getId(),
+            $entity->getStatus(),
+            $entity->getEnvironment(),
+            $entity->getProtocol()->getProtocol(),
+            true
+        );
+
+        $connectionRequests = $service->getOpenConnectionRequests($manageId);
+
+
+        return $this->render(
+            '@Dashboard/EntityPublished/openConnectionRequest.html.twig',
+            [
+                'connectionRequests' => $connectionRequests,
+                'entity' => $entity,
+                'serviceId' => $serviceId,
+                'actions' => $actions,
+                'isAdmin' => $this->authorizationService->isAdministrator(),
+            ]
+        );
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -335,6 +335,10 @@ services:
         arguments:
             - '@Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\EntityChangeRequestClient'
 
+    Surfnet\ServiceProviderDashboard\Application\Service\ConnectionRequestService:
+        arguments:
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Client\EntityConnectionRequestClient'
+
     Surfnet\ServiceProviderDashboard\Application\Service\EntityAclService:
         arguments:
             - '@surfnet.manage.client.identity_provider_client.test_environment'
@@ -476,6 +480,11 @@ services:
         arguments:
             $client: '@surfnet.manage.http.http_client.prod_environment'
             $manageConfig: '@surfnet.manage.configuration.production'
+
+    Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Client\EntityConnectionRequestClient:
+        arguments:
+            - '@Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Factory\JiraServiceFactory'
+            - '@logger'
 
     surfnet.teams.http.http_client:
         class: Surfnet\ServiceProviderDashboard\Infrastructure\Teams\TeamsClient

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -154,7 +154,11 @@ entity:
         personal_code: Personal code attribute
         scoped_affiliation: Scoped affiliation attribute
         organization_unit_name: Organizational Unit Name
-entity.list.add_to_test: New test entity
+
+  list:
+    action:
+      open:
+        connection:
 entity.list.add_to_production: New production entity
 entity.list.name: Entity
 entity.list.entity_id: Entity ID
@@ -171,6 +175,7 @@ entity.list.action.delete: Delete
 entity.list.action.copy_to_production: Copy to production
 entity.list.action.reset_secret: Reset client secret
 entity.list.action.change.request: Change Request
+entity.list.action.open.connection.request: Show open connection requests
 entity.list.modal.oidc_confirmation:
   title: Confirmation
   client_id:
@@ -369,6 +374,9 @@ entity.change_request.value: Value
 entity.change_request.data: Data
 entity.change_request.text.html: "<p>All outstanding change requests</p>"
 entity.change_request.none.text.html: "<p>No outstanding change requests</p>"
+entity.open_connection_request.title: Open connection requests
+entity.open_connection_request.idp: IdP
+entity.open_connection_request.contact: Contact
 entity.edit.comments.title: Comments
 entity.edit.comments.html: "<p>If there are any questions regarding your SURFconext connection or this form, please leave them here.</p>"
 entity.edit.oidcngResourceServers.title: Select the OIDC Resource Servers(s) that belong to this Client

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityActions/actionsForList.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityActions/actionsForList.html.twig
@@ -5,4 +5,5 @@
     {% include "@Dashboard/EntityActions/secretResetAction.html.twig" with {action: entity} %}
     {% include "@Dashboard/EntityActions/deleteAction.html.twig" with {action: entity} %}
     {% include "@Dashboard/EntityActions/changeRequestAction.html.twig" with {action: entity} %}
+    {% include "@Dashboard/EntityActions/openConnectionRequestAction.html.twig" with {action: entity} %}
 </ul>

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityActions/openConnectionRequestAction.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityActions/openConnectionRequestAction.html.twig
@@ -1,0 +1,8 @@
+{% if action.allowOpenConnectionRequestAction %}
+    <li>
+        <a href="{{ path('entity_published_open_connection_request', {manageId: action.id, environment: action.environment, serviceId: action.serviceId}) }}">
+            <i class="fa fa-eye" aria-hidden="true"></i>
+            {{ 'entity.list.action.open.connection.request'|trans }}
+        </a>
+    </li>
+{% endif %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/openConnectionRequest.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/openConnectionRequest.html.twig
@@ -1,0 +1,34 @@
+{% extends '::base.html.twig' %}
+
+{% block body_container %}
+    <h1>{% block page_heading %}{{ 'entity.open_connection_request.title'|trans }}{%endblock%}</h1>
+
+    <div class="fieldset card action">
+        {% include '@Dashboard/EntityActions/actionsForDetail.html.twig' with {entity: actions, isAdmin: isAdmin} %}
+    </div>
+
+    {%  for request, idPs in connectionRequests %}
+        <h2>{{ request }}</h2>
+        <table class="connection-request-overview">
+            <tr>
+                <th>{{ 'entity.open_connection_request.idp'|trans }}</th>
+                <th>{{ 'entity.open_connection_request.contact'|trans }}</th>
+            </tr>
+            {% for idP in idPs %}
+                <tr>
+                    <td>{{ idP.idp }}</td>
+                    <td>
+                        {% if idP.contact is iterable %}
+                            {%  for index, value in idP.contact %}
+                                {%  if index > 0 %}
+                                    {{ ' ' }}
+                                {% endif %}
+                                {{ value }}
+                            {% endfor %}
+                        {% endif %}
+                    </td>
+                </tr>
+            {%  endfor %}
+        </table>
+    {% endfor %}
+{% endblock %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Client/EntityConnectionRequestClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Client/EntityConnectionRequestClient.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Client;
+
+use Psr\Log\LoggerInterface;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityConnectionRequestRepository;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Factory\JiraServiceFactory;
+
+class EntityConnectionRequestClient implements EntityConnectionRequestRepository
+{
+    /**
+     * @var JiraServiceFactory
+     */
+    private $factory;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        JiraServiceFactory $jiraFactory,
+        LoggerInterface $logger
+    ) {
+        $this->factory = $jiraFactory;
+        $this->logger = $logger;
+    }
+
+    public function getOpenConnectionRequest(string $id): array
+    {
+        // TODO: connect to Jira and fetch open connection requests and built value objects from there
+        return [
+            'request-1' => [
+                [
+                    'idp' => 'Identity Provider 1',
+                    'contact' => [
+                        'firstName' => 'John',
+                        'surName' => 'Doo',
+                        'email' => 'john@doo.com'
+                    ]
+                ],
+                [
+                    'idp' => 'Identity Provider 2',
+                    'contact' => [
+                        'firstName' => 'Jack',
+                        'surName' => 'Daniels',
+                        'email' => 'jack@daniels.com'
+                    ]
+                ],
+            ],
+            'request-2' => [
+                [
+                    'idp' => 'Identity Provider 3',
+                    'contact' => [
+                        'firstName' => 'Barbara',
+                        'surName' => 'Bush',
+                        'email' => 'barbara@bush.com'
+                    ]
+                ],
+            ]
+        ];
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/EntityChangeRequestClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/EntityChangeRequestClient.php
@@ -25,6 +25,7 @@ use Surfnet\ServiceProviderDashboard\Application\ViewObject\Apis\ApiConfig;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Protocol;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
+use Surfnet\ServiceProviderDashboard\Domain\Exception\ProtocolNotFoundException;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityChangeRequestRepository;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\PublishMetadataException;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\HttpClientInterface;
@@ -81,9 +82,6 @@ class EntityChangeRequestClient implements EntityChangeRequestRepository
         return $response;
     }
 
-    /**
-     * @throws Exception
-     */
     public function getChangeRequest(string $id, Protocol $protocol): array
     {
         $this->logger->info(sprintf('Get outstanding change requests from manage for entity "%s"', $id));

--- a/tests/integration/Application/ViewObject/EntityActionsTest.php
+++ b/tests/integration/Application/ViewObject/EntityActionsTest.php
@@ -189,4 +189,60 @@ class EntityActionsTest extends TestCase
 
         $this->assertFalse($actions->allowChangeRequestAction());
     }
+
+    public function test_open_connection_request_action_is_allowed()
+    {
+        $actions = new EntityActions(
+            'manage-id',
+            1,
+            Constants::STATE_PUBLISHED,
+            Constants::ENVIRONMENT_PRODUCTION,
+            Constants::TYPE_SAML,
+            false
+        );
+
+        $this->assertTrue($actions->allowOpenConnectionRequestAction());
+    }
+
+    public function test_open_connection_request_action_is_not_allowed_for_test_env()
+    {
+        $actions = new EntityActions(
+            'manage-id',
+            1,
+            Constants::STATE_PUBLISHED,
+            Constants::ENVIRONMENT_TEST,
+            Constants::TYPE_SAML,
+            false
+        );
+
+        $this->assertFalse($actions->allowOpenConnectionRequestAction());
+    }
+
+    public function test_open_connection_request_action_is_not_allowed_for_oauth_ccc()
+    {
+        $actions = new EntityActions(
+            'manage-id',
+            1,
+            Constants::STATE_PUBLISHED,
+            Constants::ENVIRONMENT_PRODUCTION,
+            Constants::TYPE_OAUTH_CLIENT_CREDENTIAL_CLIENT,
+            false
+        );
+
+        $this->assertFalse($actions->allowOpenConnectionRequestAction());
+    }
+
+    public function test_open_connection_request_action_is_not_allowed_for_oauth_rs()
+    {
+        $actions = new EntityActions(
+            'manage-id',
+            1,
+            Constants::STATE_PUBLISHED,
+            Constants::ENVIRONMENT_PRODUCTION,
+            Constants::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER,
+            false
+        );
+
+        $this->assertFalse($actions->allowOpenConnectionRequestAction());
+    }
 }

--- a/tests/unit/Domain/Entity/Entity/ProtocolTest.php
+++ b/tests/unit/Domain/Entity/Entity/ProtocolTest.php
@@ -21,6 +21,7 @@ namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Domain\Entity\Entity;
 use Exception;
 use PHPUnit\Framework\TestCase;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Protocol;
+use Surfnet\ServiceProviderDashboard\Domain\Exception\ProtocolNotFoundException;
 
 class ProtocolTest extends TestCase
 {
@@ -48,7 +49,7 @@ class ProtocolTest extends TestCase
 
     public function test_it_throws_exception_on_invalid_managed_protocol()
     {
-        $this->expectException(Exception::class);
+        $this->expectException(ProtocolNotFoundException::class);
         $this->expectExceptionMessage('The protocol \'fantasy\' is not supported');
         $protocol = new Protocol('fantasy');
         $protocol->getManagedProtocol();


### PR DESCRIPTION
We want to make the open Jira tickets with regard to the connection requests transparent for a user. For the saml and oidcng entities an extra option is served to show the open connection requests.

In this first implementation of the connection request no checks are done to see if there are any connections request. This is a rudimentary setup and will be expanded from there. The results from jira are simulated by returning some hard coded data from the EntityConnectionRequestClient.

see: https://www.pivotaltracker.com/story/show/183572833