### PR TITLE
Show change request action only when available

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Factory/EntityDetailFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Factory/EntityDetailFactory.php
@@ -63,7 +63,8 @@ class EntityDetailFactory
             $manageEntity->getStatus(),
             $manageEntity->getEnvironment(),
             $manageEntity->getProtocol()->getProtocol(),
-            $manageEntity->isReadOnly()
+            $manageEntity->isReadOnly(),
+            false
         );
 
         $grants = null;

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Entity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Entity.php
@@ -81,6 +81,7 @@ class Entity
      * @param string $environment
      * @param string $protocol
      * @param bool $isReadOnly
+     * @param bool $hasChangeRequests
      * @param RouterInterface $router
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
@@ -94,6 +95,7 @@ class Entity
         $environment,
         $protocol,
         $isReadOnly,
+        $hasChangeRequests,
         RouterInterface $router
     ) {
         $this->id = $id;
@@ -104,7 +106,15 @@ class Entity
         $this->environment = $environment;
         $this->protocol = $protocol;
         $this->router = $router;
-        $this->actions = new EntityActions($id, $serviceId, $state, $environment, $protocol, $isReadOnly);
+        $this->actions = new EntityActions(
+            $id,
+            $serviceId,
+            $state,
+            $environment,
+            $protocol,
+            $isReadOnly,
+            $hasChangeRequests
+        );
     }
 
     /**
@@ -113,8 +123,11 @@ class Entity
      * @param int $serviceId
      * @return Entity
      */
-    public static function fromManageTestResult(ManageEntity $result, RouterInterface $router, $serviceId)
-    {
+    public static function fromManageTestResult(
+        ManageEntity $result,
+        RouterInterface $router,
+        int $serviceId
+    ) {
         $formattedContact = self::formatManageContact($result);
         $protocol = $result->getProtocol()->getProtocol();
         return new self(
@@ -127,6 +140,7 @@ class Entity
             'test',
             $protocol,
             false,
+            false,
             $router
         );
     }
@@ -135,10 +149,15 @@ class Entity
      * @param ManageEntity $result
      * @param RouterInterface $router
      * @param int $serviceId
+     * @param bool $hasChangeRequests
      * @return Entity
      */
-    public static function fromManageProductionResult(ManageEntity $result, RouterInterface $router, $serviceId)
-    {
+    public static function fromManageProductionResult(
+        ManageEntity $result,
+        RouterInterface $router,
+        int $serviceId,
+        bool $hasChangeRequests
+    ) {
         $formattedContact = self::formatManageContact($result);
 
         // As long as the coin:exclude_from_push metadata is present, allow modifications to the entity by
@@ -161,6 +180,7 @@ class Entity
             'production',
             $protocol,
             false,
+            $hasChangeRequests,
             $router
         );
     }

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityActions.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityActions.php
@@ -54,15 +54,27 @@ class EntityActions
      * @var bool
      */
     private $readOnly;
+    /**
+     * @var bool
+     */
+    private $changeRequest;
 
-    public function __construct(string $id, int $serviceId, string $status, string $environment, string $protocol, bool $isReadOnly)
-    {
+    public function __construct(
+        string $id,
+        int $serviceId,
+        string $status,
+        string $environment,
+        string $protocol,
+        bool $isReadOnly,
+        bool $changeRequest
+    ) {
         $this->id = $id;
         $this->serviceId = $serviceId;
         $this->status = $status;
         $this->environment = $environment;
         $this->protocol = $protocol;
         $this->readOnly = $isReadOnly;
+        $this->changeRequest = $changeRequest;
     }
 
     public function getId()
@@ -169,7 +181,7 @@ class EntityActions
 
     public function allowChangeRequestAction(): bool
     {
-        if ($this->readOnly || $this->environment !== Constants::ENVIRONMENT_PRODUCTION) {
+        if ($this->readOnly || $this->environment !== Constants::ENVIRONMENT_PRODUCTION || !$this->changeRequest) {
             return false;
         }
         return $this->status == Constants::STATE_PUBLISHED;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityChangeRequestController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityChangeRequestController.php
@@ -60,6 +60,7 @@ class EntityChangeRequestController extends Controller
             $entity->getStatus(),
             $entity->getEnvironment(),
             $entity->getProtocol()->getProtocol(),
+            true,
             true
         );
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -310,6 +310,7 @@ services:
             - '@Surfnet\ServiceProviderDashboard\Application\Provider\EntityQueryRepositoryProvider'
             - '@Surfnet\ServiceProviderDashboard\Application\Service\TicketService'
             - '@Surfnet\ServiceProviderDashboard\Application\Service\ServiceService'
+            - '@Surfnet\ServiceProviderDashboard\Application\Service\ChangeRequestService'
             - '@surfnet.manage.configuration.test'
             - '@surfnet.manage.configuration.production'
             - '@router'

--- a/tests/integration/Application/ViewObject/EntityActionsTest.php
+++ b/tests/integration/Application/ViewObject/EntityActionsTest.php
@@ -32,6 +32,7 @@ class EntityActionsTest extends TestCase
             Constants::STATE_PUBLISHED,
             Constants::ENVIRONMENT_TEST,
             Constants::TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER,
+            false,
             false
         );
         $this->assertFalse($actions->allowAclAction());
@@ -52,7 +53,7 @@ class EntityActionsTest extends TestCase
         $description
     ) {
     
-        $actions = new EntityActions('manage-id', 1, $publicationStatus, Constants::ENVIRONMENT_TEST, $protocol, false);
+        $actions = new EntityActions('manage-id', 1, $publicationStatus, Constants::ENVIRONMENT_TEST, $protocol, false, false);
 
         $this->assertEquals($expectation, $actions->allowSecretResetAction(), $description);
     }
@@ -103,7 +104,8 @@ class EntityActionsTest extends TestCase
             Constants::STATE_DRAFT,
             Constants::ENVIRONMENT_TEST,
             Constants::TYPE_OPENID_CONNECT_TNG,
-            true
+            true,
+            false
         );
         $this->assertFalse($actions->allowEditAction());
         $this->assertFalse($actions->allowDeleteAction());
@@ -121,6 +123,7 @@ class EntityActionsTest extends TestCase
             Constants::STATE_REMOVAL_REQUESTED,
             Constants::ENVIRONMENT_PRODUCTION,
             Constants::TYPE_OPENID_CONNECT_TNG,
+            false,
             false
         );
         $this->assertFalse($removalRequested->allowEditAction());
@@ -130,7 +133,8 @@ class EntityActionsTest extends TestCase
             Constants::STATE_PUBLICATION_REQUESTED,
             Constants::ENVIRONMENT_PRODUCTION,
             Constants::TYPE_OPENID_CONNECT_TNG,
-            true
+            true,
+            false
         );
         $this->assertFalse($readOnly->allowEditAction());
         $publishedToProd = new EntityActions(
@@ -139,6 +143,7 @@ class EntityActionsTest extends TestCase
             Constants::STATE_PUBLISHED,
             Constants::ENVIRONMENT_PRODUCTION,
             Constants::TYPE_OPENID_CONNECT_TNG,
+            false,
             false
         );
         $this->assertTrue($publishedToProd->allowEditAction());
@@ -148,6 +153,7 @@ class EntityActionsTest extends TestCase
             Constants::STATE_PUBLICATION_REQUESTED,
             Constants::ENVIRONMENT_PRODUCTION,
             Constants::TYPE_OPENID_CONNECT_TNG,
+            false,
             false
         );
         $this->assertTrue($shouldBeEditable->allowEditAction());
@@ -157,6 +163,7 @@ class EntityActionsTest extends TestCase
             Constants::STATE_PUBLISHED,
             Constants::ENVIRONMENT_TEST,
             Constants::TYPE_OPENID_CONNECT_TNG,
+            false,
             false
         );
         $this->assertTrue($shouldBeEditable2->allowEditAction());
@@ -170,13 +177,29 @@ class EntityActionsTest extends TestCase
             Constants::STATE_PUBLISHED,
             Constants::ENVIRONMENT_PRODUCTION,
             Constants::TYPE_SAML,
-            false
+            false,
+            true
         );
 
         $this->assertTrue($actions->allowChangeRequestAction());
     }
 
-    public function test_change_request_action_is_not_allowed()
+    public function test_change_request_action_is_not_allowed_for_this_production_entity()
+    {
+        $actions = new EntityActions(
+            'manage-id',
+            1,
+            Constants::STATE_PUBLISHED,
+            Constants::ENVIRONMENT_PRODUCTION,
+            Constants::TYPE_SAML,
+            false,
+            false
+        );
+
+        $this->assertFalse($actions->allowChangeRequestAction());
+    }
+
+    public function test_change_request_action_is_not_allowed_for_test_entities()
     {
         $actions = new EntityActions(
             'manage-id',
@@ -184,7 +207,8 @@ class EntityActionsTest extends TestCase
             Constants::STATE_PUBLISHED,
             Constants::ENVIRONMENT_TEST,
             Constants::TYPE_SAML,
-            false
+            false,
+            true
         );
 
         $this->assertFalse($actions->allowChangeRequestAction());

--- a/tests/unit/Application/ViewObject/EntityTest.php
+++ b/tests/unit/Application/ViewObject/EntityTest.php
@@ -95,6 +95,7 @@ class EntityTest extends MockeryTestCase
             $env,
             $protocol,
             false,
+            false,
             $router
         );
     }


### PR DESCRIPTION
Only show the option 'Change request' in the action list of an  entity when an entity has pending change request.

see: https://www.pivotaltracker.com/story/show/183710218