### PR TITLE
Set template on mail message correctly

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Factory/MailMessageFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Factory/MailMessageFactory.php
@@ -44,18 +44,14 @@ class MailMessageFactory
     public function buildJiraIssueFailedMessage(Exception $exception, ManageEntity $entity): TemplatedEmail
     {
         $message = $this->createNewMessage();
-        $message->subject($this->translator->trans('mail.jira.publish_production_failed.subject'));
-
-        $template = $this->renderView(
-            '@Dashboard/Mail/jiraPublicationFailed.html.twig',
-            [
+        $message
+            ->subject($this->translator->trans('mail.jira.publish_production_failed.subject'))
+            ->htmlTemplate('@Dashboard/Mail/jiraPublicationFailed.html.twig')
+            ->context([
                 'exception' => $exception,
                 'entityId' => $entity->getMetaData()->getEntityId(),
                 'serviceName' => $entity->getService()->getName(),
-            ]
-        );
-
-        $message->htmlTemplate($template);
+            ]);
 
         return $message;
     }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Factory/MailMessageFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Factory/MailMessageFactory.php
@@ -22,7 +22,6 @@ use Exception;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Twig\Environment as TwigEnvironment;
 
 /**
  * The mail message factory builds mail messages. These messages are set with a translatable title and their message
@@ -36,8 +35,7 @@ class MailMessageFactory
         private readonly string $sender,
         private readonly string $receiver,
         private readonly string $noReply,
-        private readonly TranslatorInterface $translator,
-        private readonly TwigEnvironment $templating
+        private readonly TranslatorInterface $translator
     ) {
     }
 
@@ -66,10 +64,5 @@ class MailMessageFactory
         $email->to($this->receiver);
 
         return $email;
-    }
-
-    private function renderView($view, array $parameters = array())
-    {
-        return $this->templating->render($view, $parameters);
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -170,8 +170,6 @@ services:
       - '%env(mail_receiver)%'
       - '%env(mail_no_reply)%'
       - '@translator'
-      - '@twig'
-
 
   Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Menu\Builder:
     tags:


### PR DESCRIPTION
The twig template can now be passed to the mailer, and symfony takes care of rendering the template without the need to render it ourself.