### PR TITLE
Improve secret reset behavior

### DIFF
--- a/app/scss/components/modal.scss
+++ b/app/scss/components/modal.scss
@@ -38,6 +38,12 @@
       width: 100px;
       display: inline-block;
     }
+    pre {
+      display: inline-block;
+      font-family: monospace;
+      font-size: 1.2rem;
+      width: auto;
+    }
   }
   .button-row {
     height: 3em;

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/ResetOidcSecretCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/ResetOidcSecretCommandHandler.php
@@ -81,14 +81,14 @@ class ResetOidcSecretCommandHandler implements CommandHandler
         if ($entity->getEnvironment() === Constants::ENVIRONMENT_PRODUCTION) {
             $publishCommand = new PublishEntityProductionCommand($entity, $this->authorizationService->getContact());
             $this->commandBus->handle($publishCommand);
-            if (!$entity->isExcludedFromPush()) {
-                // Push metadata (we push to production manage upon client secret resets)
-                // https://www.pivotaltracker.com/story/show/173009970
-                $this->publishEntityClient->pushMetadata();
-            }
         } else if ($entity->getEnvironment() === Constants::ENVIRONMENT_TEST) {
             $publishCommand = new PublishEntityTestCommand($entity);
             $this->commandBus->handle($publishCommand);
+        }
+        if (!$entity->isExcludedFromPush()) {
+            // Push metadata (we push to production manage upon client secret resets)
+            // https://www.pivotaltracker.com/story/show/173009970
+            $this->publishEntityClient->pushMetadata();
         }
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detailMonospacedTextField.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityDetail/detailMonospacedTextField.html.twig
@@ -1,0 +1,10 @@
+{% if value is not empty %}
+<div class="detail monospaced">
+    {% if informationPopup is defined %}
+        <span data-tippy-content="{{ informationPopup|trans }}" class="help-button">
+            <i class="fa fa-question-circle"></i>
+        </span>
+    {% endif %}
+    <label>{{ label }}</label><pre>{{ value }}</pre>
+</div>
+{% endif %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/oidcConfirmationModal.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/oidcConfirmationModal.html.twig
@@ -8,7 +8,7 @@
     <div class="wysiwyg">{{ infoString|trans|wysiwyg }}</div>
 
     <div class="row oidc-confirmation">
-        {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.list.modal.oidc_confirmation.client_secret.label'|trans, value: entity.clientSecret} %}
+        {% include '@Dashboard/EntityDetail/detailMonospacedTextField.html.twig' with {label: 'entity.list.modal.oidc_confirmation.client_secret.label'|trans, value: entity.clientSecret } %}
         {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.list.modal.oidc_confirmation.client_id.label'|trans, value: entity.entityId} %}
 
         <div class="button-row">

--- a/tests/integration/Application/CommandHandler/Entity/ResetOidcSecretCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/ResetOidcSecretCommandHandlerTest.php
@@ -70,6 +70,7 @@ class ResetOidcSecretCommandHandlerTest extends MockeryTestCase
     {
         $status = Constants::STATE_PUBLISHED;
         $command = $this->buildCommand(Constants::ENVIRONMENT_TEST, $status);
+        $this->publicationClient->shouldReceive('pushMetadata');
         $this->commandBus
             ->shouldReceive('handle')
             ->once();

--- a/tests/webtests/EntityCreateClientCredentialsClientTest.php
+++ b/tests/webtests/EntityCreateClientCredentialsClientTest.php
@@ -110,11 +110,11 @@ class EntityCreateClientCredentialsClientTest extends WebTestCase
 
         $confirmation = $crawler->filter('.oidc-confirmation');
         $label = $confirmation->filter('label')->text();
-        $span = $confirmation->filter('span')->text();
+        $secret = $confirmation->filter('pre')->text();
 
         // A secret should be displayed
         $this->assertEquals('Secret', $label);
-        $this->assertSame(20, strlen($span));
+        $this->assertSame(20, strlen($secret));
     }
 
     public function test_it_stays_on_create_action_when_publish_failed()

--- a/tests/webtests/EntityCreateOidcngResourceServerTest.php
+++ b/tests/webtests/EntityCreateOidcngResourceServerTest.php
@@ -110,11 +110,11 @@ class EntityCreateOidcngResourceServerTest extends WebTestCase
 
         $confirmation = $crawler->filter('.oidc-confirmation');
         $label = $confirmation->filter('label')->text();
-        $span = $confirmation->filter('span')->text();
+        $secret = $confirmation->filter('pre')->text();
 
         // A secret should be displayed
         $this->assertEquals('Secret', $label);
-        $this->assertSame(20, strlen($span));
+        $this->assertSame(20, strlen($secret));
 
         // When a new entity is published, a flash message should be displayed
         $flashMessage = $crawler->filter('.flashMessage.wysiwyg')->text();


### PR DESCRIPTION
1. The push action in manage is now triggered not only for production entities, but also for the ones on test. See: https://www.pivotaltracker.com/story/show/183572242
2. The secret that shal be only displayed once. Is reformatted slightly different (monospaced) allowing for easier reading of similar looking
   characters. See: https://www.pivotaltracker.com/story/show/182408063