### PR TITLE
Service switcher improvements

### DIFF
--- a/assets/js/components/service_switcher.js
+++ b/assets/js/components/service_switcher.js
@@ -9,6 +9,8 @@ $(document).ready(function() {
     }
 
     $('select#service-switcher')
-        .select2()
+        .select2({
+            placeholder: ''
+        })
         .change(submitFormOnSelectionChange);
 });

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/ServiceService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/ServiceService.php
@@ -58,7 +58,7 @@ class ServiceService
      *
      * @param array $allowedServices The input should be service names keyed by service id.
      *                               As provided by: AuthorizationService::getAllowedServiceNamesById
-     * @return array
+     * @return Service[]
      */
     public function getServicesByAllowedServices(array $allowedServices)
     {

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -51,6 +51,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\RouterInterface;
+use function reset;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -83,8 +84,17 @@ class ServiceController extends AbstractController
         if (empty($services)) {
             return $this->redirectToRoute('service_add');
         }
+        // If only one service is available and you are admin, select that one
+        if ($this->isGranted('ROLE_ADMINISTRATOR') && count($services) === 1) {
+            $service = reset($services);
+            $this->authorizationService->changeActiveService($service->getId());
+            return $this->redirect(
+                $this->generateUrl('service_admin_overview', ['serviceId' => $service->getId()])
+            );
+        }
 
-        if ($this->isGranted('ROLE_ADMINISTRATOR')) {
+        // If more than one service and you are admin, the show the: select a service from the switcher message
+        if ($this->isGranted('ROLE_ADMINISTRATOR') && count($services) > 1) {
             return $this->render("@Dashboard/Service/admin_overview.html.twig");
         }
 


### PR DESCRIPTION
1. The empty option was removed from the service switcher (was caused by a missing placeholder text)
2. Given you are admin and only one service is activated, the service overview of that service is now auto-loaded.

See: https://www.pivotaltracker.com/story/show/182154117