### PR TITLE
Throw exception on oauth_ccc when ccc is disabled

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateController.php
@@ -159,6 +159,12 @@ class EntityCreateController extends AbstractController
             );
         }
 
+        if (!$service->isClientCredentialClientsEnabled() && $type === Constants::TYPE_OAUTH_CLIENT_CREDENTIAL_CLIENT) {
+            throw $this->createAccessDeniedException(
+                'You cannot create client credential clients entities because they are not allowed for this service'
+            );
+        }
+
         $form = $this->entityTypeFactory->createCreateForm($type, $service, $targetEnvironment);
         $command = $form->getData();
 


### PR DESCRIPTION
An authorization check has been added to prevent creation of an oAuth client credential clients (ccc) when the option to add client credential clients is disabled.

see: https://www.pivotaltracker.com/story/show/183828026