### PR TITLE
Use devconf as basis for development.

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,93 @@
+APP_ENV=prod
+APP_SECRET=e1023e5989bec76e282bd0ee405200e0
+DATABASE_URL="mysql://spdrw:secret@mariadb/spdashboard?serverVersion=mariadb-10.4.11&charset=utf8"
+MAILER_DSN=null://null
+locale=en
+mailer_transport=smtp
+mailer_host=mailcatcher
+mailer_user=null
+mailer_password=null
+secret=ThisTokenIsNotSoSecretChangeIt
+session_max_absolute_lifetime=3600
+session_max_relative_lifetime=600
+logout_redirect_url='https=//www.surf.nl/over-surf/werkmaatschappijen/surfnet'
+# All users in these teams get the administrator role
+administrator_teams="'urn:collab:org:surf.nl','urn:collab:org:dev.openconext.local','urn:collab:org:dev.support.surfconext.nl','urn:collab:group:dev.openconext.local:dev:openconext:local:spd_admin'"
+saml_sp_publickey='%kernel.project_dir%//vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_publickey.cer'
+saml_sp_privatekey='%kernel.project_dir%//vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_privatekey.pem'
+saml_metadata_publickey='%kernel.project_dir%//vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_publickey.cer'
+saml_metadata_privatekey='%kernel.project_dir%//vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_privatekey.pem'
+saml_remote_idp_entity_id='https://engine.dev.openconext.local/authentication/idp/metadata'
+saml_remote_idp_host=engine.dev.openconext.local
+saml_remote_idp_sso_url='https://engine.dev.openconext.local/authentication/idp/single-sign-on'
+saml_remote_idp_certificate=MIIDuDCCAqCgAwIBAgIJAPdqJ9JQKN6vMA0GCSqGSIb3DQEBBQUAMEYxDzANBgNVBAMTBkVuZ2luZTERMA8GA1UECxMIU2VydmljZXMxEzARBgNVBAoTCk9wZW5Db25leHQxCzAJBgNVBAYTAk5MMB4XDTE1MDQwMjE0MDE1NFoXDTI1MDQwMTE0MDE1NFowRjEPMA0GA1UEAxMGRW5naW5lMREwDwYDVQQLEwhTZXJ2aWNlczETMBEGA1UEChMKT3BlbkNvbmV4dDELMAkGA1UEBhMCTkwwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCeVodghQwFR0pItxGaJ3LXHA+ZLy1w/TMaGDcJaszAZRWRkL/6djwbabR7TB45QN6dfKOFGzobQxG1Oksky3gz4Pki1BSzi/DwsjWCw+Yi40cYpYeg/XM0tvHKVorlsx/7Thm5WuC7rwytujr/lV7f6lavf/ApnLHnOORU2h0ZWctJiestapMaC5mc40msruWWp04axmrYICmTmGhEy7w0qO4/HLKjXtWbJh71GWtJeLzG5Hj04X44wI+D9PUJs9U3SYh9SCFZwq0v+oYeqajiX0JPzB+8aVOPmOOM5WqoT8OCddOM/TlsL/0PcxByGHsgJuWbWMI1PKlK3omR764PAgMBAAGjgagwgaUwHQYDVR0OBBYEFLowmsUCD2CrHU0lich1DMkNppmLMHYGA1UdIwRvMG2AFLowmsUCD2CrHU0lich1DMkNppmLoUqkSDBGMQ8wDQYDVQQDEwZFbmdpbmUxETAPBgNVBAsTCFNlcnZpY2VzMRMwEQYDVQQKEwpPcGVuQ29uZXh0MQswCQYDVQQGEwJOTIIJAPdqJ9JQKN6vMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAIF9tGG1C9HOSTQJA5qL13y5Ad8G57bJjBfTjp/dw308zwagsdTeFQIgsP4tdQqPMwYmBImcTx6vUNdiwlIol7TBCPGuqQAHD0lgTkChCzWezobIPxjitlkTUZGHqn4Kpq+mFelX9x4BElmxdLj0RQV3c3BhoW0VvJvBkqVKWkZ0HcUTQMlMrQEOq6D32jGh0LPCQN7Ke6ir0Ix5knb7oegND49fbLSxpdo5vSuxQd+Zn6nI1/VLWtWpdeHMKhiw2+/ArR9YM3cY8UwFQOj9Y6wI6gPCGh/q1qv2HnngmnPrNzZik8XucGcf1Wm2zE4UIVYKW31T52mqRVDKRk8F3Eo=
+
+# The default timeout for Curl requests when retrieving metadata
+metadata_url_timeout=30
+
+# Manage defaults
+
+## Manage test instance
+manage_test_host='https://manage.dev.openconext.local'
+manage_test_username=sp-portal
+manage_test_password=secret
+manage_test_publication_status=testaccepted
+
+## Manage production instance
+manage_prod_host='https://manage.dev.openconext.local'
+manage_prod_username=sp-portal
+manage_prod_password=secret
+manage_prod_publication_status=prodaccepted
+
+## Teams test instance
+teams_host='https://teams.dev.openconext.local'
+teams_username=spdashboard
+teams_password=secret
+
+# Mail default settings
+mail_from=support@surfconext.nl
+mail_receiver=support@surfconext.nl
+mail_no_reply=no-reply@surfconext.nl
+
+# When 'jira_enable_test_mode' is enabled, 'jira_test_mode_storage_path' must be configured with a filename in a
+# directory that is writable for the user run ning the application.
+# See the:
+# - Compiler pass (IssueRepositoryCompilerPass),
+# - environment specific services.yml file
+# - docs/jira.md readme
+# for details on how to enable the test stand in.
+jira_test_mode_storage_path='../var/issues.json'
+
+# Jira settings
+jira_host='https://your_jira_host.nl'
+jira_personal_access_token='your_jira_personal_access_token'
+
+# Jira default issue settings
+jira_issue_priority=Medium
+jira_issue_type=spd-delete-production-entity
+jira_issue_type_publication_request=spd-request-production-entity
+jira_issue_type_entity_change_request=spd-request-change-request-prod
+jira_issue_entityid_fieldname=customfield_13018
+jira_issue_manageid_fieldname=customfield_13401
+jira_issue_manageid_field_label="SURFconext Manage ID"
+jira_issue_type_idp_invite=SPD-IdP-invite
+
+# The label that is set for the manage id field, used to compose the JQL which identifies a custom field by its label
+ra_issue_manageid_field_label='Manage entity ID'
+jira_issue_reporter_fieldname=customfield_99999
+jira_issue_project_key=CXT
+
+# Playground uri's for OIDC entities
+playground_uri_test='https://test.dev.playground.surfconext.nl'
+playground_uri_prod='https://prod.dev.playground.surfconext.nl'
+
+## Toggle display & content of global site notice.  Use a date to ensure that multiple notification in short order do not interfere with each other (aka: th    e user can close the first, and still see the second).
+global_site_notice_show=false
+global_site_notice_date='11.05.2021'
+global_site_notice_allowed_tags='<a><u><i><br><wbr><strong><em><blink><marquee><p><ul><ol><dl><li><dd><dt><div><span><blockquote><hr><h2></h2><h3><h4><h5><h6>'
+
+# Teams urn prefix, see: https://www.pivotaltracker.com/story/show/179572218/comments/227653860
+team_prefix_default_stem_name='urn:collab:group:dev.openconext.local:'
+team_prefix_group_name_context='demo:openconext:org:'
+
+acs_location_route_name=dashboard_saml_consume_assertion

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     env:
-      DOCKER_COMPOSE: docker-compose -f docker-compose.yml -f docker-compose-ci.yml
-      DOCKER_COMPOSE_PHP: docker-compose -f docker-compose.yml -f docker-compose-ci.yml exec -T php
-      DOCKER_COMPOSE_OPENCONEXT: docker-compose -f docker-compose.yml -f docker-compose-ci.yml exec -T openconext
-      DOCKER_COMPOSE_CYPRESS: docker-compose -f docker-compose.yml -f docker-compose-ci.yml exec -T cypress
+      DOCKER_COMPOSE: docker-compose -f docker-compose-openconext.yml -f docker-compose-ci.yml
+      DOCKER_COMPOSE_PHP: docker-compose -f docker-compose-openconext.yml -f docker-compose-ci.yml exec -T php
+      DOCKER_COMPOSE_OPENCONEXT: docker-compose -f docker-compose-openconext.yml -f docker-compose-ci.yml exec -T openconext
+      DOCKER_COMPOSE_CYPRESS: docker-compose -f docker-compose-openconext.yml -f docker-compose-ci.yml exec -T cypress
 
     steps:
       - name: Check out the repo

--- a/README.md
+++ b/README.md
@@ -14,18 +14,18 @@ their services. This can be both SAML 2.0, OpenID Connect Relying Parties and Oa
 
 ## Prerequisites
 
-- [PHP](https://secure.php.net/manual/en/install.php) (8.1)
+- [PHP](https://secure.php.net/manual/en/install.php) (8.2)
 - [Composer](https://getcomposer.org/doc/00-intro.md)
 - [Apache Ant](https://ant.apache.org/manual/install.html)
 - [Docker](https://docs.docker.com/engine/install/)
 - [Docker Compose](https://docs.docker.com/compose/install/)
 
-Use `docker-compose up -d` to create and build the development environment.
+Use `docker compose up -d` to create and build the development environment.
 
 An entry in your hostsfile is still required for things to work. An example entry would look like:
 
 ```
-127.0.0.1 welcome.vm.openconext.org static.vm.openconext.org mujina-sp.vm.openconext.org mujina-idp.vm.openconext.org engine-api.vm.openconext.org oidc.vm.openconext.org manage.vm.openconext.org spdashboard.vm.openconext.org engine.vm.openconext.org teams.vm.openconext.org
+127.0.0.1 welcome.dev.openconext.local static.dev.openconext.local mujina-sp.dev.openconext.local mujina-idp.dev.openconext.local engine-api.dev.openconext.local oidc.dev.openconext.local manage.dev.openconext.local spdashboard.dev.openconext.local engine.dev.openconext.local teams.dev.openconext.local
 ```
 
 Is your host system on an ARM based archetecture CPU, and are you running a docker solution in a VM? Chances are 
@@ -37,23 +37,34 @@ might aid in that area.
 
 ## Getting started
 
-In order to start the development environment, run `docker-compose up -d`. This will build and start the container that is
-used in development to run the application.
+This setup includes the OpenConext environment from the [Devconf](https://github.com/OpenConext/OpenConext-devconf) project. You need to checkout this project in the same directory as the sp-dashboard appcode. You will have:
 
-Then start the command line in the container with `docker exec -it sp-dashboard-php-fpm-1 sh`. This will start a shell
+dir/
+  - sp-dashboard/
+  - OpenConext-devconf/
+
+In order to start the development environment, run `docker compose --profile teams up -d`. This will start the container that is
+used in development to run the application. 
+
+You can then bootstrap the environment. It will ensure that a complete working OpenConext setup is running:
+```
+sh ../OpenConext-devconf/core/scripts/init.sh
+```
+
+Then start the command line in the container with `docker compose exec -ti spdashboard bash`. This will start a shell
 
 Run `composer install`. This will install all PHP dependencies, including the development dependencies.
 Run `yarn install`. This will install all js dependencies, including the development dependencies.
 
 Install database migrations
 ```
-$ docker exec sp-dashboard-php-fpm-1 /var/www/html/bin/console doctrine:migrations:migrate
+$ docker compose exec spdashboard /var/www/html/bin/console doctrine:migrations:migrate
 ```
 
 The application is now up and running and can be accessed at
-[https://spdashboard.vm.openconext.org/](https://spdashboard.vm.openconext.org). Note that in development the `app_dev.php`
+[https://spdashboard.dev.openconext.local/](https://spdashboard.dev.openconext.local). Note that in development the `app_dev.php`
 front controller is used automatically, so you don't have to include `/app_dev.php/` in the URLs.
-* To view mails caught by Mailcatcher, visit [spdashboard.vm.openconext.org:1080](https://spdashboard.vm.openconext.org:1080/)
+* To view mails caught by Mailcatcher, visit [spdashboard.dev.openconext.local:1080](https://spdashboard.dev.openconext.local:1080/)
 
 ### Running the tests
 

--- a/docker-compose-openconext.yml
+++ b/docker-compose-openconext.yml
@@ -1,0 +1,65 @@
+---
+
+version: "3.4"
+
+services:
+  openconext:
+    build:
+      context: 'docker/'
+      dockerfile: Dockerfiledev
+      target: openconext
+    extra_hosts:
+      engine-api.vm.openconext.org: 127.0.0.2
+      engine.vm.openconext.org: 127.0.0.1
+      manage.vm.openconext.org: 127.0.0.1
+      voot.vm.openconext.org: 127.0.0.1
+      connect.vm.openconext.org: 127.0.0.1
+      test.openconext.org: 127.0.0.1
+      teams.vm.openconext.org: 127.0.0.1
+      ansible-test-ga: 127.0.0.1
+    privileged: true
+    networks:
+      spdashboard:
+        aliases:
+          - db.vm.openconext.org
+          - engine.vm.openconext.org
+          - manage.vm.openconext.org
+          - teams.vm.openconext.org
+          - spdashboard.vm.openconext.org
+          - mujina-idp.vm.openconext.org
+    volumes:
+      - spdashboard_mysql:/var/lib/mysql
+      - spdashboard_mongo:/var/lib/mongo
+    ports:
+      - "443:443"
+      - "3306:3306"
+
+  php:
+    build:
+      context: 'docker/'
+      dockerfile: Dockerfiledev
+      target: spddev
+    volumes:
+      - .:/var/www/html/
+    networks:
+      spdashboard:
+        aliases: 
+          - spdashboard_web
+
+  test-browser:
+    image: selenium/standalone-chrome:latest
+    hostname: test-browser
+    ports:
+      - "5900:5900"
+      - "4444:4444"
+    privileged: true
+    shm_size: 2g
+    networks:
+      spdashboard:
+
+networks:
+  spdashboard:
+
+volumes:
+  spdashboard_mysql:
+  spdashboard_mongo:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,65 +1,19 @@
----
-
-version: "3.4"
+include: 
+  - ../OpenConext-devconf/core/docker-compose.yml
 
 services:
-  openconext:
-    build:
-      context: 'docker/'
-      dockerfile: Dockerfiledev
-      target: openconext
-    extra_hosts:
-      engine-api.vm.openconext.org: 127.0.0.2
-      engine.vm.openconext.org: 127.0.0.1
-      manage.vm.openconext.org: 127.0.0.1
-      voot.vm.openconext.org: 127.0.0.1
-      connect.vm.openconext.org: 127.0.0.1
-      test.openconext.org: 127.0.0.1
-      teams.vm.openconext.org: 127.0.0.1
-      ansible-test-ga: 127.0.0.1
-    privileged: true
-    networks:
-      spdashboard:
-        aliases:
-          - db.vm.openconext.org
-          - engine.vm.openconext.org
-          - manage.vm.openconext.org
-          - teams.vm.openconext.org
-          - spdashboard.vm.openconext.org
-          - mujina-idp.vm.openconext.org
-    volumes:
-      - spdashboard_mysql:/var/lib/mysql
-      - spdashboard_mongo:/var/lib/mongo
-    ports:
-      - "443:443"
-      - "3306:3306"
-
-  php:
-    build:
-      context: 'docker/'
-      dockerfile: Dockerfiledev
-      target: spddev
-    volumes:
-      - .:/var/www/html/
-    networks:
-      spdashboard:
-        aliases: 
-          - spdashboard_web
-
-  test-browser:
-    image: selenium/standalone-chrome:latest
-    hostname: test-browser
-    ports:
-      - "5900:5900"
-      - "4444:4444"
-    privileged: true
-    shm_size: 2g
-    networks:
-      spdashboard:
-
-networks:
-  spdashboard:
-
-volumes:
-  spdashboard_mysql:
-  spdashboard_mongo:
+    spdashboard:
+      image:  ghcr.io/openconext/openconext-basecontainers/php82-apache2-node20-composer2:latest
+      environment:
+      - APP_ENV=dev
+      volumes:
+        - ../OpenConext-devconf/core/:/config
+        - ./:/var/www/html/
+      networks:
+        coreconextdev:
+      hostname: spdashboard.docker
+      depends_on:
+        engine:
+          condition: service_healthy
+        mariadb:
+          condition: service_healthy


### PR DESCRIPTION
We used a custom OpenConext container before. Since we use the [devconf](https://github.com/OpenConext/OpenConext-devconf) project for all docker related development, SPD will use that as well. Some work needs yet to be done to rewrite the integration tests to use the same environment.

you will need to checkout devconf in the same dir as  the sp-dashboard code 

codedir:
  - sp-dashboard/
  - OpenConext-devconf/

