### PR TITLE
Reduce button height

### DIFF
--- a/assets/scss/components/collection_widget.scss
+++ b/assets/scss/components/collection_widget.scss
@@ -24,7 +24,7 @@
 
 
     display: inline-block;
-    padding: 5px 10px;
+    padding: 3px 10px;
     text-transform: uppercase;
     background-color: white;
     color: $blue;

--- a/assets/scss/components/connection_request.scss
+++ b/assets/scss/components/connection_request.scss
@@ -1,6 +1,6 @@
 .connection-request-wrapper {
   .button-small {
-    padding: 5px 10px;
+    padding: 3px 10px;
     top: 1.5rem;
   }
   .collection-list {


### PR DESCRIPTION
To ensure they are the exact height of the textfields they are usually rendered next to.

See: https://www.pivotaltracker.com/story/show/184325032/comments/237589026