### PR TITLE
Display secrets after adding a connection request for an OIDC entity

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateConnectionRequestController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateConnectionRequestController.php
@@ -84,7 +84,10 @@ class EntityCreateConnectionRequestController extends Controller
 
             if ($form->isValid()) {
                 $this->commandBus->handle($command);
-                return $this->render('@Dashboard/EntityPublished/sendConnectionRequest.html.twig', $parameters);
+                return $this->render(
+                    '@Dashboard/EntityPublished/publishedProductionAndConnectionRequest.html.twig',
+                    $parameters
+                );
             }
         }
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateConnectionRequestController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityCreateConnectionRequestController.php
@@ -84,7 +84,7 @@ class EntityCreateConnectionRequestController extends Controller
 
             if ($form->isValid()) {
                 $this->commandBus->handle($command);
-                return $this->redirectToRoute('publish_to_production_and_send_connection_request', $parameters);
+                return $this->render('@Dashboard/EntityPublished/sendConnectionRequest.html.twig', $parameters);
             }
         }
 
@@ -137,19 +137,14 @@ class EntityCreateConnectionRequestController extends Controller
      */
     public function sendConnectionRequestAction()
     {
-        return $this->render(
-            '@Dashboard/EntityPublished/sendConnectionRequest.html.twig'
-        );
-    }
+        $parameters = [
+            'entityName' => '',
+            'showOidcPopup' => false,
+            'publishedEntity' => null
+        ];
 
-    /**
-     * @Method("GET")
-     * @Route("/entity/send-connection-request", name="publish_to_production_and_send_connection_request")
-     */
-    public function publishedToProductionAndSendConnectionRequest(array $parameters)
-    {
         return $this->render(
-            '@Dashboard/EntityPublished/publishedProductionAndConnectionRequest.html.twig',
+            '@Dashboard/EntityPublished/sendConnectionRequest.html.twig',
             $parameters
         );
     }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -406,10 +406,10 @@ entity.connection_request.ticket.institution: "Institution: %institution_name% C
 
 "
 entity.published_production.text.html: "Thanks for publishing \"%entityName%\" to our production environment."
-entity.published_production_and_sent_connection_request.text.html: "Thanks for publishing \"%entityName%\" to our production environment and and connection request(s) to the service desk."
+entity.published_production_and_sent_connection_request.text.html: "Thanks for publishing \"%entityName%\" to our production environment and sending the connection request(s) to the service desk."
 entity.sending_connection_request.text.html: "Thanks for sending the connection request(s) to the service desk."
 entity.sent_connection_request.title: "Successfully sent the connection request(s) to the service desk"
-entity.published_production_and_sent_connection_request.title: "Successfully published the entity to production and sent connection request(s) to the service desk"
+entity.published_production_and_sent_connection_request.title: "Successfully published the entity to production"
 
 entity.published_production.title: "Successfully published the entity to production"
 entity.published_test.text.html: "Thanks for publishing \"%entityName%\" to our test environment."

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/sendConnectionRequest.html.twig
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/views/EntityPublished/sendConnectionRequest.html.twig
@@ -5,4 +5,9 @@
 
     {{ 'entity.sending_connection_request.text.html'|trans|wysiwyg }}
 
+    {% if showOidcPopup %}
+        <div class="modal" id="oidc-published-popup">
+            {{ render(controller('DashboardBundle:EntityPublished:oidcConfirmationModal', {'entity': publishedEntity})) }}
+        </div>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
The secrets of an OIDC were only displayed when the dialog of the connection request was skipped. This PR fixes this issue that the secrets are also shown when an connection request is posted.

see: https://www.pivotaltracker.com/story/show/184460472