### PR TITLE
Prevent teammember double delete drama

### DIFF
--- a/assets/js/components/delete_member.ts
+++ b/assets/js/components/delete_member.ts
@@ -7,7 +7,8 @@ $(() => {
 
   if (!!flashUl && !!deleteLinks) {
     deleteLinks.forEach(item => {
-      item.addEventListener('mousedown', (event) => {
+      item.addEventListener('click', (event) => {
+        event.preventDefault();
         event.stopImmediatePropagation();
         const target = event.target as HTMLSelectElement;
         if (!target.matches('.teams__deleteMemberLink')) return;


### PR DESCRIPTION
When pressing the delete membership button on the manageTeam page, the click on the anchor would be catched with the mousedown event listener. Propagation was stopped, but the mouseup/click event was still triggered. Drawing this behavior:

1. The team membership was removed via the mousedown event
2. The href was followed resulting in a visit to the api that handles the removal of the member. As the member was remove previously, that resulted in the error message that was described in the story

What was done to prevent this?

1. The listener was changed to be a click event listener
2. Both immediate propagation is stopped and 'preventDefault' is called on the event.

See: https://www.pivotaltracker.com/story/show/185585883