### PR TITLE
Remove tooltip from DPA type parent element

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/PrivacyQuestions/PrivacyQuestionsFormBuilder.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/PrivacyQuestions/PrivacyQuestionsFormBuilder.php
@@ -96,7 +96,6 @@ class PrivacyQuestionsFormBuilder
                 'empty_data' => DpaType::DEFAULT,
                 'placeholder' => false,
                 'attr' => [
-                    'data-help' => 'privacy.information.dpaType',
                     'class' => 'dpa-types',
                     'rows' => 8,
                 ],

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -450,7 +450,6 @@ privacy.information.country: In what country/countries is the data stored (inclu
 privacy.information.otherInfo: What other information do you want to share regarding data security, privacy etc?
 privacy.information.securityMeasures: What security measures have you taken (remember the encryption during transport and storage)?
 privacy.information.whatData: Describe what (kind of) data is processed in the service, and pay specific attention to possible processing of personal data.
-privacy.information.dpaType: DPA data type hint
 privacy.information.privacyStatementUrlNl: Privacy statement URL in Dutch
 privacy.information.privacyStatementUrlEn: Privacy statement URL in English
 privacy.edit.flash.success: Your changes were saved!


### PR DESCRIPTION
Now that the individual dpa type options have their own tooltips, the parent tooltip has become redundant. And is removed in this commit.

See: https://www.pivotaltracker.com/story/show/183883449
Part of: https://github.com/SURFnet/sp-dashboard/pull/591