### PR TITLE
Show secrets modal for new oidc entities after connection request

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityProductionCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityProductionCommandHandler.php
@@ -128,8 +128,6 @@ class PublishEntityProductionCommandHandler implements CommandHandler
             );
             $publishResponse = $this->publishClient->publish($entity, $pristineEntity);
             if (array_key_exists('id', $publishResponse)) {
-                // Set entity status to published
-                $entity->setStatus(Constants::STATE_PUBLISHED);
                 $entity->setId($publishResponse['id']);
 
                 $this->logger->info(

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityControllerTrait.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityControllerTrait.php
@@ -236,12 +236,12 @@ trait EntityControllerTrait
     private function findDestinationForRedirectToCreateConnectionRequest(
         PublishProductionCommandInterface $publishEntityCommand
     ): string {
-    
         switch (true) {
             case $publishEntityCommand instanceof EntityChangeRequestCommand:
                 return 'entity_change_request';
             case $publishEntityCommand instanceof PublishEntityProductionCommand:
-                if ($this->allowToRedirectToCreateConnectionRequest($publishEntityCommand)) {
+                if ($publishEntityCommand->getManageEntity()->getStatus() !== Constants::STATE_PUBLICATION_REQUESTED &&
+                    $this->allowToRedirectToCreateConnectionRequest($publishEntityCommand)) {
                     return 'entity_published_create_connection_request';
                 }
                 return 'entity_published_production';

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityPublishedController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityPublishedController.php
@@ -55,7 +55,11 @@ class EntityPublishedController extends Controller
             return $this->redirectToRoute('service_overview');
         }
 
-        $parameters = ['entityName' => $entity->getMetaData()->getNameEn()];
+        $parameters = [
+            'entityName' => $entity->getMetaData()->getNameEn(),
+            'showOidcPopup' => false,
+            'publishedEntity' => $entity
+        ];
 
         if ($entity->getEnvironment() === Constants::ENVIRONMENT_TEST) {
             return $this->render('@Dashboard/EntityPublished/publishedTest.html.twig', $parameters);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/publishedProduction.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/publishedProduction.html.twig
@@ -5,4 +5,9 @@
 
     {{ 'entity.published_production.text.html'|trans({'%entityName%': entityName})|wysiwyg }}
 
+    {% if showOidcPopup %}
+        <div class="modal" id="oidc-published-popup">
+            {{ render(controller('DashboardBundle:EntityPublished:oidcConfirmationModal', {'entity': publishedEntity})) }}
+        </div>
+    {% endif %}
 {% endblock %}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/publishedProductionAndConnectionRequest.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/publishedProductionAndConnectionRequest.html.twig
@@ -5,4 +5,9 @@
 
     {{ 'entity.published_production_and_sent_connection_request.text.html'|trans({'%entityName%': entityName})|wysiwyg }}
 
+    {% if showOidcPopup %}
+        <div class="modal" id="oidc-published-popup">
+            {{ render(controller('DashboardBundle:EntityPublished:oidcConfirmationModal', {'entity': publishedEntity})) }}
+        </div>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
When I  an OIDC entity is published to production, the modal with the secret and ClientID has to appear after submittance or skipping the connection request form. 

see: https://www.pivotaltracker.com/story/show/184477504