### PR TITLE
Prevent double actions

### DIFF
--- a/assets/js/components/change_member_role.ts
+++ b/assets/js/components/change_member_role.ts
@@ -5,7 +5,8 @@ $(() => {
   const flashUl = document.querySelector('.teams__flashMessages') as HTMLUListElement;
   const changeRoleLinks = document.querySelectorAll('.teams__changeMemberRole');
   changeRoleLinks.forEach(item => {
-    item.addEventListener('mousedown', (event) => {
+    item.addEventListener('click', (event) => {
+      event.preventDefault();
       const target = event.target as HTMLAnchorElement;
       const roleName = target.getAttribute('data-role');
       const parentElement = target.closest('div');

--- a/assets/js/components/resend_invite.ts
+++ b/assets/js/components/resend_invite.ts
@@ -7,7 +7,8 @@ $(() => {
 
   if (!!flashUl && !!resendInviteLinks) {
     resendInviteLinks.forEach(item => {
-      item.addEventListener('mousedown', (event) => {
+      item.addEventListener('click', (event) => {
+        event.preventDefault();
         event.stopImmediatePropagation();
         const target = event.target as HTMLSelectElement;
         if (!target.matches('.teams__resendInviteLink')) return;


### PR DESCRIPTION
When clicking certain buttons in the teams screens, events would be triggered multiple times. This was already fixed in #600. But other construct also used the mousedown event. That was fixed in this commit for the change member the resent invitation listeners. The issue was described in the storie mentioned below.

See: https://www.pivotaltracker.com/story/show/185785974
See: https://github.com/SURFnet/sp-dashboard/pull/600/files