### PR TITLE
Add properties to the ARP values

### DIFF
--- a/ci/qa/phpstan-baseline.php
+++ b/ci/qa/phpstan-baseline.php
@@ -1822,16 +1822,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/Service/TicketServiceInterface.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method Surfnet\\\\ServiceProviderDashboard\\\\Application\\\\Service\\\\ValueObject\\\\EntityMergeAttribute\\:\\:fromAttribute\\(\\) has parameter \\$name with no type specified\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/Service/ValueObject/EntityMergeAttribute.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method Surfnet\\\\ServiceProviderDashboard\\\\Application\\\\Service\\\\ValueObject\\\\EntityMergeAttribute\\:\\:fromAttribute\\(\\) has parameter \\$urn with no type specified\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/Service/ValueObject/EntityMergeAttribute.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Surfnet\\\\ServiceProviderDashboard\\\\Application\\\\ViewObject\\\\Apis\\\\ApiConfig\\:\\:getPublicationStatus\\(\\) should return Surfnet\\\\ServiceProviderDashboard\\\\Application\\\\ViewObject\\\\Apis\\\\PublicationStatus but returns Surfnet\\\\ServiceProviderDashboard\\\\Application\\\\ViewObject\\\\Apis\\\\PublicationStatus\\|null\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Apis/ApiConfig.php',

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
@@ -50,6 +50,8 @@ class ArpGenerator implements MetadataGenerator
                     'source' => $attribute->getSource(),
                     'value' => $attribute->getValue() === '' ? '*' : $attribute->getValue(),
                     'motivation' => $attribute->getMotivation(),
+                    'release_as' => $attribute->getReleaseAs() ?? '',
+                    'use_as_name_id' => $attribute->getUseAsNameId() ?? false,
                 ];
             }
         }
@@ -85,6 +87,8 @@ class ArpGenerator implements MetadataGenerator
                     'source' => $attribute->getSource(),
                     'value' => $attribute->getValue(),
                     'motivation' => $attribute->getMotivation(),
+                    'release_as' => $attribute->getReleaseAs(),
+                    'use_as_name_id' => $attribute->getUseAsNameId(),
                 ];
             }
         }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityMergeService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityMergeService.php
@@ -158,11 +158,7 @@ class EntityMergeService
     {
         $attributeList = new AttributeList();
 
-        // Oidc TNG resource servers do not track attributes in manage
-        // Neither do the Oauth Client Credentials clients
-        if ($command instanceof SaveOidcngResourceServerEntityCommand
-            || $command instanceof SaveOauthClientCredentialClientCommand
-        ) {
+        if ($this->isNotTrackedInManage($command)) {
             return $attributeList;
         }
 
@@ -174,7 +170,9 @@ class EntityMergeService
                         $entityMergeAttribute->getUrn(),
                         '',
                         'idp',
-                        $commandAttribute->getMotivation()
+                        $commandAttribute->getMotivation(),
+                        '',
+                        false
                     )
                 );
             }
@@ -250,5 +248,19 @@ class EntityMergeService
             }
         }
         return $urls;
+    }
+
+    /**
+     * @param SaveEntityCommandInterface $command
+     * @return bool
+     */
+    private function isNotTrackedInManage(SaveEntityCommandInterface $command): bool
+    {
+        // Oidc TNG resource servers do not track attributes in manage
+        // Neither do the Oauth Client Credentials clients
+
+        return
+            $command instanceof SaveOidcngResourceServerEntityCommand ||
+            $command instanceof SaveOauthClientCredentialClientCommand;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/ValueObject/EntityMergeAttribute.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/ValueObject/EntityMergeAttribute.php
@@ -28,8 +28,8 @@ class EntityMergeAttribute
     }
 
     public static function fromAttribute(
-        $name,
-        $urn,
+        string $name,
+        string $urn,
     ): EntityMergeAttribute {
         return new self(
             $name,

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Attribute.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Attribute.php
@@ -29,17 +29,23 @@ class Attribute
         $value = $attributeData['value'];
         $source = $attributeData['source'] ?? '';
         $motivation = $attributeData['motivation'] ?? '';
+        $releaseAs = $attributeData['release_as'] ?? '';
+        $useAsNameId = $attributeData['use_as_name_id'] ?? '';
 
         Assert::stringNotEmpty($attributeName, 'The attribute name must be non-empty string');
         Assert::stringNotEmpty($value, 'The attribute value must be non-empty string');
         Assert::string($source, 'The attribute source must be string');
+        Assert::string($releaseAs, 'The attribute release_as must be string');
+        Assert::boolean($useAsNameId, 'The attribute use_as_name_id must be boolean');
         Assert::string($motivation, 'The attribute motivation must be string');
 
         return new self(
             $attributeName,
             $value,
             $source,
-            $motivation
+            $motivation,
+            $releaseAs,
+            $useAsNameId,
         );
     }
 
@@ -48,6 +54,8 @@ class Attribute
         private readonly string $value,
         private string $source,
         private ?string $motivation,
+        private ?string $releaseAs,
+        private ?bool $useAsNameId,
     ) {
     }
 
@@ -74,6 +82,16 @@ class Attribute
     public function getMotivation(): string
     {
         return $this->motivation;
+    }
+
+    public function getReleaseAs(): string
+    {
+        return $this->releaseAs;
+    }
+
+    public function getUseAsNameId(): bool
+    {
+        return $this->useAsNameId;
     }
 
     public function updateSource(string $newSource): static

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Attribute.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Attribute.php
@@ -30,7 +30,7 @@ class Attribute
         $source = $attributeData['source'] ?? '';
         $motivation = $attributeData['motivation'] ?? '';
         $releaseAs = $attributeData['release_as'] ?? '';
-        $useAsNameId = $attributeData['use_as_name_id'] ?? '';
+        $useAsNameId = $attributeData['use_as_name_id'] ?? false;
 
         Assert::stringNotEmpty($attributeName, 'The attribute name must be non-empty string');
         Assert::stringNotEmpty($value, 'The attribute value must be non-empty string');
@@ -54,8 +54,8 @@ class Attribute
         private readonly string $value,
         private string $source,
         private ?string $motivation,
-        private ?string $releaseAs,
-        private ?bool $useAsNameId,
+        private string $releaseAs,
+        private bool $useAsNameId,
     ) {
     }
 

--- a/tests/unit/Application/Metadata/JsonGenerator/ArpGeneratorTest.php
+++ b/tests/unit/Application/Metadata/JsonGenerator/ArpGeneratorTest.php
@@ -119,10 +119,10 @@ class ArpGeneratorTest extends MockeryTestCase
         $attributes = [];
         if ($registerAttributes) {
             $attributes = [
-                $this->buildManageAttribute($manageEntity, 'urn:mace:dir:attribute-def:cn', 'voot', '*'),
-                $this->buildManageAttribute($manageEntity, 'urn:mace:dir:attribute-def:displayName', 'idp', '*'),
-                $this->buildManageAttribute($manageEntity, 'urn:mace:dir:attribute-def:givenName', 'idp', '*'),
-                $this->buildManageAttribute($manageEntity, 'urn:mace:dir:attribute-def:eduPersonEntitlement', 'sab', '/^foobar(.*)$/i'),
+                $this->buildManageAttribute($manageEntity, 'urn:mace:dir:attribute-def:cn', 'voot', '*', '123', false),
+                $this->buildManageAttribute($manageEntity, 'urn:mace:dir:attribute-def:displayName', 'idp', '*', '123', false),
+                $this->buildManageAttribute($manageEntity, 'urn:mace:dir:attribute-def:givenName', 'idp', '*', '123', false),
+                $this->buildManageAttribute($manageEntity, 'urn:mace:dir:attribute-def:eduPersonEntitlement', 'sab', '/^foobar(.*)$/i', '123', false),
             ];
             $manageEntity
                 ->shouldReceive('getAttributes->findAllByUrn')
@@ -162,7 +162,14 @@ class ArpGeneratorTest extends MockeryTestCase
         return $manageEntity;
     }
 
-    private function buildManageAttribute(ManageEntity $manageEntity, string $attributeName, string $source, string $value)
+    private function buildManageAttribute(
+        ManageEntity $manageEntity,
+        string $attributeName,
+        string $source,
+        string $value,
+        string $releaseAs = "123",
+        bool  $useAsNameId =  true,
+    )
     {
         $attribute = m::mock(Attribute::class);
         $attribute->shouldReceive('getName')
@@ -171,6 +178,10 @@ class ArpGeneratorTest extends MockeryTestCase
             ->andReturn($source);
         $attribute->shouldReceive('getValue')
             ->andReturn($value);
+        $attribute->shouldReceive('getReleaseAs')
+            ->andReturn($releaseAs);
+        $attribute->shouldReceive('getUseAsNameId')
+            ->andReturn($useAsNameId);
         $attribute->shouldReceive('getMotivation')
             ->andReturn('The Manage motivation');
         $attribute->shouldReceive('hasMotivation')

--- a/tests/unit/Domain/Entity/Entity/AttributeListTest.php
+++ b/tests/unit/Domain/Entity/Entity/AttributeListTest.php
@@ -55,42 +55,65 @@ class AttributeListTest extends TestCase
         yield [
             $this->attributeList(
                 [
-                    $this->attr('urn0', '*', 'idp', 'motivation', 'release_as', true),
-                    $this->attr('urn1', '*', 'idp', 'motivation', 'release_as', true),
-                    $this->attr('urn2', '*', 'idp', 'motivation', 'release_as', true)
+                    $this->attr('urn0', '*', 'idp', 'motivation', 'release_as', false),
+                    $this->attr('urn1', '*', 'idp', 'motivation', 'release_as', false),
+                    $this->attr('urn2', '*', 'idp', 'motivation', 'release_as', false)
                 ]
             ),
             $this->attributeList(
                 [
-                    $this->attr('urn0', '*', 'idp', 'motivation', 'release_as', true),
-                    $this->attr('urn1', '*', 'idp', 'motivation', 'release_as', true),
+                    $this->attr('urn0', '*', 'idp', 'motivation', 'release_as', false),
+                    $this->attr('urn1', '*', 'idp', 'motivation', 'release_as', false),
                 ]
             ),
             $this->attributeList(
                 [
-                    $this->attr('urn0', '*', 'idp', 'motivation', 'release_as', true),
-                    $this->attr('urn1', '*', 'idp', 'motivation', 'release_as', true),
+                    $this->attr('urn0', '*', 'idp', 'motivation', 'release_as', false),
+                    $this->attr('urn1', '*', 'idp', 'motivation', 'release_as', false),
                 ]
             ),
         ];
         yield [
             $this->attributeList(
                 [
-                    $this->attr('urn0', '*', 'idp', 'motivation', 'release_as', true),
-                    $this->attr('urn1', '*', 'idp', 'motivation', 'release_as', true),
-                    $this->attr('urn2', '*', 'idp', 'motivation', 'release_as', true),
+                    $this->attr('urn0', '*', 'idp', 'motivation', 'release_as', false),
+                    $this->attr('urn1', '*', 'idp', 'motivation', 'release_as', false),
+                    $this->attr('urn2', '*', 'idp', 'motivation', 'release_as', false)
                 ]
             ),
             $this->attributeList(
                 [
-                    $this->attr('urn2', '*', 'idp', 'motivation', 'release_as', true),
-                    $this->attr('urn1', '*', 'idp', 'super motivation', 'release_as', true),
+                    $this->attr('urn0', '*', 'idp', 'motivation', 'nameid', false),
+                    $this->attr('urn1', '*', 'idp', 'motivation', '', true),
+                    $this->attr('urn2', '*', 'idp', 'motivation', 'release_as', false)
                 ]
             ),
             $this->attributeList(
                 [
-                    $this->attr('urn2', '*', 'idp', 'motivation', 'release_as', true),
-                    $this->attr('urn1', '*', 'idp', 'super motivation', 'release_as', true),
+                    $this->attr('urn0', '*', 'idp', 'motivation', 'nameid', false),
+                    $this->attr('urn1', '*', 'idp', 'motivation', '', true),
+                    $this->attr('urn2', '*', 'idp', 'motivation', 'release_as', false)
+                ]
+            ),
+        ];
+        yield [
+            $this->attributeList(
+                [
+                    $this->attr('urn0', '*', 'idp', 'motivation', 'release_as', false),
+                    $this->attr('urn1', '*', 'idp', 'motivation', 'release_as', false),
+                    $this->attr('urn2', '*', 'idp', 'motivation', 'release_as', false),
+                ]
+            ),
+            $this->attributeList(
+                [
+                    $this->attr('urn2', '*', 'idp', 'motivation', 'release_as', false),
+                    $this->attr('urn1', '*', 'idp', 'super motivation', 'release_as', false),
+                ]
+            ),
+            $this->attributeList(
+                [
+                    $this->attr('urn2', '*', 'idp', 'motivation', 'release_as', false),
+                    $this->attr('urn1', '*', 'idp', 'super motivation', 'release_as', false),
                 ]
             ),
         ];

--- a/tests/unit/Domain/Entity/Entity/AttributeListTest.php
+++ b/tests/unit/Domain/Entity/Entity/AttributeListTest.php
@@ -55,51 +55,51 @@ class AttributeListTest extends TestCase
         yield [
             $this->attributeList(
                 [
-                    $this->attr('urn0', '*', 'idp', 'motivation'),
-                    $this->attr('urn1', '*', 'idp', 'motivation'),
-                    $this->attr('urn2', '*', 'idp', 'motivation')
+                    $this->attr('urn0', '*', 'idp', 'motivation', 'release_as', true),
+                    $this->attr('urn1', '*', 'idp', 'motivation', 'release_as', true),
+                    $this->attr('urn2', '*', 'idp', 'motivation', 'release_as', true)
                 ]
             ),
             $this->attributeList(
                 [
-                    $this->attr('urn0', '*', 'idp', 'motivation'),
-                    $this->attr('urn1', '*', 'idp', 'motivation'),
+                    $this->attr('urn0', '*', 'idp', 'motivation', 'release_as', true),
+                    $this->attr('urn1', '*', 'idp', 'motivation', 'release_as', true),
                 ]
             ),
             $this->attributeList(
                 [
-                    $this->attr('urn0', '*', 'idp', 'motivation'),
-                    $this->attr('urn1', '*', 'idp', 'motivation'),
-                ]
-            ),
-        ];
-        yield [
-            $this->attributeList(
-                [
-                    $this->attr('urn0', '*', 'idp', 'motivation'),
-                    $this->attr('urn1', '*', 'idp', 'motivation'),
-                    $this->attr('urn2', '*', 'idp', 'motivation')
-                ]
-            ),
-            $this->attributeList(
-                [
-                    $this->attr('urn2', '*', 'idp', 'motivation'),
-                    $this->attr('urn1', '*', 'idp', 'super motivation'),
-                ]
-            ),
-            $this->attributeList(
-                [
-                    $this->attr('urn2', '*', 'idp', 'motivation'),
-                    $this->attr('urn1', '*', 'idp', 'super motivation'),
+                    $this->attr('urn0', '*', 'idp', 'motivation', 'release_as', true),
+                    $this->attr('urn1', '*', 'idp', 'motivation', 'release_as', true),
                 ]
             ),
         ];
         yield [
             $this->attributeList(
                 [
-                    $this->attr('urn0', '*', 'idp', 'motivation'),
-                    $this->attr('urn1', '*', 'idp', 'motivation'),
-                    $this->attr('urn2', '*', 'idp', 'motivation')
+                    $this->attr('urn0', '*', 'idp', 'motivation', 'release_as', true),
+                    $this->attr('urn1', '*', 'idp', 'motivation', 'release_as', true),
+                    $this->attr('urn2', '*', 'idp', 'motivation', 'release_as', true),
+                ]
+            ),
+            $this->attributeList(
+                [
+                    $this->attr('urn2', '*', 'idp', 'motivation', 'release_as', true),
+                    $this->attr('urn1', '*', 'idp', 'super motivation', 'release_as', true),
+                ]
+            ),
+            $this->attributeList(
+                [
+                    $this->attr('urn2', '*', 'idp', 'motivation', 'release_as', true),
+                    $this->attr('urn1', '*', 'idp', 'super motivation', 'release_as', true),
+                ]
+            ),
+        ];
+        yield [
+            $this->attributeList(
+                [
+                    $this->attr('urn0', '*', 'idp', 'motivation', 'release_as', true),
+                    $this->attr('urn1', '*', 'idp', 'motivation', 'release_as', true),
+                    $this->attr('urn2', '*', 'idp', 'motivation', 'release_as', true)
                 ]
             ),
             $this->attributeList([]),
@@ -107,7 +107,7 @@ class AttributeListTest extends TestCase
         ];
     }
 
-    private function attributeList(array $attributes = null)
+    private function attributeList(array $attributes = null): AttributeList
     {
         $attributeList = new AttributeList();
         if ($attributes) {
@@ -118,8 +118,15 @@ class AttributeListTest extends TestCase
         return $attributeList;
     }
 
-    private function attr(string $urn, string $value, string $source, string $motivation)
+    private function attr(string $urn, string $value, string $source, string $motivation, string $releaseAs, bool $useAsNameId): Attribute
     {
-        return new Attribute($urn, $value, $source, $motivation);
+        return new Attribute(
+            $urn,
+            $value,
+            $source,
+            $motivation,
+            $releaseAs,
+            $useAsNameId
+        );
     }
 }


### PR DESCRIPTION
A number of fields will be added in the arp. Besides source, value and motivation, use_as_name_id and "release_as" are added. If these already exist, they should be returned with the same values (analogous to "source" which we also leave untouched)

Before: 

```json
 "arp" : {
    "attributes" : {
      "urn:mace:dir:attribute-def:givenName" : [ {
        "source" : "idp",
        "value" : "*",
        "motivation" : "1243"
      } ],
      "urn:mace:dir:attribute-def:uid" : [ {
        "source" : "idp",
        "value" : "*",
        "motivation" : "test"
      } ]
}
```

After:
```json
 "arp" : {
    "attributes" : {
      "urn:mace:dir:attribute-def:givenName" : [ {
        "source" : "idp",
        "value" : "*",
        "motivation" : "1243",
        "release_as" : "123",
        "use_as_name_id" : true
      } ],
      "urn:mace:dir:attribute-def:uid" : [ {
        "source" : "idp",
        "value" : "*",
        "motivation" : "test"
        "release_as" : "123",
        "use_as_name_id" : true
      } ]
}
```