### PR TITLE
Add `createdAt` to Service entity

### DIFF
--- a/migrations/Version20240610074359.php
+++ b/migrations/Version20240610074359.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Surfnet\ServiceProviderDashboard\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add the `created` datetime field on the service entity
+ */
+final class Version20240610074359 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE service ADD createdAt DATETIME NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE service DROP createdAt');
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
@@ -18,9 +18,11 @@
 
 namespace Surfnet\ServiceProviderDashboard\Domain\Entity;
 
+use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\ServiceRepository;
 
 /**
@@ -62,6 +64,10 @@ class Service
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
     private $id;
+
+    #[Gedmo\Timestampable(on: 'create')]
+    #[ORM\Column(type: 'datetime')]
+    private DateTime $createdAt;
 
     /**
      * @var string


### PR DESCRIPTION
This additional field will show us when a service is created. It is not displayed anywhere in the UI (by design). It is just there for the TPMs to inform them for how long the SP has been granted access to the dashboard.

See: https://www.pivotaltracker.com/story/show/187715470