### PR TITLE
Remove filter column and add the extra explanation text

### DIFF
--- a/assets/scss/pages/service-connection.scss
+++ b/assets/scss/pages/service-connection.scss
@@ -1,15 +1,5 @@
 .service-connections {
-  display: flex;
-  aside.filters {
-    margin-right: 32px;
-    width: 230px;
-    flex-basis: 230px;
-    flex-shrink: 0;
-  }
   div.sps {
-    flex: 1 1;
-    flex-basis: 400px;
-
     td {
       padding: 15px 10px;
 
@@ -29,6 +19,7 @@
       padding: 11px 10px;
       font-size: .875rem;
       font-weight: 600;
+      vertical-align: bottom;
     }
 
     td.name {

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -563,8 +563,8 @@ service.overview.progress.tooltip.production-connection.in-progress.html: "The d
 service.overview.progress.tooltip.production-connection.success.html: "Thank you\nA production connection is active"
 
 service.connections.title.main: "Connections"
-service.connections.title.filters: Filters
 service.connections.title.content: Connection status
+service.connections.content.description: "The list below shows the entities you are responsible for. If a service is connected to a test IdP, it is marked with a green checkmark. If the service is connected to any other IdP, then a green checkmark wil be displayed in the final column."
 service.connections.connected: Not connected
 service.connections.not-connected: Connected
 service.connections.table.no-results: No entities found

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/DevelopmentIssueRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/DevelopmentIssueRepository.php
@@ -49,6 +49,12 @@ class DevelopmentIssueRepository implements TicketServiceInterface
         $this->failIssueCreation = true;
         $this->storeData();
     }
+    public function shouldNotFailCreateIssue(): void
+    {
+        $this->loadData();
+        $this->failIssueCreation = false;
+        $this->storeData();
+    }
 
     public function findByManageIds(array $manageIds): IssueCollection
     {

--- a/templates/Service/my-services.html.twig
+++ b/templates/Service/my-services.html.twig
@@ -10,12 +10,6 @@
             {{ 'service.connections.title.main'|trans }}
         </h1>
         <article class="fieldset card service-connections">
-            <aside class="filters">
-                <div class="header"><h2>{{ 'service.connections.title.filters'|trans }}</h2></div>
-                <div>
-                    <div class="totals">Todo</div>
-                </div>
-            </aside>
             <div class="sps">
                 <div class="header"><h2>{{ 'service.connections.title.content'|trans }}</h2></div><div>
                 <table>

--- a/templates/Service/my-services.html.twig
+++ b/templates/Service/my-services.html.twig
@@ -9,9 +9,14 @@
         <h1 id="main" class="service-title">
             {{ 'service.connections.title.main'|trans }}
         </h1>
+
         <article class="fieldset card service-connections">
             <div class="sps">
-                <div class="header"><h2>{{ 'service.connections.title.content'|trans }}</h2></div><div>
+                <div class="header"><h2>{{ 'service.connections.title.content'|trans }}</h2>
+                    <p> {{ 'service.connections.content.description'|trans }}</p>
+                </div>
+                <div>
+
                 <table>
                     <thead>
                         <tr>

--- a/tests/webtests/EntityDetailTest.php
+++ b/tests/webtests/EntityDetailTest.php
@@ -37,6 +37,7 @@ class EntityDetailTest extends WebTestCase
         );
 
         $issueType = 'spd-delete-production-entity';
+        $this->jiraIssueRepository->shouldNotFailCreateIssue();
         $this->createjiraTicket($entityId, $issueType);
 
         $this->switchToService('SURFnet');

--- a/tests/webtests/ServiceCreateTest.php
+++ b/tests/webtests/ServiceCreateTest.php
@@ -57,6 +57,6 @@ class ServiceCreateTest extends WebTestCase
         self::fillFormField($form, 'input[name="dashboard_bundle_service_type[teams][teamManagerEmail]"]', 'loeki@example.org');
         self::findBy('#dashboard_bundle_service_type_save')->click();
         $services = $this->getServiceRepository()->findAll();
-        $this->assertCount(3, $services);
+        $this->assertCount(4, $services);
     }
 }

--- a/tests/webtests/ServiceSwitcherTest.php
+++ b/tests/webtests/ServiceSwitcherTest.php
@@ -74,12 +74,14 @@ class ServiceSwitcherTest extends WebTestCase
         $crawler = self::$pantherClient->request('GET', '/service/create');
 
         $options = $crawler->filter('select#service-switcher option');
-        $this->assertCount(3, $options, 'Expecting 2 services in service switcher (excluding empty option)');
+        $this->assertCount(4, $options, 'Expecting 3 services in service switcher (excluding empty option)');
 
         $crawler->filter('.service-switcher form')->click();
-        $ibuildings = "//li[contains(@id,'select2-service-switcher-result-')][1]";
-        $surf = "//li[contains(@id,'select2-service-switcher-result-')][2]";
+        $acme = "//li[contains(@id,'select2-service-switcher-result-')][1]";
+        $ibuildings = "//li[contains(@id,'select2-service-switcher-result-')][2]";
+        $surf = "//li[contains(@id,'select2-service-switcher-result-')][3]";
 
+        $this->assertEquals('Acme Corporation [acme.com]', $crawler->findElement(WebDriverBy::xpath($acme))->getText());
         $this->assertEquals('Ibuildings B.V. [ibuildings.nl]', $crawler->findElement(WebDriverBy::xpath($ibuildings))->getText());
         $this->assertEquals('SURFnet [surf.nl]', $crawler->findElement(WebDriverBy::xpath($surf))->getText());
     }


### PR DESCRIPTION
1. The filter column is removed from the template as it is out of scope for now.
2. An additional translatable explanation text was added 
3. Webtests have been reinstated