### PR TITLE
Add DPA choice specific tooltips

### DIFF
--- a/assets/scss/pages/privacy_questions.scss
+++ b/assets/scss/pages/privacy_questions.scss
@@ -1,0 +1,7 @@
+.dpa-types {
+  .help-button {
+    position: initial;
+    margin-left: auto;
+    padding: 8px 4px 0;
+  }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/PrivacyQuestions/PrivacyQuestionsFormBuilder.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/PrivacyQuestions/PrivacyQuestionsFormBuilder.php
@@ -97,8 +97,14 @@ class PrivacyQuestionsFormBuilder
                 'placeholder' => false,
                 'attr' => [
                     'data-help' => 'privacy.information.dpaType',
+                    'class' => 'dpa-types',
                     'rows' => 8,
                 ],
+                'choice_attr' => function ($choice) {
+                    return [
+                        'help' => $choice,
+                    ];
+                },
             ]
         );
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -454,6 +454,11 @@ privacy.information.dpaType: DPA data type hint
 privacy.information.privacyStatementUrlNl: Privacy statement URL in Dutch
 privacy.information.privacyStatementUrlEn: Privacy statement URL in English
 privacy.edit.flash.success: Your changes were saved!
+privacy.information.dpaType.dpa_not_applicable: The service is not a processor according to GDPR
+privacy.information.dpaType.dpa_model_surf: Agreements are dealt with through SURF
+privacy.information.dpaType.dpa_in_surf_agreement: We are open to signing the SURF model contract/we have signed the SURF model contract
+privacy.information.dpaType.dpa_supplied_by_service: We have arranged the  company's data processing agreement.
+privacy.information.dpaType.other: None of the above. You can  elaborate on this in question 7.
 service.admin_overview.introduction.html: "Please use the service switcher to manage the entities of one of the services."
 service.create.title: Add new service
 service.create.description: "Members of this team have access to SP %Name% via the SP Dashboard (sp.surfconext.nl) and can add/manage their entities on the SURFconext platform."

--- a/templates/form/fields.html.twig
+++ b/templates/form/fields.html.twig
@@ -116,6 +116,11 @@
             <div class="radio-container">
             {{- form_widget(child) -}}
             {{- form_label(child, null, {translation_domain: choice_translation_domain, 'label_attr': {'for': child.vars.id}}) -}}
+                {% if child.vars.attr.help is defined %}
+                    <span data-tippy-content="{{ ('privacy.information.dpaType.' ~ child.vars.attr.help)|trans }}" class="help-button">
+                        <i class="fa fa-question-circle"></i>
+                    </span>
+                {% endif %}
             </div>
         {% endfor -%}
     </div>


### PR DESCRIPTION
Each DPA type now has a dedicated tooltip as described in:

https://www.pivotaltracker.com/story/show/185441616

The hints are rendered inside the choices. 
The base form template needed an adjustment to allow the hint to show up. 
The hints rely on the existing tippy tooltip implementation. So no additional JS was required to add event listeners.