### PR TITLE
Disable type of service for oauth_ccc entities

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOauthClientCredentialClientCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOauthClientCredentialClientCommand.php
@@ -118,19 +118,6 @@ class SaveOauthClientCredentialClientCommand implements SaveEntityCommandInterfa
     #[Assert\Url]
     private $applicationUrl;
 
-    /** @var TypeOfService[] */
-    #[Assert\All([
-        new Assert\NotBlank(),
-        new Assert\Type(type: TypeOfService::class),
-    ])]
-    #[Assert\Count(
-        min: 1,
-        max: 3,
-        minMessage: 'validator.type-of-service.min',
-        maxMessage: 'validator.type-of-service.max',
-    )]
-    private array $typeOfService;
-
     /**
      * @var string
      */
@@ -550,19 +537,9 @@ class SaveOauthClientCredentialClientCommand implements SaveEntityCommandInterfa
         return null;
     }
 
-    /**
-     * @return TypeOfService[]
-     */
     public function getTypeOfService(): array
     {
-        return $this->typeOfService;
-    }
-
-    /**
-     * @param TypeOfService[] $typeOfService
-     */
-    public function setTypeOfService(array $typeOfService): void
-    {
-        $this->typeOfService = $typeOfService;
+        // not implemented for oauth_ccc entities
+        return [];
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OauthClientCredentialEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OauthClientCredentialEntityType.php
@@ -20,8 +20,6 @@ namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\E
 
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOauthClientCredentialClientCommand;
 use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveOidcngEntityCommand;
-use Surfnet\ServiceProviderDashboard\Domain\Repository\TypeOfServiceRepository;
-use Surfnet\ServiceProviderDashboard\Domain\ValueObject\TypeOfService;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
@@ -40,7 +38,6 @@ class OauthClientCredentialEntityType extends AbstractType
 {
     public function __construct(
         private readonly OidcngResourceServerOptionsFactory $oidcngResourceServerOptionsFactory,
-        private readonly TypeOfServiceRepository $typeOfServiceProvider
     ) {
     }
 
@@ -165,22 +162,6 @@ class OauthClientCredentialEntityType extends AbstractType
                         'data-help' => 'entity.edit.information.applicationUrl',
                         'data-parsley-urlstrict' => null,
                         'data-parsley-trigger' => 'blur',
-                    ],
-                ]
-            )
-            ->add(
-                'typeOfService',
-                ChoiceType::class,
-                [
-                    'required' => false,
-                    'choices' => $this->typeOfServiceProvider->getTypesOfServiceChoices(),
-                    'choice_value' => fn(TypeOfService $tos): string => $tos->typeEn,
-                    'choice_label' => fn(TypeOfService $tos): string => $tos->typeEn,
-                    'expanded' => true,
-                    'multiple' => true,
-                    'attr' => [
-                        'class' => 'type-of-service',
-                        'data-help' => 'entity.edit.information.typeOfService',
                     ],
                 ]
             )


### PR DESCRIPTION
The type of service should not be on the client credential entity forms. At first I implemented them on there, but never finished work on it, causing the CCC web tests to fail. That was fixed here.