### PR TITLE
Update changes of organization names to manage

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/EntityChangeRequestCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/EntityChangeRequestCommandHandler.php
@@ -110,7 +110,7 @@ class EntityChangeRequestCommandHandler implements CommandHandler
         if (!$entity->isManageEntity()) {
             throw new EntityNotFoundException('Unable to request changes to a unkown entity in Manage');
         }
-        $pristineEntity = $this->entityService->getManageEntityById($entity->getId(), $entity->getEnvironment());
+        $pristineEntity = $this->entityService->getPristineManageEntityById($entity->getId(), $entity->getEnvironment());
         try {
             $this->logger->info(
                 sprintf(

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityProductionCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityProductionCommandHandler.php
@@ -117,7 +117,7 @@ class PublishEntityProductionCommandHandler implements CommandHandler
         $pristineEntity = null;
         if ($entity->isManageEntity()) {
             // The entity as it is now known in Manage
-            $pristineEntity = $this->entityService->getManageEntityById($entity->getId(), $entity->getEnvironment());
+            $pristineEntity = $this->entityService->getPristineManageEntityById($entity->getId(), $entity->getEnvironment());
         }
         try {
             $this->logger->info(

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityTestCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityTestCommandHandler.php
@@ -74,7 +74,7 @@ class PublishEntityTestCommandHandler implements CommandHandler
         $pristineEntity = null;
         if ($entity->isManageEntity()) {
             // The entity as it is now known in Manage
-            $pristineEntity = $this->entityService->getManageEntityById($entity->getId(), $entity->getEnvironment());
+            $pristineEntity = $this->entityService->getPristineManageEntityById($entity->getId(), $entity->getEnvironment());
         }
         try {
             $this->logger->info(

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
@@ -218,6 +218,7 @@ class EntityService implements EntityServiceInterface
     }
 
     /**
+     *
      * @param string $manageId
      * @param string $env
      *
@@ -242,6 +243,10 @@ class EntityService implements EntityServiceInterface
     }
 
     /**
+     * @desc get a pure manage entity together with the associated service. Notice that meta data of the
+     * organization is untouched, so that any difference on the organization data can be noticed and updated from
+     * the service accordingly.
+     *
      * @param string $manageId
      * @param string $env
      *

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
@@ -242,6 +242,28 @@ class EntityService implements EntityServiceInterface
     }
 
     /**
+     * @param string $manageId
+     * @param string $env
+     *
+     * @return ManageEntity|null
+     *
+     * @throws InvalidArgumentException
+     * @throws QueryServiceProviderException
+     */
+    public function getPristineManageEntityById($manageId, $env = 'test')
+    {
+        $entity = $this->queryRepositoryProvider
+            ->fromEnvironment($env)
+            ->findByManageId($manageId);
+        $entity->setEnvironment($env);
+        // Set the service associated to the entity on the entity.
+        $service = $this->serviceService->getServiceByTeamName($entity->getMetaData()->getCoin()->getServiceTeamId());
+        $entity->setService($service);
+        $this->updateStatus($entity);
+        return $entity;
+    }
+
+    /**
      * @param string $teamName
      * @return array|null
      * @throws QueryServiceProviderException

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityServiceInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityServiceInterface.php
@@ -54,4 +54,14 @@ interface EntityServiceInterface
      * @throws \Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\QueryServiceProviderException
      */
     public function getManageEntityById($manageId, $env = 'test');
+
+    /**
+     * @param string $manageId
+     * @param string $env
+     * @return ManageEntity|null
+     *
+     * @throws InvalidArgumentException
+     * @throws \Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\QueryServiceProviderException
+     */
+    public function getPristineManageEntityById($manageId, $env = 'test');
 }

--- a/tests/integration/Application/CommandHandler/Entity/PublishEntityProductionCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/PublishEntityProductionCommandHandlerTest.php
@@ -153,7 +153,7 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
         $this->logger
             ->shouldReceive('info')
             ->times(2);
-        $this->entityService->shouldReceive('getManageEntityById')->andReturn($manageEntity);
+        $this->entityService->shouldReceive('getPristineManageEntityById')->andReturn($manageEntity);
 
         $applicant = new Contact('john:doe', 'john@example.com', 'John Doe');
         $command = new PublishEntityProductionCommand($manageEntity, $applicant);
@@ -215,7 +215,7 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
         $this->logger
             ->shouldReceive('info')
             ->times(2);
-        $this->entityService->shouldReceive('getManageEntityById')->andReturn($manageEntity);
+        $this->entityService->shouldReceive('getPristineManageEntityById')->andReturn($manageEntity);
 
 
         $applicant = new Contact('john:doe', 'john@example.com', 'John Doe');
@@ -274,7 +274,7 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
         $this->flashBag
             ->shouldReceive('add')
             ->with('error', 'entity.edit.error.publish');
-        $this->entityService->shouldReceive('getManageEntityById')->andReturn($manageEntity);
+        $this->entityService->shouldReceive('getPristineManageEntityById')->andReturn($manageEntity);
 
         $applicant = new Contact('john:doe', 'john@example.com', 'John Doe');
 


### PR DESCRIPTION
Organization names are registered on the Service
and copied to the metadata of the entity. The copy action 
should not be applied to the entity data
fetched from Manage when used for comparison.

see: https://www.pivotaltracker.com/story/show/184014629