### PR TITLE
Push test metadata upon entity deletion

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/DeletePublishedTestEntityCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/DeletePublishedTestEntityCommandHandler.php
@@ -24,11 +24,13 @@ use Surfnet\ServiceProviderDashboard\Application\CommandHandler\CommandHandler;
 use Surfnet\ServiceProviderDashboard\Application\Exception\EntityNotDeletedException;
 use Surfnet\ServiceProviderDashboard\Application\Exception\UnableToDeleteEntityException;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\DeleteManageEntityRepository;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\PublishEntityRepository;
 
 class DeletePublishedTestEntityCommandHandler implements CommandHandler
 {
     public function __construct(
         private readonly DeleteManageEntityRepository $deleteEntityRepository,
+        private readonly PublishEntityRepository $publishClient,
         private readonly LoggerInterface $logger
     ) {
     }
@@ -56,7 +58,10 @@ class DeletePublishedTestEntityCommandHandler implements CommandHandler
         }
 
         if ($response !== DeleteManageEntityRepository::RESULT_SUCCESS) {
-            throw new EntityNotDeletedException('Deleting the entity yielded an non success response');
+            throw new EntityNotDeletedException('Deleting the entity yielded a non success response');
         }
+
+        // Push metadata to EngineBlock and other listeners nudging them to update their indexed entity metadata
+        $this->publishClient->pushMetadata();
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -45,6 +45,7 @@ services:
     class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\DeletePublishedTestEntityCommandHandler
     arguments:
       - '@surfnet.manage.client.delete_client.test_environment'
+      - '@Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\PublishEntityClient'
     public: true
     tags:
       - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Entity\DeletePublishedTestEntityCommand }

--- a/tests/integration/Application/CommandHandler/Entity/DeletePublishedTestEntityCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/DeletePublishedTestEntityCommandHandlerTest.php
@@ -27,6 +27,7 @@ use Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\DeletePub
 use Surfnet\ServiceProviderDashboard\Application\Exception\UnableToDeleteEntityException;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\DeleteManageEntityRepository;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\PublishEntityRepository;
 
 class DeletePublishedTestEntityCommandHandlerTest extends MockeryTestCase
 {
@@ -42,9 +43,11 @@ class DeletePublishedTestEntityCommandHandlerTest extends MockeryTestCase
     private $repository;
 
     /**
-     * @var LoggerInterface|Mock
+     * @var LoggerInterface&Mock
      */
     private $logger;
+
+    private PublishEntityRepository $publishClient;
 
     public function setUp(): void
     {
@@ -52,8 +55,11 @@ class DeletePublishedTestEntityCommandHandlerTest extends MockeryTestCase
 
         $this->logger = m::mock(LoggerInterface::class);
 
+        $this->publishClient = m::mock(PublishEntityRepository::class);
+
         $this->commandHandler = new DeletePublishedTestEntityCommandHandler(
             $this->repository,
+            $this->publishClient,
             $this->logger
         );
     }
@@ -61,6 +67,10 @@ class DeletePublishedTestEntityCommandHandlerTest extends MockeryTestCase
     public function test_it_can_delete_an_entity_from_test()
     {
         $command = new DeletePublishedTestEntityCommand('d6f394b2-08b1-4882-8b32-81688c15c489', Constants::TYPE_SAML);
+
+        $this->publishClient
+            ->shouldReceive('pushMetadata')
+            ->once();
 
         $this->repository
             ->shouldReceive('delete')


### PR DESCRIPTION
When a test entity is removed from manage, also push the updated metadata to EngineBlock and the OidcNg gateway.

`https://www.pivotaltracker.com/story/show/184915015`