### PR TITLE
Dont show edit and delete actions when removal requested

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -7,4 +7,4 @@ SYMFONY_DEPRECATIONS_HELPER=999999
 DATABASE_URL="sqlite:////tmp/spdashboard-webtests.sqlite"
 PANTHER_APP_ENV=panther
 administrator_teams="'urn:collab:org:dev.openconext.local'"
-jira_test_mode_storage_path='/var/www/html/var/webtest-jira.json'
+jira_test_mode_storage_path='/var/www/html/var/issues.json'

--- a/ci/qa/phpstan-baseline.php
+++ b/ci/qa/phpstan-baseline.php
@@ -2657,6 +2657,11 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Property Surfnet\\\\ServiceProviderDashboard\\\\Domain\\\\Entity\\\\Service\\:\\:\\$createdAt is unused\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method Surfnet\\\\ServiceProviderDashboard\\\\Domain\\\\Mailer\\\\Mailer\\:\\:send\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Domain/Mailer/Mailer.php',
@@ -3198,11 +3203,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method getCoin\\(\\) on Surfnet\\\\ServiceProviderDashboard\\\\Domain\\\\Entity\\\\Entity\\\\MetaData\\|null\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityDetailController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^PHPDoc tag @return with type array\\|Symfony\\\\Component\\\\HttpFoundation\\\\RedirectResponse is not subtype of native type Symfony\\\\Component\\\\HttpFoundation\\\\Response\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityDetailController.php',
 ];
@@ -4062,7 +4062,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/DependencyInjection/Configuration.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method arrayNode\\(\\) on Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\|null\\.$#',
+	'message' => '#^Cannot call method scalarNode\\(\\) on Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\|null\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/DependencyInjection/Configuration.php',
 ];

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityService.php
@@ -81,9 +81,7 @@ class EntityService implements EntityServiceInterface
                     $service->getOrganizationNameNl()
                 );
                 $issue = $this->findIssueBy($entity);
-                $shouldUseTicketStatus = $entity->getStatus() !== Constants::STATE_PUBLISHED &&
-                    $entity->getStatus() !== Constants::STATE_PUBLICATION_REQUESTED;
-                if ($issue && $shouldUseTicketStatus) {
+                if ($issue && $issue->getIssueType() === $this->removalStatus && !$issue->isClosedOrResolved()) {
                     $entity->updateStatusToRemovalRequested();
                 }
                 return $entity;

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
@@ -27,6 +27,7 @@ use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\S
 
 /**
  * @SuppressWarnings(PHPMD.TooManyFields)
+ * @SuppressWarnings(PHPMD.UnusedPrivateField) It is used to indicate the age of a service. See: https://www.pivotaltracker.com/story/show/187715470
  */
 #[ORM\Entity(repositoryClass: ServiceRepository::class)]
 class Service

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityDetailController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityDetailController.php
@@ -36,19 +36,12 @@ class EntityDetailController extends AbstractController
     ) {
     }
 
-    /**
-     *
-     * @return                              \Symfony\Component\HttpFoundation\RedirectResponse|array
-     */
     #[IsGranted('ROLE_USER')]
     #[Route(path: '/entity/detail/{serviceId}/{id}/{manageTarget}', name: 'entity_detail', methods: ['GET'], defaults: ['manageTarget' => false])]
     public function detail(string $id, int $serviceId, string $manageTarget): Response
     {
         $service = $this->authorizationService->changeActiveService($serviceId);
         $team = $service->getTeamName();
-        /**
- * @var ManageEntity $entity
-*/
         $entity = $this->entityService->getEntityByIdAndTarget($id, $manageTarget, $service);
         if ($entity->getMetaData()->getCoin()->getServiceTeamId() !== $team) {
             $entity->setIsReadOnly();

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Security/Authentication/Provider/SamlProvider.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Security/Authentication/Provider/SamlProvider.php
@@ -76,6 +76,9 @@ class SamlProvider implements SamlProviderInterface, UserProviderInterface
         return $this->attributeDictionary->translate($assertion)->getNameID();
     }
 
+    /**
+     * @SuppressWarnings(PHPMD) // this suppression is fixed in PR: https://github.com/SURFnet/sp-dashboard/pull/634
+     */
     public function getUser(Assertion $assertion): UserInterface
     {
         $translatedAssertion = $this->attributeDictionary->translate($assertion);

--- a/templates/EntityActions/deleteAction.html.twig
+++ b/templates/EntityActions/deleteAction.html.twig
@@ -7,7 +7,7 @@
         {% endif %}
     {% endset %}
     <li>
-        <a href="{{ deletePath }}">
+        <a data-testid="delete" href="{{ deletePath }}">
             <i class="fa fa-trash" aria-hidden="true"></i>
             {{ 'entity.list.action.delete'|trans }}
         </a>

--- a/templates/EntityActions/editAction.html.twig
+++ b/templates/EntityActions/editAction.html.twig
@@ -1,6 +1,6 @@
 {% if action.allowEditAction %}
     <li>
-        <a href="{{ path('entity_edit', {manageId: action.id, environment: action.environment, serviceId: action.serviceId}) }}">
+        <a data-testid="edit" href="{{ path('entity_edit', {manageId: action.id, environment: action.environment, serviceId: action.serviceId}) }}">
             <i class="fa fa-pencil-square" aria-hidden="true"></i>
             {{ 'entity.list.action.edit'|trans }}
         </a>

--- a/templates/EntityActions/overviewAction.html.twig
+++ b/templates/EntityActions/overviewAction.html.twig
@@ -4,7 +4,7 @@
     {% else %}
         {% set overviewHref = path('service_overview') %}
     {% endif %}
-    <a href="{{ overviewHref }}">
+    <a data-testid="overview" href="{{ overviewHref }}">
         <i class="fa fa-arrow-left" aria-hidden="true"></i>
         {{ 'entity.list.action.back'|trans }}
     </a>

--- a/tests/unit/Infrastructure/DashboardSamlBundle/Security/Authentication/Provider/SamlProviderTest.php
+++ b/tests/unit/Infrastructure/DashboardSamlBundle/Security/Authentication/Provider/SamlProviderTest.php
@@ -88,8 +88,8 @@ class SamlProviderTest extends TestCase
     public function test_surfconext_responsible_teams_rejects_invalid_teams()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('All entries in the `surfconext_responsible_authorization` config parameter should be string.');
-        $this->buildProvider("'urn:collab:foo:team.foobar.com'", ",345345,true,false,foo,bar");
+        $this->expectExceptionMessage('The `surfconext_responsible_authorization` config parameter should be a non empty string.');
+        $this->buildProvider("'urn:collab:foo:team.foobar.com'", "");
     }
 
     private function buildProvider(string $administratorTeams, string $surfConextResponsible = "'defualt")

--- a/tests/webtests/EntityDetailTest.php
+++ b/tests/webtests/EntityDetailTest.php
@@ -21,6 +21,37 @@ namespace Surfnet\ServiceProviderDashboard\Webtests;
 class EntityDetailTest extends WebTestCase
 {
 
+    public function test_render_details_of_removal_requested_manage_entity()
+    {
+        $this->loadFixtures();
+        $this->logIn();
+        $entityId = '9729d851-cfdd-4283-a8f1-a29ba5036261';
+        $this->registerManageEntity(
+            'production',
+            'saml20_sp',
+            $entityId,
+            'SP3',
+            'https://sp1-entityid.example.com',
+            'https://sp1-entityid.example.com/metadata',
+            'urn:collab:group:vm.openconext.org:demo:openconext:org:surf.nl'
+        );
+
+        $issueType = 'spd-delete-production-entity';
+        $this->createjiraTicket($entityId, $issueType);
+
+        $this->switchToService('SURFnet');
+
+        $crawler = self::$pantherClient->request('GET', sprintf('/entity/detail/1/%s/production', $entityId));
+
+        self::assertOnPage("Entity details");
+        // Only the back to overview link should be on the actions toolbar
+        $toolbar = $crawler->filter('.fieldset.card.action');
+        $actions = $toolbar->filter('a[data-testid]');
+        $this->assertCount(1, $actions);
+        $this->assertEquals('Back to overview', $actions->first()->getText());
+    }
+
+
     public function test_render_details_of_manage_entity()
     {
         $this->loadFixtures();

--- a/tests/webtests/WebTestCase.php
+++ b/tests/webtests/WebTestCase.php
@@ -35,9 +35,11 @@ use Surfnet\ServiceProviderDashboard\Domain\Repository\IdentityProviderRepositor
 use Surfnet\ServiceProviderDashboard\Domain\Repository\PublishEntityRepository;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\QueryManageRepository;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\QueryTeamsRepository;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Ticket;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\DataFixtures\ORM\WebTestFixtures;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\ServiceRepository;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AuthorizationService;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Repository\DevelopmentIssueRepository;
 use Surfnet\ServiceProviderDashboard\Webtests\Debug\DebugFile;
 use Surfnet\ServiceProviderDashboard\Webtests\Manage\Client\FakeTeamsQueryClient;
 use Symfony\Component\BrowserKit\AbstractBrowser;
@@ -83,6 +85,8 @@ class WebTestCase extends PantherTestCase
 
     /** @var QueryTeamsRepository&FakeTeamsQueryClient */
     protected $teamsQueryClient;
+
+    protected DevelopmentIssueRepository $jiraIssueRepository;
 
     public static function setUpBeforeClass(): void
     {
@@ -156,6 +160,8 @@ class WebTestCase extends PantherTestCase
         $this->teamsQueryClient = self::getContainer()
             ->get('Surfnet\ServiceProviderDashboard\Infrastructure\Teams\Client\QueryClient');
         $this->teamsQueryClient->reset();
+        $this->jiraIssueRepository = self::getContainer()
+            ->get('surfnet.dashboard.repository.issue');
     }
 
     protected function registerManageEntity(
@@ -199,6 +205,21 @@ class WebTestCase extends PantherTestCase
             default:
                 throw new RuntimeException('Unsupported environment');
         }
+    }
+
+    protected function createjiraTicket(string $entityId, string $issueType)
+    {
+        $ticket = new Ticket(
+            $entityId,
+            $entityId,
+            'Name',
+            'TranslationKey',
+            'DescriptionTransKey',
+            'John Doe',
+            'jdoe@example.com',
+            $issueType
+        );
+        $this->jiraIssueRepository->createIssueFrom($ticket);
     }
 
     private function registerSp(


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/187684723
This PR concludes point 2 of the story mentioned above. In short, the edit and delete action-buttons would still be visible on the entity detail page. That allowed multiple remove jira tickets from being created. That was remedied in this PR by removing those buttons.

A web test was added, for which I created a means to create a fake jira ticket directly from test.