### PR TITLE
Add the 'deluxe' revision note when creating a new entity

### DIFF
--- a/ci/qa/phpstan-baseline.php
+++ b/ci/qa/phpstan-baseline.php
@@ -2882,11 +2882,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Ticket.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$manageId of class Surfnet\\\\ServiceProviderDashboard\\\\Domain\\\\ValueObject\\\\Ticket constructor expects string, string\\|null given\\.$#',
-	'count' => 2,
-	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Ticket.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#3 \\$entityName of class Surfnet\\\\ServiceProviderDashboard\\\\Domain\\\\ValueObject\\\\Ticket constructor expects string, string\\|null given\\.$#',
 	'count' => 2,
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Ticket.php',

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/PublishEntityTestCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/PublishEntityTestCommand.php
@@ -28,11 +28,17 @@ class PublishEntityTestCommand implements Command
     public function __construct(
         #[Assert\Type(ManageEntity::class)]
         private readonly ManageEntity $manageEntity,
+        private readonly Contact $applicant,
     ) {
     }
 
     public function getManageEntity(): ManageEntity
     {
         return $this->manageEntity;
+    }
+
+    public function getApplicant(): Contact
+    {
+        return $this->applicant;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/ResetOidcSecretCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/ResetOidcSecretCommand.php
@@ -19,6 +19,7 @@
 namespace Surfnet\ServiceProviderDashboard\Application\Command\Entity;
 
 use Surfnet\ServiceProviderDashboard\Application\Command\Command;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints as SpDashboardAssert;
 
@@ -26,11 +27,17 @@ class ResetOidcSecretCommand implements Command
 {
     public function __construct(
         private readonly ManageEntity $manageEntity,
+        private readonly Contact $applicant,
     ) {
     }
 
     public function getManageEntity(): ManageEntity
     {
         return $this->manageEntity;
+    }
+
+    public function getApplicant(): Contact
+    {
+        return $this->applicant;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/UpdateEntityAclCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/UpdateEntityAclCommand.php
@@ -19,6 +19,7 @@
 namespace Surfnet\ServiceProviderDashboard\Application\Command\Entity;
 
 use Surfnet\ServiceProviderDashboard\Application\Command\Command;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\IdentityProvider;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
@@ -37,6 +38,7 @@ class UpdateEntityAclCommand implements Command
         ])]
         private array $selected,
         private bool $selectAll,
+        private readonly Contact $applicant,
     ) {
     }
 
@@ -72,5 +74,10 @@ class UpdateEntityAclCommand implements Command
     public function setSelectAll($selectAll): void
     {
         $this->selectAll = (bool)$selectAll;
+    }
+
+    public function getApplicant(): Contact
+    {
+        return $this->applicant;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/UpdateEntityIdpsCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/UpdateEntityIdpsCommand.php
@@ -21,6 +21,7 @@ declare(strict_types = 1);
 namespace Surfnet\ServiceProviderDashboard\Application\Command\Entity;
 
 use Surfnet\ServiceProviderDashboard\Application\Command\Command;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\IdentityProvider;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -45,6 +46,7 @@ class UpdateEntityIdpsCommand implements Command
             new Assert\Type(type: IdentityProvider::class),
         ])]
         public array $institutionEntities,
+        public readonly Contact $applicant,
     ) {
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityTestCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityTestCommandHandler.php
@@ -24,6 +24,8 @@ use Surfnet\ServiceProviderDashboard\Application\CommandHandler\CommandHandler;
 use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
 use Surfnet\ServiceProviderDashboard\Application\Service\EntityServiceInterface;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\JiraTicketNumber;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\PublishEntityRepository;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\PublishMetadataException;
@@ -60,7 +62,11 @@ class PublishEntityTestCommandHandler implements CommandHandler
                 )
             );
 
-            $publishResponse = $this->publishClient->publish($entity, $pristineEntity);
+            $publishResponse = $this->publishClient->publish(
+                $entity,
+                $pristineEntity,
+                $command->getApplicant(),
+            );
             if (array_key_exists('id', $publishResponse)) {
                 if ($this->isNewResourceServer($entity)) {
                     $this->requestStack->getSession()->getFlashBag()->add('wysiwyg', 'entity.list.oidcng_connection.info.html');

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/ResetOidcSecretCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/ResetOidcSecretCommandHandler.php
@@ -68,7 +68,7 @@ class ResetOidcSecretCommandHandler implements CommandHandler
             $publishCommand->markPublishClientReset();
             $this->commandBus->handle($publishCommand);
         } elseif ($entity->getEnvironment() === Constants::ENVIRONMENT_TEST) {
-            $publishCommand = new PublishEntityTestCommand($entity);
+            $publishCommand = new PublishEntityTestCommand($entity, $command->getApplicant());
             $this->commandBus->handle($publishCommand);
         }
         if (!$entity->isExcludedFromPush()) {

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/UpdateEntityAclCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/UpdateEntityAclCommandHandler.php
@@ -54,7 +54,7 @@ class UpdateEntityAclCommandHandler implements CommandHandler
         $allowedIdps = new AllowedIdentityProviders($idps, $command->isSelectAll());
         $entity->getAllowedIdentityProviders()->merge($allowedIdps);
         try {
-            $this->publishClient->publish($entity, $entity, 'ACL');
+            $this->publishClient->publish($entity, $entity, $command->getApplicant(), 'ACL');
         } catch (PublishMetadataException $e) {
             $this->logger->error(
                 sprintf(

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/UpdateEntityIdpsCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/UpdateEntityIdpsCommandHandler.php
@@ -58,7 +58,7 @@ class UpdateEntityIdpsCommandHandler implements CommandHandler
         $allowedIdps = new AllowedIdentityProviders($idps, $allowedAll);
         $entity->getAllowedIdentityProviders()->merge($allowedIdps);
         try {
-            $this->publishClient->publish($entity, $entity, 'ACL');
+            $this->publishClient->publish($entity, $entity, $command->applicant, 'ACL');
         } catch (Exception $e) {
             $this->logger->error(
                 sprintf(

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/GeneratorInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/GeneratorInterface.php
@@ -28,7 +28,11 @@ interface GeneratorInterface
     /**
      * Convert a new, unpublished entity to json-serializable array.
      */
-    public function generateForNewEntity(ManageEntity $entity, string $workflowState): array;
+    public function generateForNewEntity(
+        ManageEntity $entity,
+        string $workflowState,
+        Contact $contact,
+    ): array;
 
     /**
      * Convert entity to an array for the manage merge-write API call.

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
@@ -25,6 +25,7 @@ use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact as ContactEntity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\ChangeRequestRevisionNote;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Contact;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\EntityCreationRevisionNote;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\JiraTicketNumber;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\EntityDiff;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
@@ -44,13 +45,22 @@ class JsonGenerator implements GeneratorInterface
     ) {
     }
 
-    public function generateForNewEntity(ManageEntity $entity, string $workflowState): array
-    {
+    public function generateForNewEntity(
+        ManageEntity $entity,
+        string $workflowState,
+        ContactEntity $contact,
+    ): array {
         // the type for entities is always saml because manage is using saml internally
-        return [
+        $payload = [
             'data' => $this->generateDataForNewEntity($entity, $workflowState),
             'type' => 'saml20_sp',
         ];
+        $payload['data']['revisionnote'] = (string) new EntityCreationRevisionNote(
+            $entity->getComments(),
+            $contact->getDisplayName(),
+            $contact->getEmailAddress(),
+        );
+        return $payload;
     }
 
     public function generateForExistingEntity(
@@ -75,20 +85,22 @@ class JsonGenerator implements GeneratorInterface
         ContactEntity $contact,
         JiraTicketNumber $jiraTicketNumber,
     ): array {
+        $revisionNote = (string) new ChangeRequestRevisionNote(
+            $entity->getComments(),
+            $contact->getDisplayName(),
+            $contact->getEmailAddress(),
+            $jiraTicketNumber,
+        );
         $payload = [
             'metaDataId' => $entity->getId(),
             'type' => 'saml20_sp',
             'pathUpdates' => $this->generateForChangeRequest($entity, $differences),
             'auditData' => [
                 'user' => $contact->getEmailAddress(),
+                'notes' => $revisionNote,
             ],
         ];
-        $payload['note'] = (string) new ChangeRequestRevisionNote(
-            $entity->getComments(),
-            $contact->getDisplayName(),
-            $contact->getEmailAddress(),
-            $jiraTicketNumber,
-        );
+        $payload['note'] = $revisionNote;
         return $payload;
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGeneratorStrategy.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGeneratorStrategy.php
@@ -50,9 +50,16 @@ class JsonGeneratorStrategy
     /**
      * @throws JsonGeneratorStrategyNotFoundException
      */
-    public function generateForNewEntity(ManageEntity $entity, string $workflowState): array
-    {
-        return $this->getStrategy($entity->getProtocol()->getProtocol())->generateForNewEntity($entity, $workflowState);
+    public function generateForNewEntity(
+        ManageEntity $entity,
+        string $workflowState,
+        Contact $contact,
+    ): array {
+        return $this->getStrategy($entity->getProtocol()->getProtocol())->generateForNewEntity(
+            $entity,
+            $workflowState,
+            $contact,
+        );
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
@@ -25,6 +25,7 @@ use Surfnet\ServiceProviderDashboard\Application\Parser\OidcngClientIdParser;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact as ContactEntity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\ChangeRequestRevisionNote;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Contact;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\EntityCreationRevisionNote;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\JiraTicketNumber;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\EntityDiff;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
@@ -49,13 +50,22 @@ class OidcngJsonGenerator implements GeneratorInterface
     ) {
     }
 
-    public function generateForNewEntity(ManageEntity $entity, string $workflowState): array
-    {
+    public function generateForNewEntity(
+        ManageEntity $entity,
+        string $workflowState,
+        ContactEntity $contact,
+    ) : array {
         // the type for entities is always saml because manage is using saml internally
-        return [
+        $payload = [
             'data' => $this->generateDataForNewEntity($entity, $workflowState),
             'type' => 'oidc10_rp',
         ];
+        $payload['data']['revisionnote'] = (string) new EntityCreationRevisionNote(
+            $entity->getComments(),
+            $contact->getDisplayName(),
+            $contact->getEmailAddress(),
+        );
+        return $payload;
     }
 
     public function generateForExistingEntity(
@@ -77,21 +87,23 @@ class OidcngJsonGenerator implements GeneratorInterface
         ContactEntity $contact,
         JiraTicketNumber $jiraTicketNumber,
     ): array {
+        $revisionNote = (string) new ChangeRequestRevisionNote(
+            $entity->getComments(),
+            $contact->getDisplayName(),
+            $contact->getEmailAddress(),
+            $jiraTicketNumber,
+        );
         $payload = [
             'metaDataId' => $entity->getId(),
             'type' => 'oidc10_rp',
             'pathUpdates' => $this->generateForChangeRequest($differences, $entity),
             'auditData' => [
                 'user' => $contact->getEmailAddress(),
+                'notes' => $revisionNote,
             ],
         ];
 
-        $payload['note'] = (string) new ChangeRequestRevisionNote(
-            $entity->getComments(),
-            $contact->getDisplayName(),
-            $contact->getEmailAddress(),
-            $jiraTicketNumber,
-        );
+        $payload['note'] = $revisionNote;
 
         return $payload;
     }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/EntityCreationRevisionNote.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/EntityCreationRevisionNote.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Domain\Entity\Entity;
+
+use DateTimeImmutable;
+use Stringable;
+use const PHP_EOL;
+
+class EntityCreationRevisionNote implements Stringable
+{
+    private const REVISION_NOTE_FORMAT =
+        'Entity Created by user %s with email address "%s"' . PHP_EOL .
+        'Via the SPdashboard on %s ' . PHP_EOL .
+        'Comment: "%s"';
+    public function __construct(
+        private ?string $comments,
+        private string $commonName,
+        private string $emailAddress,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        $dateTime = new DateTimeImmutable();
+        if ($this->comments === null) {
+            $this->comments = 'No comment provided';
+        }
+
+
+        return sprintf(
+            self::REVISION_NOTE_FORMAT,
+            $this->commonName,
+            $this->emailAddress,
+            $dateTime->format(DateTimeImmutable::ATOM),
+            $this->comments,
+        );
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Repository/PublishEntityRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Repository/PublishEntityRepository.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Domain\Repository;
 
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 
 interface PublishEntityRepository
@@ -26,7 +27,12 @@ interface PublishEntityRepository
      * Publishes the Entity to a Service registry (like Manage, ..) This action might also result in the
      * sending of a mail message to a service desk who in turn can publish the entity in the registry.
      */
-    public function publish(ManageEntity $entity, ?ManageEntity $pristineEntity, string $part = ''): mixed;
+    public function publish(
+        ManageEntity $entity,
+        ?ManageEntity $pristineEntity,
+        Contact $contact,
+        string $part = '',
+    ): mixed;
 
     /**
      * Push the metadata from Manage to Engineblock

--- a/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Ticket.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/Ticket.php
@@ -31,7 +31,7 @@ class Ticket
 
     public function __construct(
         private readonly string $entityId,
-        private readonly string $manageId,
+        private readonly ?string $manageId,
         private readonly string $entityName,
         private readonly string $summaryTranslationKey,
         private readonly string $descriptionTranslationKey,
@@ -95,7 +95,7 @@ class Ticket
         return $this->entityId;
     }
 
-    public function getManageId(): string
+    public function getManageId(): ?string
     {
         return $this->manageId;
     }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityAclController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityAclController.php
@@ -65,6 +65,7 @@ class EntityAclController extends AbstractController
             $entity,
             $selectedIdps,
             $selectedIdps,
+            $this->authorizationService->getContact()
         );
 
         $form = $this->createForm(IdpEntityType::class, $command);
@@ -97,7 +98,8 @@ class EntityAclController extends AbstractController
         $command = new UpdateEntityAclCommand(
             $entity,
             $selectedIdps,
-            $entity->getAllowedIdentityProviders()->isAllowAll()
+            $entity->getAllowedIdentityProviders()->isAllowAll(),
+            $this->authorizationService->getContact(),
         );
         $form = $this->createForm(AclEntityType::class, $command);
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityControllerTrait.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityControllerTrait.php
@@ -151,16 +151,15 @@ trait EntityControllerTrait
         ?ManageEntity $entity,
         bool $isEntityChangeRequest,
     ): PublishEntityTestCommand|EntityChangeRequestCommand|PublishEntityProductionCommand {
+        $applicant = $this->authorizationService->getContact();
         switch (true) {
             case $entity->getEnvironment() === Constants::ENVIRONMENT_TEST:
-                $publishEntityCommand = new PublishEntityTestCommand($entity);
+                $publishEntityCommand = new PublishEntityTestCommand($entity, $applicant);
                 break;
             case $isEntityChangeRequest:
-                $applicant = $this->authorizationService->getContact();
                 $publishEntityCommand = new EntityChangeRequestCommand($entity, $applicant);
                 break;
             case $entity->getEnvironment() === Constants::ENVIRONMENT_PRODUCTION:
-                $applicant = $this->authorizationService->getContact();
                 $publishEntityCommand = new PublishEntityProductionCommand($entity, $applicant);
                 break;
             default:

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityResetSecretController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityResetSecretController.php
@@ -57,8 +57,8 @@ class EntityResetSecretController extends AbstractController
         }
         // Verify the Entity Service Id is one of the logged in users services
         $this->authorizationService->assertServiceIdAllowed($entityServiceId);
-
-        $resetOidcSecretCommand = new ResetOidcSecretCommand($manageEntity);
+        $applicant = $this->authorizationService->getContact();
+        $resetOidcSecretCommand = new ResetOidcSecretCommand($manageEntity, $applicant);
         try {
             $this->commandBus->handle($resetOidcSecretCommand);
         } catch (Exception) {

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/DevelopmentIssueRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Repository/DevelopmentIssueRepository.php
@@ -105,7 +105,7 @@ class DevelopmentIssueRepository implements TicketServiceInterface
         if ($this->failIssueCreation) {
             throw new JiraException('Unable to write the Jira issue (failure was requested by calling shouldFailCreateIssue)');
         }
-        $issue = new Issue($ticket->getManageId(), $ticket->getIssueType(), Issue::STATUS_OPEN);
+        $issue = new Issue($ticket->getManageId() ?: "manage-id", $ticket->getIssueType(), Issue::STATUS_OPEN);
         $this->data[$ticket->getManageId()] = $issue;
         $this->storeData();
         return $issue;
@@ -117,7 +117,7 @@ class DevelopmentIssueRepository implements TicketServiceInterface
         if ($this->failIssueCreation) {
             throw new JiraException('Unable to write the Jira issue (failure was requested by calling shouldFailCreateIssue)');
         }
-        $issue = new Issue($ticket->getManageId(), $ticket->getIssueType(), Issue::STATUS_OPEN);
+        $issue = new Issue($ticket->getManageId() ?: "manage-id", $ticket->getIssueType(), Issue::STATUS_OPEN);
         $this->data[$ticket->getManageId()] = $issue;
         $this->storeData();
         return $issue;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php
@@ -21,6 +21,7 @@ namespace Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client;
 use Psr\Log\LoggerInterface;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGeneratorStrategy;
 use Surfnet\ServiceProviderDashboard\Application\ViewObject\Apis\ApiConfig;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\HttpException\HttpException;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\PublishMetadataException;
@@ -44,8 +45,12 @@ class PublishEntityClient implements PublishEntityRepositoryInterface
      *
      * @SuppressWarnings(PHPMD.ElseExpression)
      */
-    public function publish(ManageEntity $entity, ?ManageEntity $pristineEntity, string $updatedPart = ''): mixed
-    {
+    public function publish(
+        ManageEntity $entity,
+        ?ManageEntity $pristineEntity,
+        Contact $contact,
+        string $part = ''
+    ): mixed {
         try {
             if (!$entity->isManageEntity()) {
                 $this->logger->info(sprintf('Creating new entity \'%s\' in manage', $entity->getId()));
@@ -53,7 +58,8 @@ class PublishEntityClient implements PublishEntityRepositoryInterface
                     json_encode(
                         $this->generator->generateForNewEntity(
                             $entity,
-                            $this->manageConfig->getPublicationStatus()->getStatus()
+                            $this->manageConfig->getPublicationStatus()->getStatus(),
+                            $contact,
                         )
                     ),
                     '/manage/api/internal/metadata'
@@ -67,7 +73,7 @@ class PublishEntityClient implements PublishEntityRepositoryInterface
                         $entity,
                         $diff,
                         $this->manageConfig->getPublicationStatus()->getStatus(),
-                        $updatedPart
+                        $part
                     )
                 );
 

--- a/tests/integration/Application/CommandHandler/Entity/PublishEntityProductionCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/PublishEntityProductionCommandHandlerTest.php
@@ -108,14 +108,6 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
         $manageEntity->shouldReceive('isManageEntity')->andReturnTrue();
         $manageEntity->shouldReceive('getEnvironment')->andReturn('production');
 
-        $this->publishEntityClient
-            ->shouldReceive('publish')
-            ->once()
-            ->with($manageEntity, $manageEntity)
-            ->andReturn([
-                'id' => '123',
-            ]);
-
         $manageEntity
             ->shouldReceive('getMetaData->getEntityId')
             ->andReturn('https://app.example.com/');
@@ -147,6 +139,15 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
         $this->entityService->shouldReceive('getPristineManageEntityById')->andReturn($manageEntity);
 
         $applicant = new Contact('john:doe', 'john@example.com', 'John Doe');
+
+        $this->publishEntityClient
+            ->shouldReceive('publish')
+            ->once()
+            ->with($manageEntity, $manageEntity, $applicant)
+            ->andReturn([
+                'id' => '123',
+            ]);
+
         $command = new PublishEntityProductionCommand($manageEntity, $applicant);
         $this->commandHandler->handle($command);
     }
@@ -161,14 +162,6 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
         $manageEntity
             ->shouldReceive('getMetaData->getNameEn')
             ->andReturn('Test Entity Name');
-
-        $this->publishEntityClient
-            ->shouldReceive('publish')
-            ->once()
-            ->with($manageEntity, $manageEntity)
-            ->andReturn([
-                'id' => '123',
-            ]);
 
         $manageEntity
             ->shouldReceive('getMetaData->getEntityId')
@@ -204,6 +197,13 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
 
 
         $applicant = new Contact('john:doe', 'john@example.com', 'John Doe');
+        $this->publishEntityClient
+            ->shouldReceive('publish')
+            ->once()
+            ->with($manageEntity, $manageEntity, $applicant)
+            ->andReturn([
+                'id' => '123',
+            ]);
         $command = new PublishEntityProductionCommand($manageEntity, $applicant);
         $this->commandHandler->handle($command);
     }
@@ -269,15 +269,6 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
             ->andReturn('Test Entity Name');
         $manageEntity->shouldReceive('isManageEntity')->andReturnTrue();
         $manageEntity->shouldReceive('getEnvironment')->andReturn('production');
-
-        $this->publishEntityClient
-            ->shouldReceive('publish')
-            ->once()
-            ->with($manageEntity, $manageEntity)
-            ->andReturn([
-                'id' => '123',
-            ]);
-
         $manageEntity
             ->shouldReceive('getMetaData->getEntityId')
             ->andReturn('https://app.example.com/');
@@ -309,6 +300,13 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
         $this->entityService->shouldReceive('getPristineManageEntityById')->andReturn($manageEntity);
 
         $applicant = new Contact('john:doe', 'john@example.com', 'John Doe');
+        $this->publishEntityClient
+            ->shouldReceive('publish')
+            ->once()
+            ->with($manageEntity, $manageEntity, $applicant)
+            ->andReturn([
+                'id' => '123',
+            ]);
         $command = new PublishEntityProductionCommand($manageEntity, $applicant);
         $command->markPublishClientReset();
         $this->commandHandler->handle($command);

--- a/tests/integration/Application/CommandHandler/Entity/PublishEntityTestCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/PublishEntityTestCommandHandlerTest.php
@@ -19,6 +19,7 @@
 namespace Application\CommandHandler\Entity;
 
 use Surfnet\ServiceProviderDashboard\Application\Service\EntityServiceInterface;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\PublishEntityClient;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient;
 use Mockery as m;
@@ -79,13 +80,6 @@ class PublishEntityTestCommandHandlerTest extends MockeryTestCase
             ->shouldReceive('info')
             ->times(1);
 
-        $this->client
-            ->shouldReceive('publish')
-            ->once()
-            ->with($manageEntity, $manageEntity)
-            ->andReturn([
-                'id' => '123',
-            ]);
         $manageEntity
             ->shouldReceive('getAllowedIdentityProviders->getAllowedIdentityProviders')
             ->andReturn([]);
@@ -109,7 +103,14 @@ class PublishEntityTestCommandHandlerTest extends MockeryTestCase
         $this->entityService
             ->shouldReceive('getPristineManageEntityById')
             ->andReturn($manageEntity);
-        $command = new PublishEntityTestCommand($manageEntity);
+        $command = new PublishEntityTestCommand($manageEntity, m::mock(Contact::class));
+        $this->client
+            ->shouldReceive('publish')
+            ->once()
+            ->with($manageEntity, $manageEntity, $command->getApplicant())
+            ->andReturn([
+                'id' => '123',
+            ]);
         $this->commandHandler->handle($command);
     }
 
@@ -147,12 +148,6 @@ class PublishEntityTestCommandHandlerTest extends MockeryTestCase
             ->shouldReceive('error')
             ->times(1);
 
-        $this->client
-            ->shouldReceive('publish')
-            ->once()
-            ->with($manageEntity, $manageEntity)
-            ->andThrow(PublishMetadataException::class);
-
         $this->requestStack
             ->shouldReceive('getSession->getFlashBag->add')
             ->with('error', 'entity.edit.error.publish');
@@ -161,7 +156,14 @@ class PublishEntityTestCommandHandlerTest extends MockeryTestCase
             ->shouldReceive('getPristineManageEntityById')
             ->andReturn($manageEntity);
 
-        $command = new PublishEntityTestCommand($manageEntity);
+        $command = new PublishEntityTestCommand($manageEntity, m::mock(Contact::class));
+
+        $this->client
+            ->shouldReceive('publish')
+            ->once()
+            ->with($manageEntity, $manageEntity, $command->getApplicant())
+            ->andThrow(PublishMetadataException::class);
+
         $this->commandHandler->handle($command);
     }
 }

--- a/tests/integration/Application/CommandHandler/Entity/ResetOidcSecretCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/ResetOidcSecretCommandHandlerTest.php
@@ -149,6 +149,6 @@ class ResetOidcSecretCommandHandlerTest extends MockeryTestCase
             ->shouldReceive('isExcludedFromPush')
             ->andReturn($isExcludedFromPush);
 
-        return new ResetOidcSecretCommand($manageEntity);
+        return new ResetOidcSecretCommand($manageEntity, m::mock(Contact::class));
     }
 }

--- a/tests/unit/Application/Metadata/JsonGeneratorStrategyTest.php
+++ b/tests/unit/Application/Metadata/JsonGeneratorStrategyTest.php
@@ -25,6 +25,7 @@ use Surfnet\ServiceProviderDashboard\Application\Dto\MetadataConversionDto;
 use Surfnet\ServiceProviderDashboard\Application\Exception\JsonGeneratorStrategyNotFoundException;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\GeneratorInterface;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGeneratorStrategy;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\EntityDiff;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 
@@ -72,11 +73,11 @@ class JsonGeneratorStrategyTest extends MockeryTestCase
         $entity = m::mock(ManageEntity::class);
 
         $entity->shouldReceive('getProtocol->getProtocol')->andReturn('saml');
-        $result = $this->strategy->generateForNewEntity($entity, 'prodaccepted');
+        $result = $this->strategy->generateForNewEntity($entity, 'prodaccepted', m::mock(Contact::class));
         $this->assertIsArray($result);
 
         $entity->shouldReceive('getProtocol->getProtocol')->andReturn('oidcng');
-        $result = $this->strategy->generateForNewEntity($entity, 'prodaccepted');
+        $result = $this->strategy->generateForNewEntity($entity, 'prodaccepted', m::mock(Contact::class));
         $this->assertIsArray($result);
     }
 

--- a/tests/unit/Application/Metadata/JsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/JsonGeneratorTest.php
@@ -79,7 +79,10 @@ class JsonGeneratorTest extends MockeryTestCase
             $this->spDashboardMetadataGenerator
         );
 
-        $metadata = $generator->generateForNewEntity($this->createManageEntity(), 'testaccepted');
+        $contact = m::mock(Contact::class);
+        $contact->shouldReceive('getDisplayName')->andReturn('John Doe');
+        $contact->shouldReceive('getEmailAddress')->andReturn('jd@example.com');
+        $metadata = $generator->generateForNewEntity($this->createManageEntity(), 'testaccepted', $contact);
         $metadata = $metadata['data'];
 
         $this->assertEquals('saml20-sp', $metadata['type']);
@@ -92,7 +95,7 @@ class JsonGeneratorTest extends MockeryTestCase
         $this->assertEquals('http://metadata', $metadata['metadataurl']);
         $this->assertEquals('testaccepted', $metadata['state']);
         $this->assertEquals('saml20-sp', $metadata['type']);
-        $this->assertEquals('revisionnote', $metadata['revisionnote']);
+        $this->assertMatchesRegularExpression('/Entity Created by user John Doe with email address "jd@example.com"\nVia the SPdashboard on .* \nComment: "revisionnote"/', $metadata['revisionnote']);
         $this->assertEquals(['arp' => 'arp'], $metadata['arp']);
 
         $fields = $metadata['metaDataFields'];
@@ -155,8 +158,10 @@ class JsonGeneratorTest extends MockeryTestCase
             $this->privacyQuestionsMetadataGenerator,
             $this->spDashboardMetadataGenerator
         );
-
-        $data = $generator->generateForNewEntity($this->createManageEntity(), 'prodaccepted');
+        $contact = m::mock(Contact::class);
+        $contact->shouldReceive('getDisplayName')->andReturn('John Doe');
+        $contact->shouldReceive('getEmailAddress')->andReturn('jd@example.com');
+        $data = $generator->generateForNewEntity($this->createManageEntity(), 'prodaccepted', $contact);
 
         $expected = array (
             'data' =>
@@ -198,10 +203,15 @@ class JsonGeneratorTest extends MockeryTestCase
                             'coin:exclude_from_push' => '0'
                         ),
                     'metadataurl' => 'http://metadata',
-                    'revisionnote' => 'revisionnote',
                 ),
             'type' => 'saml20_sp',
         );
+
+        // Test the revisionNote separately
+        $expectedRevisionNote = '/Entity Created by user John Doe with email address "jd@example.com"\nVia the SPdashboard on .* \nComment: "revisionnote"/';
+        $actualrevisionNote = $data['data']['revisionnote'];
+        unset($data['data']['revisionnote']);
+        $this->assertMatchesRegularExpression($expectedRevisionNote, $actualrevisionNote);
 
         $this->addEmptyAscLocations(1, '', $expected['data']['metaDataFields']);
         $this->assertEquals($expected, $data);
@@ -416,7 +426,10 @@ class JsonGeneratorTest extends MockeryTestCase
             ->shouldReceive('isProduction')
             ->andReturn(false);
 
-        $data = $generator->generateForNewEntity($entity, 'prodaccepted');
+        $contact = m::mock(Contact::class);
+        $contact->shouldReceive('getDisplayName')->andReturn('John Doe');
+        $contact->shouldReceive('getEmailAddress')->andReturn('jd@example.com');
+        $data = $generator->generateForNewEntity($entity, 'prodaccepted', $contact);
 
         $expected = array (
             'data' =>
@@ -456,10 +469,16 @@ class JsonGeneratorTest extends MockeryTestCase
                             'coin:institution_guid' => '543b4e5b-76b5-453f-af1e-5648378bb266'
                         ),
                     'metadataurl' => 'http://metadata',
-                    'revisionnote' => 'revisionnote',
                 ),
             'type' => 'saml20_sp',
         );
+
+        // Test the revisionNote separately
+        $expectedRevisionNote = '/Entity Created by user John Doe with email address "jd@example.com"\nVia the SPdashboard on .* \nComment: "revisionnote"/';
+        $actualrevisionNote = $data['data']['revisionnote'];
+        unset($data['data']['revisionnote']);
+        $this->assertMatchesRegularExpression($expectedRevisionNote, $actualrevisionNote);
+
         $this->addEmptyAscLocations(1, '', $expected['data']['metaDataFields']);
         $this->assertEquals($expected, $data);
     }

--- a/tests/unit/Application/Metadata/OauthClientCredentialsClientJsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/OauthClientCredentialsClientJsonGeneratorTest.php
@@ -85,8 +85,11 @@ class OauthClientCredentialsClientJsonGeneratorTest extends MockeryTestCase
             $this->spDashboardMetadataGenerator
         );
         $entity = $this->createManageEntity();
-        $data = $generator->generateForNewEntity($entity, 'prodaccepted');
-        $this->assertSame('revisionnote', $data['data']['revisionnote']);
+        $contact = m::mock(Contact::class);
+        $contact->shouldReceive('getDisplayName')->andReturn('John Doe');
+        $contact->shouldReceive('getEmailAddress')->andReturn('jd@example.com');
+        $data = $generator->generateForNewEntity($entity, 'prodaccepted', $contact);
+        $this->assertMatchesRegularExpression('/Entity Created by user John Doe with email address "jd@example.com"\nVia the SPdashboard on .* \nComment: "revisionnote"/', $data['data']['revisionnote']);
     }
 
     private function createManageEntity()

--- a/tests/unit/Application/Metadata/OidcngResourceServerJsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/OidcngResourceServerJsonGeneratorTest.php
@@ -73,8 +73,16 @@ class OidcngResourceServerJsonGeneratorTest extends MockeryTestCase
             $this->privacyQuestionsMetadataGenerator,
             $this->spDashboardMetadataGenerator
         );
+        $contact = m::mock(Contact::class);
+        $contact->shouldReceive('getDisplayName')->andReturn('John Doe');
+        $contact->shouldReceive('getEmailAddress')->andReturn('jd@example.com');
+        $data = $generator->generateForNewEntity($this->createManageEntity(), 'testaccepted', $contact);
+        // Test the revisionNote separately
+        $expectedRevisionNote = '/Entity Created by user John Doe with email address "jd@example.com"\nVia the SPdashboard on .* \nComment: "revisionnote"/';
+        $actualrevisionNote = $data['data']['revisionnote'];
+        unset($data['data']['revisionnote']);
+        $this->assertMatchesRegularExpression($expectedRevisionNote, $actualrevisionNote);
 
-        $data = $generator->generateForNewEntity($this->createManageEntity(), 'testaccepted');
         $this->assertEquals(
             [
                 'data' => [
@@ -82,7 +90,6 @@ class OidcngResourceServerJsonGeneratorTest extends MockeryTestCase
                     'state' => 'testaccepted',
                     'entityid' => 'entityid',
                     'active' => true,
-                    'revisionnote' => 'revisionnote',
                     'metaDataFields' => [
                         'description:en' => 'description en',
                         'description:nl' => 'description nl',

--- a/tests/unit/Infrastructure/Manage/Client/PublishEntityClientTest.php
+++ b/tests/unit/Infrastructure/Manage/Client/PublishEntityClientTest.php
@@ -28,6 +28,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGeneratorStrategy;
 use Surfnet\ServiceProviderDashboard\Application\ViewObject\Apis\ApiConfig as Config;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\EntityDiff;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\PublishMetadataException;
@@ -114,7 +115,7 @@ class PublishEntityClientTest extends MockeryTestCase
             ->shouldReceive('generateForNewEntity')
             ->andReturn(json_decode($json, true));
 
-        $response = $this->client->publish($entity, $entity);
+        $response = $this->client->publish($entity, $entity, m::mock(Contact::class));
         $this->assertEquals('1', $response['id']);
     }
 
@@ -148,7 +149,7 @@ class PublishEntityClientTest extends MockeryTestCase
             ->shouldReceive('generateForExistingEntity')
             ->andReturn(json_decode($json, true));
 
-        $response = $this->client->publish($entity, $entity);
+        $response = $this->client->publish($entity, $entity, m::mock(Contact::class));
         $this->assertEquals('1', $response['id']);
     }
 
@@ -192,7 +193,7 @@ class PublishEntityClientTest extends MockeryTestCase
             ->shouldReceive('generateForNewEntity')
             ->andReturn(json_decode($json, true));
 
-        $this->client->publish($entity, $entity);
+        $this->client->publish($entity, $entity, m::mock(Contact::class));
     }
 
     public function test_it_can_push_to_engineblock()

--- a/tests/webtests/Manage/Client/FakePublishEntityClient.php
+++ b/tests/webtests/Manage/Client/FakePublishEntityClient.php
@@ -19,6 +19,7 @@
 namespace Surfnet\ServiceProviderDashboard\Webtests\Manage\Client;
 
 use RuntimeException;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\PublishEntityRepository as PublishEntityRepositoryInterface;
 
@@ -45,8 +46,12 @@ class FakePublishEntityClient implements PublishEntityRepositoryInterface
         $this->pushOk = false;
     }
 
-    public function publish(ManageEntity $entity, ?ManageEntity $pristineEntity, string $part = ''): mixed
-    {
+    public function publish(
+        ManageEntity $entity,
+        ?ManageEntity $pristineEntity,
+        Contact $contact,
+        string $part = ''
+    ): mixed {
         $entityId = $entity->getMetaData()->getEntityId();
         $publishResponses = $this->read();
         if (!array_key_exists($entityId, $publishResponses)) {

--- a/tests/webtests/Manage/Client/FakeQueryClient.php
+++ b/tests/webtests/Manage/Client/FakeQueryClient.php
@@ -23,6 +23,7 @@ use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\QueryManageRepository;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\InstitutionId;
 use function array_key_exists;
+use function json_encode;
 
 class FakeQueryClient implements QueryManageRepository
 {


### PR DESCRIPTION
This concludes most of the work. However I ran into an issue where the Jira ticket is now created before the data is persisted to manage (on new entity creation). But at that point the ticket expects a manageID to be present for the ticket system.

We ended up with not adding the Ticket id to the revision notes as can be read in the Pivotal comments.

https://www.pivotaltracker.com/story/show/186241167/comments/241835455