### PR TITLE
When no privacy Q&A set, do not try to read them

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/PrivacyQuestionsMetadataGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/PrivacyQuestionsMetadataGenerator.php
@@ -58,7 +58,7 @@ class PrivacyQuestionsMetadataGenerator implements MetadataGenerator
 
         $attributes = [];
 
-        if ($entity->getService()->isPrivacyQuestionsEnabled()) {
+        if ($privacyQuestionAnswers !== null && $entity->getService()->isPrivacyQuestionsEnabled()) {
             foreach ($privacyQuestions as $question) {
                 if ($question->id === 'privacyStatementUrl') {
                     $privacyStatements = $privacyQuestionAnswers->privacyStatementUrls();
@@ -71,7 +71,7 @@ class PrivacyQuestionsMetadataGenerator implements MetadataGenerator
                 }
 
                 $getterName = $question->getterName;
-                if ($privacyQuestionAnswers !== null && method_exists($privacyQuestionAnswers, $getterName)) {
+                if (method_exists($privacyQuestionAnswers, $getterName)) {
                     $this->buildPrivacyQuestion(
                         $attributes,
                         $getterName,

--- a/tests/unit/Application/Metadata/JsonGenerator/PrivacyQuestionsMetadataGeneratorTest.php
+++ b/tests/unit/Application/Metadata/JsonGenerator/PrivacyQuestionsMetadataGeneratorTest.php
@@ -24,7 +24,6 @@ use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGenerator\PrivacyQ
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\PrivacyQuestions;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
-use Surfnet\ServiceProviderDashboard\Domain\ValueObject\DpaType;
 use Surfnet\ServiceProviderDashboard\Legacy\Repository\AttributesMetadataRepository;
 
 class PrivacyQuestionsMetadataGeneratorTest extends MockeryTestCase
@@ -54,9 +53,9 @@ class PrivacyQuestionsMetadataGeneratorTest extends MockeryTestCase
         $service->setPrivacyQuestions($privacyQuestions);
         $entity->setService($service);
 
-        $metadataRepository = new AttributesMetadataRepository(__DIR__ . '/../../../../../assets/Resources');
-
-        $factory = new PrivacyQuestionsMetadataGenerator($metadataRepository);
+        $factory = new PrivacyQuestionsMetadataGenerator(
+            new AttributesMetadataRepository(__DIR__ . '/../../../../../assets/Resources')
+        );
 
         $metadata = $factory->build($entity);
 
@@ -83,11 +82,28 @@ class PrivacyQuestionsMetadataGeneratorTest extends MockeryTestCase
 
         $entity->setService($service);
 
-        $metadataRepository = new AttributesMetadataRepository(__DIR__ . '/../../../../../assets/Resources');
+        $factory = new PrivacyQuestionsMetadataGenerator(
+            new AttributesMetadataRepository(__DIR__ . '/../../../../../assets/Resources')
+        );
 
-        $factory = new PrivacyQuestionsMetadataGenerator($metadataRepository);
         $metadata = $factory->build($entity);
 
         $this->assertEmpty($metadata);
+    }
+    public function test_does_not_fail_when_no_questions_and_answers_provided()
+    {
+        $entity = m::mock(ManageEntity::class)->makePartial();
+        $service = m::mock(Service::class)->makePartial();
+
+        $service->setPrivacyQuestionsEnabled(true);
+        $entity->setService($service);
+
+        $factory = new PrivacyQuestionsMetadataGenerator(
+            new AttributesMetadataRepository(__DIR__ . '/../../../../../assets/Resources')
+        );
+
+        $metadata = $factory->build($entity);
+
+        $this->assertCount(0, $metadata);
     }
 }


### PR DESCRIPTION
The JSON generator has been made more robust, only adding the questions (and associated answers) when they are present on the Service entity.