### PR TITLE
Introduce new privacy questions

### DIFF
--- a/assets/Resources/metadata/privacy_questions.json
+++ b/assets/Resources/metadata/privacy_questions.json
@@ -38,5 +38,22 @@
     "urns": [
       "coin:privacy:other_info"
     ]
+  },
+  {
+    "id": "dpaType",
+    "friendlyName": "DPAType",
+    "getterName": "getDpaType",
+    "urns": [
+      "coin:privacy:dpa_type"
+    ]
+  },
+  {
+    "id": "privacyStatementUrl",
+    "friendlyName": "PrivacyStatementUrl",
+    "getterName": "getPrivacyStatementUrl",
+    "urns": [
+      "mdui:PrivacyStatementURL:nl",
+      "mdui:PrivacyStatementURL:en"
+    ]
   }
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       connect.vm.openconext.org: 127.0.0.1
       test.openconext.org: 127.0.0.1
       teams.vm.openconext.org: 127.0.0.1
+      ansible-test-ga: 127.0.0.1
     privileged: true
     networks:
       spdashboard:

--- a/migrations/Version20230620124841.php
+++ b/migrations/Version20230620124841.php
@@ -21,11 +21,13 @@ final class Version20230620124841 extends AbstractMigration
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE privacy_questions DROP certification, DROP certification_location, DROP certification_valid_from, DROP certification_valid_to, DROP surfmarket_dpa_agreement, DROP surfnet_dpa_agreement, DROP sn_dpa_why_not, DROP privacy_policy, DROP privacy_policy_url');
+        $this->addSql('ALTER TABLE privacy_questions ADD dpa_type LONGTEXT DEFAULT NULL, ADD privacy_statement_url_nl LONGTEXT DEFAULT NULL, ADD privacy_statement_url_en LONGTEXT DEFAULT NULL');
     }
 
     public function down(Schema $schema): void
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE privacy_questions ADD certification TINYINT(1) DEFAULT NULL, ADD certification_location VARCHAR(255) DEFAULT NULL, ADD certification_valid_from DATE DEFAULT NULL, ADD certification_valid_to DATE DEFAULT NULL, ADD surfmarket_dpa_agreement TINYINT(1) DEFAULT NULL, ADD surfnet_dpa_agreement TINYINT(1) DEFAULT NULL, ADD sn_dpa_why_not LONGTEXT DEFAULT NULL, ADD privacy_policy TINYINT(1) DEFAULT NULL, ADD privacy_policy_url VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE privacy_questions DROP dpa_type, DROP privacy_statement_url_nl, DROP privacy_statement_url_en');
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/PrivacyQuestions/PrivacyQuestionsCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/PrivacyQuestions/PrivacyQuestionsCommand.php
@@ -18,10 +18,11 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Command\PrivacyQuestions;
 
-use DateTime;
 use Surfnet\ServiceProviderDashboard\Application\Command\Command;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\DpaType;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @SuppressWarnings(PHPMD.TooManyFields)
@@ -69,6 +70,22 @@ class PrivacyQuestionsCommand implements Command
     private $otherInfo;
 
     /**
+     * @Assert\NotBlank()
+     * @Assert\Type("Surfnet\ServiceProviderDashboard\Domain\ValueObject\DpaType")
+     */
+    private DpaType $dpaType;
+
+    /**
+     * @Assert\Url()
+     */
+    public ?string $privacyStatementUrlNl = '';
+
+    /**
+     * @Assert\Url()
+     */
+    public ?string $privacyStatementUrlEn = '';
+
+    /**
      * @param string $whatData
      */
     public function setWhatData($whatData)
@@ -106,6 +123,11 @@ class PrivacyQuestionsCommand implements Command
     public function setOtherInfo($otherInfo)
     {
         $this->otherInfo = $otherInfo;
+    }
+
+    public function setDpaType(string $dpaType)
+    {
+        $this->dpaType = DpaType::fromString($dpaType);
     }
 
     /**
@@ -164,11 +186,16 @@ class PrivacyQuestionsCommand implements Command
         return $this->mode;
     }
 
+    public function getDpaType(): DpaType
+    {
+        return $this->dpaType;
+    }
+
     public static function fromService(Service $service)
     {
         $command = new self;
         $command->mode = self::MODE_CREATE;
-
+        $command->dpaType = DpaType::build(DpaType::DEFAULT);
         $command->service = $service;
         return $command;
     }
@@ -184,7 +211,9 @@ class PrivacyQuestionsCommand implements Command
         $command->securityMeasures = $questions->getSecurityMeasures();
         $command->service = $questions->getService();
         $command->whatData = $questions->getWhatData();
-
+        $command->dpaType = DpaType::from($questions);
+        $command->privacyStatementUrlNl = $questions->getPrivacyStatementUrlNl();
+        $command->privacyStatementUrlEn = $questions->getPrivacyStatementUrlEn();
         return $command;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/PrivacyQuestions/PrivacyQuestionsCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/PrivacyQuestions/PrivacyQuestionsCommandHandler.php
@@ -71,5 +71,12 @@ class PrivacyQuestionsCommandHandler implements CommandHandler
         $questions->setOtherInfo($command->getOtherInfo());
         $questions->setSecurityMeasures($command->getSecurityMeasures());
         $questions->setWhatData($command->getWhatData());
+        $questions->setDpaType($command->getDpaType()->type);
+        if ($command->privacyStatementUrlEn) {
+            $questions->setPrivacyStatementUrlEn($command->privacyStatementUrlEn);
+        }
+        if ($command->privacyStatementUrlNl) {
+            $questions->setPrivacyStatementUrlNl($command->privacyStatementUrlNl);
+        }
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
@@ -146,6 +146,8 @@ class JsonGenerator implements GeneratorInterface
                 if ($entity->isManageEntity() && !$entity->isExcludedFromPush()) {
                     $metadata['metaDataFields.coin:exclude_from_push'] = '0';
                 }
+                $this->privacyQuestionsMetadataGenerator->withMetadataPrefix();
+                $metadata += $this->privacyQuestionsMetadataGenerator->build($entity);
 
                 return $metadata;
         }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/PrivacyQuestionsMetadataGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/PrivacyQuestionsMetadataGenerator.php
@@ -18,8 +18,9 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator;
 
-use DateTime;
+use stdClass;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\AttributesMetadataRepository;
 
 /**
@@ -41,6 +42,11 @@ use Surfnet\ServiceProviderDashboard\Domain\Repository\AttributesMetadataReposit
  */
 class PrivacyQuestionsMetadataGenerator implements MetadataGenerator
 {
+    /**
+     * @var true
+     */
+    private bool $addMetaDataPrefix = false;
+
     public function __construct(private readonly AttributesMetadataRepository $repository)
     {
     }
@@ -54,21 +60,58 @@ class PrivacyQuestionsMetadataGenerator implements MetadataGenerator
 
         if ($entity->getService()->isPrivacyQuestionsEnabled()) {
             foreach ($privacyQuestions as $question) {
-                // Get the associated getter
+                if ($question->id === 'privacyStatementUrl') {
+                    $privacyStatements = $privacyQuestionAnswers->privacyStatementUrls();
+                    $privacyStatementsTranslated = [];
+                    foreach ($privacyStatements as $urn => $value) {
+                        $privacyStatementsTranslated[$this->buildKey($urn)] = $value;
+                    }
+                    $attributes += $privacyStatementsTranslated;
+                    continue;
+                }
+
                 $getterName = $question->getterName;
                 if ($privacyQuestionAnswers !== null && method_exists($privacyQuestionAnswers, $getterName)) {
-                    $answer = $privacyQuestionAnswers->$getterName();
-                    if (!is_null($answer)) {
-                        // Manage expects booleans as strings.
-                        if (is_bool($answer)) {
-                            $answer = ($answer) ? '1' : '0';
-                        }
-                        $attributes[$question->urns[0]] = $answer;
-                    }
+                    $this->buildPrivacyQuestion(
+                        $attributes,
+                        $getterName,
+                        $privacyQuestionAnswers,
+                        $question
+                    );
                 }
             }
         }
 
         return $attributes;
+    }
+
+    public function withMetadataPrefix(): void
+    {
+        $this->addMetaDataPrefix = true;
+    }
+
+    private function buildKey(string $urn)
+    {
+        if ($this->addMetaDataPrefix) {
+            return 'metaDataFields.' . $urn;
+        }
+        return $urn;
+    }
+
+    public function buildPrivacyQuestion(
+        array &$attributes,
+        string $getterName,
+        PrivacyQuestions $privacyQuestionAnswers,
+        mixed $question
+    ): void {
+        $answer = $privacyQuestionAnswers->$getterName();
+        if (!is_null($answer)) {
+            // Manage expects booleans as strings.
+            if (is_bool($answer)) {
+                $answer = ($answer) ? '1' : '0';
+            }
+            $key = $this->buildKey($question->urns[0]);
+            $attributes[$key] = $answer;
+        }
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OauthClientCredentialsClientJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OauthClientCredentialsClientJsonGenerator.php
@@ -123,6 +123,10 @@ class OauthClientCredentialsClientJsonGenerator implements GeneratorInterface
                 $metadata['state'] = $workflowState;
                 $metadata += $this->generateAllowedResourceServers($entity);
                 $this->setExcludeFromPush($metadata, $entity, true);
+
+                $this->privacyQuestionsMetadataGenerator->withMetadataPrefix();
+                $metadata += $this->privacyQuestionsMetadataGenerator->build($entity);
+
                 $metadata['revisionnote'] = $entity->getRevisionNote();
                 return $metadata;
         }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
@@ -126,6 +126,9 @@ class OidcngJsonGenerator implements GeneratorInterface
                 $metadata += $this->generateAllowedResourceServers($entity);
                 $this->setExcludeFromPush($metadata, $entity, true);
 
+                $this->privacyQuestionsMetadataGenerator->withMetadataPrefix();
+                $metadata += $this->privacyQuestionsMetadataGenerator->build($entity);
+
                 $metadata['revisionnote'] = $entity->getRevisionNote();
 
                 return $metadata;

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngResourceServerJsonGenerator.php
@@ -114,6 +114,10 @@ class OidcngResourceServerJsonGenerator implements GeneratorInterface
 
         $metadata += $differences->getDiff();
         $this->setExcludeFromPush($metadata, $entity, true);
+
+        $this->privacyQuestionsMetadataGenerator->withMetadataPrefix();
+        $metadata += $this->privacyQuestionsMetadataGenerator->build($entity);
+
         $metadata['revisionnote'] = $entity->getRevisionNote();
 
         return $metadata;

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/PrivacyQuestions.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/PrivacyQuestions.php
@@ -76,6 +76,24 @@ class PrivacyQuestions
      */
     private $service;
 
+    /**
+     * @var string
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $dpaType;
+
+    /**
+     * @var string
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $privacyStatementUrlNl;
+
+    /**
+     * @var string
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $privacyStatementUrlEn;
+
     public function setService(Service $service)
     {
         $this->service = $service;
@@ -167,5 +185,47 @@ class PrivacyQuestions
     public function setOtherInfo($otherInfo)
     {
         $this->otherInfo = $otherInfo;
+    }
+
+    public function setDpaType(string $dpaType): void
+    {
+        $this->dpaType = $dpaType;
+    }
+
+    public function getDpaType()
+    {
+        return $this->dpaType;
+    }
+
+    public function getPrivacyStatementUrlNl(): ?string
+    {
+        return $this->privacyStatementUrlNl;
+    }
+
+    public function setPrivacyStatementUrlNl(?string $privacyStatementUrlNl): void
+    {
+        $this->privacyStatementUrlNl = $privacyStatementUrlNl;
+    }
+
+    public function getPrivacyStatementUrlEn(): ?string
+    {
+        return $this->privacyStatementUrlEn;
+    }
+
+    public function setPrivacyStatementUrlEn(?string $privacyStatementUrlEn): void
+    {
+        $this->privacyStatementUrlEn = $privacyStatementUrlEn;
+    }
+
+    public function privacyStatementUrls(): array
+    {
+        $out = [];
+        if ($this->privacyStatementUrlEn) {
+            $out['mdui:PrivacyStatementURL:en'] = $this->privacyStatementUrlEn;
+        }
+        if ($this->privacyStatementUrlNl) {
+            $out['mdui:PrivacyStatementURL:nl'] = $this->privacyStatementUrlNl;
+        }
+        return $out;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/DpaType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/DpaType.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Copyright 2023 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Domain\ValueObject;
+
+use Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions;
+use function in_array;
+
+/**
+ * Representation of the different DPA types Data Processing Agreement
+ * That we currently allow.
+ *
+ * Note that:
+ * - The possible DPA varieties match the Manage coin:privacy:dpa_type enum options
+ * - The `service_has_own_dpa` enum is chosen as the `coin:privacy:dpa_type` default value,
+ *   as prescribed in the coin json schema definition.
+ *
+ * Data type definition of the coin:privacy:dpa_type from Manage:
+ *  "coin:privacy:dpa_type": {
+ *    "type": "string",
+ *    "enum": [
+ *      "dpa_not_applicable",
+ *      "dpa_in_surf_agreement",
+ *      "dpa_model_surf",
+ *      "dpa_supplied_by_service",
+ *      "other"
+ *    ],
+ *    "default" : "service_has_own_dpa",
+ *    "info": "Determines what DPA this service has to offer"
+ *  }
+ */
+class DpaType
+{
+    private const DPA_TYPE_NOT_APPLICABLE = 'dpa_not_applicable';
+    private const DPA_TYPE_MODEL_SURF = 'dpa_model_surf';
+    private const DPA_TYPE_IN_SURF_AGREEMENT = 'dpa_in_surf_agreement';
+    private const DPA_TYPE_SUPPLIED_BY_SERVICE = 'dpa_supplied_by_service';
+    private const DPA_TYPE_OTHER = 'other';
+
+    public const DEFAULT = self::DPA_TYPE_SUPPLIED_BY_SERVICE;
+
+    private static array $allowedDpaTypes = [
+        'privacy.form.dpaType.choice.dpa-not-applicable' => self::DPA_TYPE_NOT_APPLICABLE,
+        'privacy.form.dpaType.choice.through-surf' => self::DPA_TYPE_MODEL_SURF,
+        'privacy.form.dpaType.choice.in-surf-agreement' => self::DPA_TYPE_IN_SURF_AGREEMENT,
+        'privacy.form.dpaType.choice.dpa-supplied-by-service' => self::DPA_TYPE_SUPPLIED_BY_SERVICE,
+        'privacy.form.dpaType.choice.other' => self::DPA_TYPE_OTHER
+    ];
+
+    private function __construct(public readonly string $type)
+    {
+    }
+
+    public static function from(PrivacyQuestions $questions): DpaType
+    {
+        $type = $questions->getDpaType();
+        if (is_null($type)) {
+            $type = self::DEFAULT;
+        }
+        return self::build($type);
+    }
+
+    public static function fromString(string $dpaType)
+    {
+        return self::build($dpaType);
+    }
+
+    public static function build(string $type)
+    {
+        if (in_array($type, self::$allowedDpaTypes, true)) {
+            return new self($type);
+        }
+        // Not set, or unknown DPA type defaults to the default
+        return new self(self::DEFAULT);
+    }
+
+    public static function choices()
+    {
+        return self::$allowedDpaTypes;
+    }
+
+    public function __toString(): string
+    {
+        return $this->type;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DataFixtures/ORM/WebTestFixtures.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DataFixtures/ORM/WebTestFixtures.php
@@ -23,6 +23,7 @@ use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\DpaType;
 
 class WebTestFixtures extends Fixture
 {
@@ -71,6 +72,7 @@ class WebTestFixtures extends Fixture
         $privacyQuestions = new PrivacyQuestions();
         $privacyQuestions->setService($service);
         $privacyQuestions->setWhatData('All your data are belong to us');
+        $privacyQuestions->setDpaType(DpaType::DEFAULT);
 
         return $privacyQuestions;
     }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/PrivacyQuestions/PrivacyQuestionsFormBuilder.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/PrivacyQuestions/PrivacyQuestionsFormBuilder.php
@@ -18,8 +18,11 @@
 
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\PrivacyQuestions;
 
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\DpaType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class PrivacyQuestionsFormBuilder
@@ -82,6 +85,50 @@ class PrivacyQuestionsFormBuilder
         );
 
         $builder->add(
+            'dpaType',
+            ChoiceType::class,
+            [
+                'expanded' => true,
+                'multiple' => false,
+                'label' => 'privacy.form.label.dpaType.html',
+                'required' => false,
+                'choices' => DpaType::choices(),
+                'empty_data' => DpaType::DEFAULT,
+                'placeholder' => false,
+                'attr' => [
+                    'data-help' => 'privacy.information.dpaType',
+                    'rows' => 8,
+                ],
+            ]
+        );
+
+        $builder->add(
+            'privacyStatementUrlNl',
+            UrlType::class,
+            [
+                'label' => 'privacy.form.label.privacyStatementUrlNl.html',
+                'required' => false,
+                'attr' => [
+                    'data-help' => 'privacy.information.privacyStatementUrlNl',
+                    'rows' => 8,
+                ],
+            ]
+        );
+
+        $builder->add(
+            'privacyStatementUrlEn',
+            UrlType::class,
+            [
+                'label' => 'privacy.form.label.privacyStatementUrlEn.html',
+                'required' => false,
+                'attr' => [
+                    'data-help' => 'privacy.information.privacyStatementUrlEn',
+                    'rows' => 8,
+                ],
+            ]
+        );
+
+        $builder->add(
             'otherInfo',
             TextareaType::class,
             [
@@ -94,6 +141,13 @@ class PrivacyQuestionsFormBuilder
             ]
         );
 
-        $builder->add('save', SubmitType::class, ['attr' => ['class'=>'button']]);
+        $builder->add(
+            'save',
+            SubmitType::class,
+            [
+                'label' => 'privacy.form.label.save-button',
+                'attr' => ['class'=>'button']
+            ]
+        );
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Menu/Builder.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Menu/Builder.php
@@ -55,19 +55,19 @@ class Builder
         }
 
         if ($this->authorizationService->isAdministrator() && $this->authorizationService->getActiveServiceId()) {
-            $menu->addChild('Service overview', [
+            $menu->addChild('global.menu.overview', [
                 'route' => 'service_admin_overview',
                 'routeParameters' => ['serviceId' => $this->authorizationService->getActiveServiceId()],
             ]);
         } else {
-            $menu->addChild('Services', ['route' => 'service_overview']);
+            $menu->addChild('global.menu.services', ['route' => 'service_overview']);
         }
         if ($this->authorizationService->isAdministrator()) {
-            $menu->addChild('Add new service', array(
+            $menu->addChild('global.menu.new-service', array(
                 'route' => 'service_add',
             ));
 
-            $menu->addChild('Translations', array(
+            $menu->addChild('global.menu.translations', array(
                 'route' => 'lexik_translation_overview',
             ));
         }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -1,3 +1,8 @@
+global.button.close: "Close"
+global.menu.overview: "Service overview"
+global.menu.services: "Services"
+global.menu.new-service: "Add new service"
+global.menu.translations: "Translations"
 allowed.html.tags: "Allowed html tags"
 site_notice.html: '<p>There is nothing wrong with your television set. <strong>Do not attempt to adjust the picture.</strong> We are controlling transmission. If we wish to make it louder, we will bring up the volume. If we wish to make it softer, we will tune it to a whisper. We will control the horizontal. We will control the vertical. We can roll the image, make it flutter. We can change the focus to a soft blur, or sharpen it to crystal clarity. <strong></p><p>For the next hour, sit quietly and we will control all that you see and hear.</strong> We repeat: There is nothing wrong with your television set. You are about to participate in a great adventure. You are about to experience the awe and mystery which reaches from the inner mind to... <a href="https://en.wikiquote.org/wiki/The_Outer_Limits_(1963_TV_series)">The Outer Limits</a>.</p>'
 site_notice.close: "Close notice"
@@ -428,14 +433,26 @@ privacy.edit.title: GDPR related questions
 privacy.edit.introduction.html: "<p><strong>Pellentesque habitant morbi tristique</strong> senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. <em>Aenean ultricies mi vitae est.</em> Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, <code>commodo vitae</code>, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. <a href=\"#\">Donec non enim</a> in turpis pulvinar facilisis. Ut felis.</p>"
 privacy.form.label.accessData.html: 2. Who can access the data?
 privacy.form.label.country.html: 3. In what country is the data stored?
-privacy.form.label.otherInfo.html: 14. Other data privacy and security information
 privacy.form.label.securityMeasures.html: 4. What security measures have you taken?
 privacy.form.label.whatData.html: 1. What (kind of) data is processed?
+privacy.form.label.dpaType.html: 5. What data processing agreement (DPA) type applies?
+privacy.form.label.privacyStatementUrlNl.html: 6. Dutch privacy statement URL
+privacy.form.label.privacyStatementUrlEn.html: 7. English privacy statement URL
+privacy.form.label.otherInfo.html: 8. Other data privacy and security information
+privacy.form.label.save-button: Save
+privacy.form.dpaType.choice.dpa-not-applicable: DPA is not applicable
+privacy.form.dpaType.choice.through-surf: Service is acquired through SURF
+privacy.form.dpaType.choice.in-surf-agreement: Service is willing or has signed the SURF data processing agreement
+privacy.form.dpaType.choice.dpa-supplied-by-service: Service has own data processing agreement
+privacy.form.dpaType.choice.other: Other
 privacy.information.accessData: Specify which organizations, including your own, and per organization what roles / (groups of) individuals have access to the data (including backups etc). Explain why they need access, and what access exactly each one has (like read only of certain specified data).
 privacy.information.country: In what country/countries is the data stored (including copies etc)
 privacy.information.otherInfo: What other information do you want to share regarding data security, privacy etc?
 privacy.information.securityMeasures: What security measures have you taken (remember the encryption during transport and storage)?
 privacy.information.whatData: Describe what (kind of) data is processed in the service, and pay specific attention to possible processing of personal data.
+privacy.information.dpaType: DPA data type hint
+privacy.information.privacyStatementUrlNl: Privacy statement URL in Dutch
+privacy.information.privacyStatementUrlEn: Privacy statement URL in English
 privacy.edit.flash.success: Your changes were saved!
 service.admin_overview.introduction.html: "Please use the service switcher to manage the entities of one of the services."
 service.create.title: Add new service

--- a/tests/unit/Application/Metadata/JsonGenerator/PrivacyQuestionsMetadataGeneratorTest.php
+++ b/tests/unit/Application/Metadata/JsonGenerator/PrivacyQuestionsMetadataGeneratorTest.php
@@ -24,6 +24,7 @@ use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\PrivacyQ
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\DpaType;
 use Surfnet\ServiceProviderDashboard\Legacy\Repository\AttributesMetadataRepository;
 
 class PrivacyQuestionsMetadataGeneratorTest extends MockeryTestCase
@@ -46,6 +47,9 @@ class PrivacyQuestionsMetadataGeneratorTest extends MockeryTestCase
         $privacyQuestions->setCountry('Country');
         $privacyQuestions->setAccessData('Access data');
         $privacyQuestions->setSecurityMeasures('Measures');
+        $privacyQuestions->setPrivacyStatementUrlEn('https://foobar.example.com/privacy');
+        $privacyQuestions->setPrivacyStatementUrlNl('https://foobar.example.nl/privacy');
+        $privacyQuestions->setDpaType('dpa_in_surf_agreement'); // DpaType::DPA_TYPE_IN_SURF_AGREEMENT
 
         $service->setPrivacyQuestions($privacyQuestions);
         $entity->setService($service);
@@ -56,10 +60,16 @@ class PrivacyQuestionsMetadataGeneratorTest extends MockeryTestCase
 
         $metadata = $factory->build($entity);
 
-        $this->assertCount(5, $metadata);
+        $this->assertCount(8, $metadata);
 
-        // Test some of the assertions
         $this->assertEquals('What data', $metadata['coin:privacy:what_data']);
+        $this->assertEquals('Access data', $metadata['coin:privacy:access_data']);
+        $this->assertEquals('Country', $metadata['coin:privacy:country']);
+        $this->assertEquals('Measures', $metadata['coin:privacy:security_measures']);
+        $this->assertEquals('Other information', $metadata['coin:privacy:other_info']);
+        $this->assertEquals('https://foobar.example.com/privacy', $metadata['mdui:PrivacyStatementURL:en']);
+        $this->assertEquals('https://foobar.example.nl/privacy', $metadata['mdui:PrivacyStatementURL:nl']);
+        $this->assertEquals('dpa_in_surf_agreement', $metadata['coin:privacy:dpa_type']); // DpaType::DPA_TYPE_IN_SURF_AGREEMENT
     }
 
     public function test_it_retuns_empty_array_when_disabled()

--- a/tests/unit/Application/Metadata/JsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/JsonGeneratorTest.php
@@ -62,6 +62,8 @@ class JsonGeneratorTest extends MockeryTestCase
         $this->privacyQuestionsMetadataGenerator
             ->shouldReceive('build')
             ->andReturn(['privacy' => 'privacy']);
+        $this->privacyQuestionsMetadataGenerator
+            ->shouldReceive('withMetadataPrefix');
 
         $this->spDashboardMetadataGenerator
             ->shouldReceive('build')
@@ -230,6 +232,7 @@ class JsonGeneratorTest extends MockeryTestCase
                     'revisionnote' => 'revisionnote',
                     'metaDataFields.contacts:2:givenName' => 'John Doe',
                     'metaDataFields.coin:exclude_from_push' => '0',
+                    'privacy' => 'privacy',
                 ),
             'type' => 'saml20_sp',
             'id' => 'manageId',

--- a/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
@@ -57,6 +57,8 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
         $this->privacyQuestionsMetadataGenerator
             ->shouldReceive('build')
             ->andReturn(['privacy' => 'privacy']);
+        $this->privacyQuestionsMetadataGenerator
+            ->shouldReceive('withMetadataPrefix');
 
         $this->spDashboardMetadataGenerator
             ->shouldReceive('build')
@@ -92,6 +94,7 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
                     'metaDataFields.OrganizationName:nl' => 'Drop Supplies',
                     'metaDataFields.OrganizationDisplayName:en' => 'Drop Supplies',
                     'revisionnote' => 'revisionnote',
+                    'privacy' => 'privacy'
                 ],
             ],
             $data
@@ -129,6 +132,7 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
 
                         ],
                         'revisionnote' => 'revisionnote',
+                        'privacy' => 'privacy'
                     ),
                 'type' => 'oidc10_rp',
                 'id' => 'manageId',

--- a/tests/unit/Application/Metadata/OidcngResourceServerJsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/OidcngResourceServerJsonGeneratorTest.php
@@ -58,6 +58,9 @@ class OidcngResourceServerJsonGeneratorTest extends MockeryTestCase
             ->shouldReceive('build')
             ->andReturn(['privacy' => 'privacy']);
 
+        $this->privacyQuestionsMetadataGenerator
+            ->shouldReceive('withMetadataPrefix');
+
         $this->spDashboardMetadataGenerator
             ->shouldReceive('build')
             ->andReturn([]);
@@ -123,7 +126,8 @@ class OidcngResourceServerJsonGeneratorTest extends MockeryTestCase
                         'entityid' => 'entityid',
                         'metaDataFields.name:en' => 'A new hope',
                         'state' => 'testaccepted',
-                        'revisionnote' => 'revisionnote'
+                        'revisionnote' => 'revisionnote',
+                        'privacy' => 'privacy'
                     ),
                 'type' => 'oauth20_rs',
                 'id' => 'manageId',

--- a/tests/unit/Legacy/Repository/AttributesMetadataRepositoryTest.php
+++ b/tests/unit/Legacy/Repository/AttributesMetadataRepositoryTest.php
@@ -72,11 +72,13 @@ class AttributesMetadataRepositoryTest extends MockeryTestCase
             "country",
             "securityMeasures",
             "otherInfo",
+            "dpaType",
+            "privacyStatementUrl"
         ];
 
         $attributes = $this->repository->findAllPrivacyQuestionsAttributes();
 
-        $this->assertCount(5, $attributes);
+        $this->assertCount(7, $attributes);
         foreach ($attributes as $attribute) {
             $this->assertContains($attribute->id, $expectedAttributes);
         }

--- a/tests/webtests/CreatePrivacyQuestionsTest.php
+++ b/tests/webtests/CreatePrivacyQuestionsTest.php
@@ -25,38 +25,55 @@ class CreatePrivacyQuestionsTest extends WebTestCase
     public function test_it_can_display_the_form()
     {
         $this->loadFixtures();
-
         $serviceRepository = $this->getServiceRepository();
         $this->logIn($serviceRepository->findByName('SURFnet'));
-
         $crawler = self::$pantherClient->request('GET', '/service/1/privacy');
 
         $this->assertEquals('GDPR related questions', $crawler->filter('h1')->first()->text());
+
         $formRows = $crawler->filter('div.form-row');
-        $this->assertCount(5, $formRows);
+
+        $this->assertCount(8, $formRows);
     }
 
     public function test_it_can_submit_the_form()
     {
         $this->loadFixtures();
-
         $serviceRepository = $this->getServiceRepository();
-
         $this->logIn($serviceRepository->findByName('SURFnet'));
-
         $crawler = self::$pantherClient->request('GET', '/service/1/privacy');
-
         $formRows = $crawler->filter('div.form-row');
 
-        $this->assertCount(5, $formRows);
+        $this->assertCount(8, $formRows);
 
         $form = $crawler->findElement(WebDriverBy::cssSelector('form[name="dashboard_bundle_privacy_questions_type"]'));
         $this->fillFormField($form, '#dashboard_bundle_privacy_questions_type_whatData', 'We will refrain from requesting any data');
         $this->fillFormField($form, '#dashboard_bundle_privacy_questions_type_accessData', 'Some data will be accessed');
         $this->fillFormField($form, '#dashboard_bundle_privacy_questions_type_country', 'The Netherlands');
+        $this->checkFormField($form, '#dashboard_bundle_privacy_questions_type_dpaType_2');
+        $this->fillFormField($form, '#dashboard_bundle_privacy_questions_type_privacyStatementUrlNl', 'foobar.example.nl/privacy');
+        $this->fillFormField($form, '#dashboard_bundle_privacy_questions_type_privacyStatementUrlEn', 'https://foobar.example.com');
         $form->submit();
 
         $crawler = self::$pantherClient->refreshCrawler();
+
         self::assertOnPage('Your changes were saved!', $crawler);
+    }
+    public function test_it_rejects_invalid_privacy_statement_urls()
+    {
+        $this->loadFixtures();
+        $serviceRepository = $this->getServiceRepository();
+        $this->logIn($serviceRepository->findByName('SURFnet'));
+        $crawler = self::$pantherClient->request('GET', '/service/1/privacy');
+        $formRows = $crawler->filter('div.form-row');
+
+        $this->assertCount(8, $formRows);
+
+        $form = $crawler->findElement(WebDriverBy::cssSelector('form[name="dashboard_bundle_privacy_questions_type"]'));
+        $this->fillFormField($form, '#dashboard_bundle_privacy_questions_type_privacyStatementUrlEn', 'I dont know if we have a privacy policy url.');
+        $form->submit();
+        $crawler = self::$pantherClient->refreshCrawler();
+
+        self::assertOnPage('This value is not a valid URL.', $crawler);
     }
 }

--- a/tests/webtests/EditPrivacyQuestionsTest.php
+++ b/tests/webtests/EditPrivacyQuestionsTest.php
@@ -19,6 +19,7 @@
 namespace Surfnet\ServiceProviderDashboard\Webtests;
 
 use Facebook\WebDriver\WebDriverBy;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\DpaType;
 
 class EditPrivacyQuestionsTest extends WebTestCase
 {
@@ -35,8 +36,10 @@ class EditPrivacyQuestionsTest extends WebTestCase
         $this->assertEquals('GDPR related questions', $crawler->filter('h1')->first()->text());
         $formRows = $crawler->filter('div.form-row');
 
-        $this->assertCount(5, $formRows);
+        $this->assertCount(8, $formRows);
         $this->assertEquals('All your data are belong to us', $formRows->eq(0)->filter('textarea')->text());
+        $checkedDpaType = $formRows->eq(4)->filter('input:checked')->getAttribute('value');
+        $this->assertEquals(DpaType::DEFAULT, $checkedDpaType);
     }
 
     public function test_it_can_submit_the_form()
@@ -50,16 +53,27 @@ class EditPrivacyQuestionsTest extends WebTestCase
         $crawler = self::$pantherClient->request('GET', '/service/2/privacy');
 
         $formRows = $crawler->filter('div.form-row');
-        $this->assertCount(5, $formRows);
+        $this->assertCount(8, $formRows);
 
         $form = $crawler->findElement(WebDriverBy::cssSelector('form[name="dashboard_bundle_privacy_questions_type"]'));
         $this->fillFormField($form, '#dashboard_bundle_privacy_questions_type_whatData', 'We will refrain from requesting any data');
         $this->fillFormField($form, '#dashboard_bundle_privacy_questions_type_accessData', 'Some data will be accessed');
         $this->fillFormField($form, '#dashboard_bundle_privacy_questions_type_country', 'The Netherlands');
+        $this->checkFormField($form, '#dashboard_bundle_privacy_questions_type_dpaType_4');
+        $this->fillFormField($form, '#dashboard_bundle_privacy_questions_type_privacyStatementUrlNl', 'foobar.example.nl/privacy');
+        $this->fillFormField($form, '#dashboard_bundle_privacy_questions_type_privacyStatementUrlEn', 'https://foobar.example.com');
         $form->submit();
 
         $crawler = self::$pantherClient->refreshCrawler();
 
         self::assertOnPage('Your changes were saved!', $crawler);
+
+        // Now check if the correct DpaType is displayed and the privacy statement Url was saved
+        $crawler = self::$pantherClient->request('GET', '/service/2/privacy');
+        $formRows = $crawler->filter('div.form-row');
+        $checkedDpaType = $formRows->eq(4)->filter('input:checked')->getAttribute('value');
+        $this->assertEquals('other', $checkedDpaType); // DpaType::DPA_TYPE_OTHER
+        $this->assertEquals('http://foobar.example.nl/privacy', $formRows->eq(5)->filter('input')->getAttribute('value'));
+        $this->assertEquals('https://foobar.example.com', $formRows->eq(6)->filter('input')->getAttribute('value'));
     }
 }


### PR DESCRIPTION
PART 2 of the Privacy Questions overhaul

In the second part, I added the new fields. Which are the `dpaType` and the multilingual `PrivacyStatementUrl` (nl+en) fields. They are added throughout the entire stack.

While at it, I found out the Privacy Questions where not included upon entity update actions. That was also addressed in this PR.