### PR TITLE
Rename use_as_nameid arp property

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator/ArpGenerator.php
@@ -51,7 +51,7 @@ class ArpGenerator implements MetadataGenerator
                     'value' => $attribute->getValue() === '' ? '*' : $attribute->getValue(),
                     'motivation' => $attribute->getMotivation(),
                     'release_as' => $attribute->getReleaseAs() ?? '',
-                    'use_as_name_id' => $attribute->getUseAsNameId() ?? false,
+                    'use_as_nameid' => $attribute->getUseAsNameId() ?? false,
                 ];
             }
         }
@@ -88,7 +88,7 @@ class ArpGenerator implements MetadataGenerator
                     'value' => $attribute->getValue(),
                     'motivation' => $attribute->getMotivation(),
                     'release_as' => $attribute->getReleaseAs(),
-                    'use_as_name_id' => $attribute->getUseAsNameId(),
+                    'use_as_nameid' => $attribute->getUseAsNameId(),
                 ];
             }
         }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Attribute.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Attribute.php
@@ -30,13 +30,13 @@ class Attribute
         $source = $attributeData['source'] ?? '';
         $motivation = $attributeData['motivation'] ?? '';
         $releaseAs = $attributeData['release_as'] ?? '';
-        $useAsNameId = $attributeData['use_as_name_id'] ?? false;
+        $useAsNameId = $attributeData['use_as_nameid'] ?? false;
 
         Assert::stringNotEmpty($attributeName, 'The attribute name must be non-empty string');
         Assert::stringNotEmpty($value, 'The attribute value must be non-empty string');
         Assert::string($source, 'The attribute source must be string');
         Assert::string($releaseAs, 'The attribute release_as must be string');
-        Assert::boolean($useAsNameId, 'The attribute use_as_name_id must be boolean');
+        Assert::boolean($useAsNameId, 'The attribute use_as_nameid must be boolean');
         Assert::string($motivation, 'The attribute motivation must be string');
 
         return new self(

--- a/tests/unit/Application/Metadata/JsonGenerator/ArpGeneratorTest.php
+++ b/tests/unit/Application/Metadata/JsonGenerator/ArpGeneratorTest.php
@@ -91,25 +91,25 @@ class ArpGeneratorTest extends MockeryTestCase
         $this->assertEquals('idp', $metadata['attributes']['urn:mace:dir:attribute-def:displayName'][0]['source']);
         $this->assertEquals('*', $metadata['attributes']['urn:mace:dir:attribute-def:displayName'][0]['value']);
         $this->assertEquals('456', $metadata['attributes']['urn:mace:dir:attribute-def:displayName'][0]['release_as']);
-        $this->assertTrue($metadata['attributes']['urn:mace:dir:attribute-def:displayName'][0]['use_as_name_id']);
+        $this->assertTrue($metadata['attributes']['urn:mace:dir:attribute-def:displayName'][0]['use_as_nameid']);
 
         $this->assertNotEmpty($metadata['attributes']['urn:mace:dir:attribute-def:cn']);
         $this->assertEquals('voot', $metadata['attributes']['urn:mace:dir:attribute-def:cn'][0]['source']);
         $this->assertEquals('*', $metadata['attributes']['urn:mace:dir:attribute-def:cn'][0]['value']);
         $this->assertEquals('123', $metadata['attributes']['urn:mace:dir:attribute-def:cn'][0]['release_as']);
-        $this->assertFalse($metadata['attributes']['urn:mace:dir:attribute-def:cn'][0]['use_as_name_id']);
+        $this->assertFalse($metadata['attributes']['urn:mace:dir:attribute-def:cn'][0]['use_as_nameid']);
 
         $this->assertNotEmpty($metadata['attributes']['urn:mace:dir:attribute-def:givenName']);
         $this->assertEquals('idp', $metadata['attributes']['urn:mace:dir:attribute-def:givenName'][0]['source']);
         $this->assertEquals('*', $metadata['attributes']['urn:mace:dir:attribute-def:givenName'][0]['value']);
         $this->assertEquals('789', $metadata['attributes']['urn:mace:dir:attribute-def:givenName'][0]['release_as']);
-        $this->assertFalse($metadata['attributes']['urn:mace:dir:attribute-def:givenName'][0]['use_as_name_id']);
+        $this->assertFalse($metadata['attributes']['urn:mace:dir:attribute-def:givenName'][0]['use_as_nameid']);
 
         $this->assertNotEmpty($metadata['attributes']['urn:mace:dir:attribute-def:eduPersonEntitlement']);
         $this->assertEquals('sab', $metadata['attributes']['urn:mace:dir:attribute-def:eduPersonEntitlement'][0]['source']);
         $this->assertEquals('/^foobar(.*)$/i', $metadata['attributes']['urn:mace:dir:attribute-def:eduPersonEntitlement'][0]['value']);
         $this->assertEquals('123', $metadata['attributes']['urn:mace:dir:attribute-def:eduPersonEntitlement'][0]['release_as']);
-        $this->assertFalse($metadata['attributes']['urn:mace:dir:attribute-def:eduPersonEntitlement'][0]['use_as_name_id']);
+        $this->assertFalse($metadata['attributes']['urn:mace:dir:attribute-def:eduPersonEntitlement'][0]['use_as_nameid']);
 
     }
 


### PR DESCRIPTION
Occurences of `use_as_name_id` changed to `use_as_nameid`