### PR TITLE
New field to set 'coin:ss:idp_visible_only' 

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveEntityCommandInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveEntityCommandInterface.php
@@ -72,4 +72,6 @@ interface SaveEntityCommandInterface extends Command
      * @return array<TypeOfService>
      */
     public function getTypeOfService(): array;
+
+    public function isPublicInDashboard(): ?bool;
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOauthClientCredentialClientCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOauthClientCredentialClientCommand.php
@@ -543,4 +543,10 @@ class SaveOauthClientCredentialClientCommand implements SaveEntityCommandInterfa
         // not implemented for oauth_ccc entities
         return [];
     }
+
+    public function isPublicInDashboard(): ?bool
+    {
+        // This coin is not used for CCC entities
+        return null;
+    }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
@@ -120,7 +120,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
     /**
      * When checked on the form, the idpVisibleOnly coin value becomes false
      */
-    public bool $isPublicOnDashboard;
+    public bool $isPublicInDashboard;
 
     /**
      * @var string
@@ -729,6 +729,11 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
 
     public function isPublicInDashboard(): ?bool
     {
-        return $this->idpVisibleOnly;
+        return $this->isPublicInDashboard;
+    }
+
+    public function setIsPublicInDashboard(bool $isPublic): void
+    {
+        $this->isPublicInDashboard = $isPublic;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
@@ -726,4 +726,9 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
     {
         $this->typeOfService = $typeOfService;
     }
+
+    public function isPublicInDashboard(): ?bool
+    {
+        return $this->idpVisibleOnly;
+    }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
@@ -118,6 +118,11 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
     private string $subjectType = Constants::NAME_ID_FORMAT_TRANSIENT;
 
     /**
+     * When checked on the form, the idpVisibleOnly coin value becomes false
+     */
+    public bool $isPublicOnDashboard;
+
+    /**
      * @var string
      */
     #[Assert\NotBlank]

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngResourceServerEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngResourceServerEntityCommand.php
@@ -449,4 +449,10 @@ class SaveOidcngResourceServerEntityCommand implements SaveEntityCommandInterfac
     {
         return [];
     }
+
+    public function isPublicInDashboard(): ?bool
+    {
+        // This coin is not used for RS entities
+        return null;
+    }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveSamlEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveSamlEntityCommand.php
@@ -153,6 +153,11 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
     #[Assert\Choice(callback: [Constants::class, 'getValidNameIdFormats'], strict: true)]
     private ?string $nameIdFormat = Constants::NAME_ID_FORMAT_TRANSIENT;
 
+    /**
+     * When checked on the form, the idpVisibleOnly value becomes false
+     */
+    public bool $isPublicOnDashboard;
+
     private ?string $manageId = null;
     private ?Attribute $organizationUnitAttribute = null;
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveSamlEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveSamlEntityCommand.php
@@ -156,7 +156,7 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
     /**
      * When checked on the form, the idpVisibleOnly value becomes false
      */
-    public bool $isPublicOnDashboard;
+    public bool $isPublicInDashboard;
 
     private ?string $manageId = null;
     private ?Attribute $organizationUnitAttribute = null;
@@ -490,6 +490,11 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
 
     public function isPublicInDashboard(): ?bool
     {
-        return $this->idpVisibleOnly;
+        return $this->isPublicInDashboard;
+    }
+
+    public function setIsPublicInDashboard(bool $isPublic): void
+    {
+        $this->isPublicInDashboard = $isPublic;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveSamlEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveSamlEntityCommand.php
@@ -487,4 +487,9 @@ class SaveSamlEntityCommand implements SaveEntityCommandInterface
     {
         $this->typeOfService = $typeOfServices;
     }
+
+    public function isPublicInDashboard(): ?bool
+    {
+        return $this->idpVisibleOnly;
+    }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Factory/EntityDetailFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Factory/EntityDetailFactory.php
@@ -104,6 +104,9 @@ class EntityDetailFactory
             $grants,
             $playgroundEnabled,
             $accessTokenValidity,
+            // Note when the metaDataFields.coin:ss:idp_visible_only is set to be true
+            // that translate to the dashboards isPublicInDashboard to be false
+            !$manageEntity->getMetaData()?->getCoin()->isIdpVisibleOnly(),
             $isPublicClient,
             $resourceServers,
             $manageEntity->getMetaData()?->getCoin()->getTypeOfService()->getServicesAsArray()

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
@@ -232,6 +232,9 @@ class JsonGenerator implements GeneratorInterface
         if ($entity->getMetaData()?->getCoin()->getContractualBase() !== null) {
             $metadata['coin:contractual_base'] = $entity->getMetaData()->getCoin()->getContractualBase();
         }
+        if ($entity->getMetaData()?->getCoin()->isIdpVisibleOnly() !== null) {
+            $metadata['coin:ss:idp_visible_only'] = $entity->getMetaData()->getCoin()->isIdpVisibleOnly();
+        }
         return $metadata;
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
@@ -201,6 +201,9 @@ class OidcngJsonGenerator implements GeneratorInterface
         if ($entity->getMetaData()?->getCoin()->getContractualBase() !== null) {
             $metadata['coin:contractual_base'] = $entity->getMetaData()->getCoin()->getContractualBase();
         }
+        if ($entity->getMetaData()?->getCoin()->isIdpVisibleOnly() !== null) {
+            $metadata['coin:ss:idp_visible_only'] = $entity->getMetaData()->getCoin()->isIdpVisibleOnly();
+        }
         return $metadata;
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityMergeService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityMergeService.php
@@ -222,7 +222,10 @@ class EntityMergeService
             $typeOfServiceCollection,
             $command->getEulaUrl(),
             null,
-            null
+            null,
+            // Note when the dashboard sets the isPublicInDashboard to be true
+            // That means the metaDataFields.coin:ss:idp_visible_only must be false
+            !$command->isPublicInDashboard(),
         );
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityDetail.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityDetail.php
@@ -64,6 +64,7 @@ class EntityDetail
         private readonly ?array $grants,
         private readonly ?bool $playgroundEnabled,
         private readonly ?int $accessTokenValidity,
+        private readonly ?bool $isPublicInDashboard,
         private readonly ?bool $isPublicClient,
         private readonly ?array $resourceServers,
         private readonly ?array $typeOfService,
@@ -263,5 +264,10 @@ class EntityDetail
     public function typeOfService(): ?array
     {
         return $this->typeOfService;
+    }
+
+    public function isPublicInDashboard(): ?bool
+    {
+        return $this->isPublicInDashboard;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Coin.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Coin.php
@@ -25,10 +25,11 @@ use Surfnet\ServiceProviderDashboard\Domain\Exception\TypeOfServiceException;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\TypeOfServiceCollection;
 use Webmozart\Assert\Assert;
 
+/**
+ * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+ */
 class Coin implements Comparable
 {
-
-
     public static function fromApiResponse(array $metaDataFields): self
     {
         $signatureMethod = $metaDataFields['coin:signature_method'] ?? '';

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Coin.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Coin.php
@@ -41,9 +41,9 @@ class Coin implements Comparable
             ? (int)$metaDataFields['coin:exclude_from_push'] : null;
         $oidcClient = isset($metaDataFields['coin:oidc_client'])
             ? (int)$metaDataFields['coin:oidc_client'] : 0;
+        $idpVisibleOnly = $metaDataFields['coin:ss:idp_visible_only'] ?? null;
 
         $typeOfService = TypeOfServiceCollection::createFromManageResponse($metaDataFields);
-
         Assert::string($signatureMethod);
         Assert::string($serviceTeamId);
         Assert::string($originalMetadataUrl);
@@ -52,6 +52,7 @@ class Coin implements Comparable
         Assert::nullOrIntegerish($excludeFromPush);
         Assert::integer($oidcClient);
         Assert::nullOrString($contractualBase);
+        Assert::nullOrBoolean($idpVisibleOnly);
 
         return new self(
             $signatureMethod,
@@ -63,6 +64,7 @@ class Coin implements Comparable
             $eula,
             $oidcClient,
             $contractualBase,
+            $idpVisibleOnly,
         );
     }
 
@@ -76,6 +78,7 @@ class Coin implements Comparable
         private ?string $eula,
         private ?int $oidcClient,
         private ?string $contractualBase,
+        private ?bool $idpVisibleOnly,
     ) {
     }
 
@@ -132,6 +135,12 @@ class Coin implements Comparable
         $this->contractualBase = $contractualBase;
     }
 
+
+    public function isIdpVisibleOnly(): ?bool
+    {
+        return $this->idpVisibleOnly;
+    }
+
     /**
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
@@ -149,6 +158,7 @@ class Coin implements Comparable
         $this->oidcClient = is_null($coin->getOidcClient()) ? null : $coin->getOidcClient();
         $this->typeOfService = $coin->getTypeOfService();
         $this->contractualBase = $coin->getContractualBase();
+        $this->idpVisibleOnly = $coin->isIdpVisibleOnly();
     }
 
     public function asArray(): array
@@ -162,6 +172,7 @@ class Coin implements Comparable
             'metaDataFields.coin:ss:type_of_service:en' => $this->getTypeOfService()->getServicesAsEnglishString(),
             'metaDataFields.coin:ss:type_of_service:nl' => $this->getTypeOfService()->getServicesAsDutchString(),
             'metaDataFields.coin:contractual_base' => $this->getContractualBase(),
+            'metaDataFields.coin:ss:idp_visible_only' => $this->isIdpVisibleOnly(),
         ];
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/EntityDiff.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/EntityDiff.php
@@ -58,7 +58,9 @@ class EntityDiff
                     if ($recursiveDiff !== []) {
                         $diffResults[$key] = $recursiveDiff;
                     }
-                } elseif ($value != $originalData[$key]) {
+                } elseif (($value === null && $originalData[$key] === "") || ($value === null && $originalData[$key] === 0)) {
+                    continue;
+                } elseif ($value !== $originalData[$key]) {
                     // When a secret is not changed (resulting in an empty value) do not include it in the diff.
                     if ($key === 'metaDataFields.secret' && $value === '') {
                         continue;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
@@ -186,7 +186,7 @@ class OidcngEntityType extends AbstractType
                 ]
             )
             ->add(
-                'isPublicOnDashboard',
+                'isPublicInDashboard',
                 CheckboxType::class,
                 [
                     'required' => false,

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
@@ -186,6 +186,17 @@ class OidcngEntityType extends AbstractType
                 ]
             )
             ->add(
+                'isPublicOnDashboard',
+                CheckboxType::class,
+                [
+                    'required' => false,
+                    'attr' => [
+                        'required' => false,
+                        'data-help' => 'entity.edit.information.isPublicOnDashboard',
+                    ],
+                ]
+            )
+            ->add(
                 'logoUrl',
                 TextType::class,
                 [

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
@@ -190,6 +190,7 @@ class OidcngEntityType extends AbstractType
                 CheckboxType::class,
                 [
                     'required' => false,
+                    'label' => 'entity.edit.label.isPublicOnDashboard',
                     'attr' => [
                         'required' => false,
                         'data-help' => 'entity.edit.information.isPublicOnDashboard',

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
@@ -23,6 +23,7 @@ use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\TypeOfServiceRepository;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\TypeOfService;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
@@ -163,6 +164,17 @@ class SamlEntityType extends AbstractType
                             'attr' => [
                                 'class' => 'nameidformat-attributesContainer',
                                 'data-help' => 'entity.edit.information.nameIdFormat',
+                            ],
+                        ]
+                    )
+                    ->add(
+                        'isPublicOnDashboard',
+                        CheckboxType::class,
+                        [
+                            'required' => false,
+                            'attr' => [
+                                'required' => false,
+                                'data-help' => 'entity.edit.information.isPublicOnDashboard',
                             ],
                         ]
                     )

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
@@ -171,6 +171,7 @@ class SamlEntityType extends AbstractType
                         'isPublicInDashboard',
                         CheckboxType::class,
                         [
+                            'label' => 'entity.edit.label.isPublicOnDashboard',
                             'required' => false,
                             'attr' => [
                                 'required' => false,

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
@@ -168,7 +168,7 @@ class SamlEntityType extends AbstractType
                         ]
                     )
                     ->add(
-                        'isPublicOnDashboard',
+                        'isPublicInDashboard',
                         CheckboxType::class,
                         [
                             'required' => false,

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -66,6 +66,7 @@ entity:
       description_en: Description EN
       application_url: Application URL
       eula_url: EULA URL
+      is_public_on_dashboard: Is your service publicly visible in the SURFconext dashboard?
       saml20:
         title: Metadata
         html: <strong>information about the metadata fields</strong>

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -266,6 +266,7 @@ entity.edit.information.accessTokenValidity: Text should be set in web translati
 entity.edit.information.resourceServers: Text should be set in web translations
 entity.edit.information.redirectUrls: Text should be set in web translations
 entity.edit.information.isPublicClient: Text should be set in web translations
+entity.edit.information.isPublicOnDashboard: Text should be set in web translations
 entity.edit.information.pastedMetadata: Text should be set in web translations
 entity.edit.information.logoUrl: Text should be set in web translations
 entity.edit.information.nameNl: Text should be set in web translations

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -267,7 +267,8 @@ entity.edit.information.accessTokenValidity: Text should be set in web translati
 entity.edit.information.resourceServers: Text should be set in web translations
 entity.edit.information.redirectUrls: Text should be set in web translations
 entity.edit.information.isPublicClient: Text should be set in web translations
-entity.edit.information.isPublicOnDashboard: Text should be set in web translations
+entity.edit.label.isPublicOnDashboard: Make your service publicly visible in the SURFconext dashboard
+entity.edit.information.isPublicOnDashboard: The SURFconext dashboard shows institutions a list of applications that are connected to SURFconext. If you tick the checkbox, your application will be visible to everyone, and instutions can request to connect. Leave the checkbox unticked if you have an application that is for one institution only and you do not want other institutions to be able to log in to your application as well.
 entity.edit.information.pastedMetadata: Text should be set in web translations
 entity.edit.information.logoUrl: Text should be set in web translations
 entity.edit.information.nameNl: Text should be set in web translations

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Factory/SaveCommandFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Factory/SaveCommandFactory.php
@@ -75,6 +75,9 @@ class SaveCommandFactory implements SaveCommandFactoryInterface
         $command->setEulaUrl($coins->getEula());
         $command->setImportUrl($coins->getOriginalMetadataUrl());
         $command->setTypeOfService($coins->getTypeOfService()->getArray());
+        // Note that the IdP Visible Only coin has the opposite meaning to our setting (is public in idp dashboard)
+        // hence the negation
+        $command->setIsPublicInDashboard(!$coins->isIdpVisibleOnly());
 
         // Attributes
         $this->setAttributes($command, $manageEntity->getAttributes());
@@ -112,6 +115,9 @@ class SaveCommandFactory implements SaveCommandFactoryInterface
         $command->setApplicationUrl($coins->getApplicationUrl());
         $command->setEulaUrl($coins->getEula());
         $command->setTypeOfService($coins->getTypeOfService()->getArray());
+        // Note that the IdP Visible Only coin has the opposite meaning to our setting (is public in idp dashboard)
+        // hence the negation
+        $command->setIsPublicInDashboard(!$coins->isIdpVisibleOnly());
 
         // Attributes
         $this->setAttributes($command, $manageEntity->getAttributes());

--- a/templates/EntityDetail/detail.html.twig
+++ b/templates/EntityDetail/detail.html.twig
@@ -23,6 +23,7 @@
         {% if entity.protocol == "saml20" %}
             {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.entity_id'|trans, value: entity.entityId, informationPopup: 'entity.edit.information.entityId'} %}
             {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.name_id_format'|trans, value: entity.nameIdFormat|replace({'urn:oasis:names:tc:SAML:2.0:nameid-format:': ''}), informationPopup: 'entity.edit.information.nameIdFormat'} %}
+            {% include '@Dashboard/EntityDetail/detailBooleanField.html.twig' with {label: 'entity.detail.metadata.is_public_on_dashboard'|trans, value: entity.isPublicInDashboard, informationPopup: 'entity.edit.information.isPublicOnDashboard'} %}
             {% include '@Dashboard/EntityDetail/detailListField.html.twig' with {label: 'entity.detail.metadata.type_of_service'|trans, value: entity.typeOfService, informationPopup: 'entity.edit.information.typeOfService'} %}
 
         {% endif %}
@@ -35,6 +36,7 @@
             {% include '@Dashboard/EntityDetail/detailBooleanField.html.twig' with {label: 'entity.detail.metadata.playground_enabled'|trans, value: entity.playgroundEnabled, informationPopup: 'entity.edit.information.enablePlayground'} %}
             {% include '@Dashboard/EntityDetail/detailBooleanField.html.twig' with {label: 'entity.detail.metadata.is_public_client'|trans, value: entity.publicClient, informationPopup: 'entity.edit.information.isPublicClient'} %}
             {% include '@Dashboard/EntityDetail/detailTextField.html.twig' with {label: 'entity.detail.metadata.access_token_validity'|trans, value: entity.accessTokenValidity, informationPopup: 'entity.edit.information.accessTokenValidity'} %}
+            {% include '@Dashboard/EntityDetail/detailBooleanField.html.twig' with {label: 'entity.detail.metadata.is_public_on_dashboard'|trans, value: entity.isPublicInDashboard, informationPopup: 'entity.edit.information.isPublicOnDashboard'} %}
             {% include '@Dashboard/EntityDetail/detailListField.html.twig' with {label: 'entity.detail.metadata.type_of_service'|trans, value: entity.typeOfService, informationPopup: 'entity.edit.information.typeOfService'} %}
 
         {% endif %}

--- a/templates/EntityDetail/detailBooleanField.html.twig
+++ b/templates/EntityDetail/detailBooleanField.html.twig
@@ -1,4 +1,4 @@
-{% if value is not empty %}
+{% if value == true or value == false %}
 <div class="detail">
     {% if informationPopup is defined %}
         <span data-tippy-content="{{ informationPopup|trans }}" class="help-button">

--- a/tests/unit/Application/Metadata/JsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/JsonGeneratorTest.php
@@ -119,6 +119,7 @@ class JsonGeneratorTest extends MockeryTestCase
         $this->assertEquals('surname', $fields['contacts:0:surName']);
         $this->assertEquals('emailaddress', $fields['contacts:0:emailAddress']);
         $this->assertEquals('telephonenumber', $fields['contacts:0:telephoneNumber']);
+        $this->assertEquals(false, $fields['coin:ss:idp_visible_only']);
     }
 
     public function test_it_can_build_saml_metadata_for_existing_entities()
@@ -201,7 +202,8 @@ class JsonGeneratorTest extends MockeryTestCase
                             'coin:signature_method' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
                             'coin:institution_id' => 'service-institution-id',
                             'coin:institution_guid' => '543b4e5b-76b5-453f-af1e-5648378bb266',
-                            'coin:exclude_from_push' => '0'
+                            'coin:exclude_from_push' => '0',
+                            'coin:ss:idp_visible_only' => false
                         ),
                     'metadataurl' => 'http://metadata',
                 ),
@@ -247,6 +249,7 @@ class JsonGeneratorTest extends MockeryTestCase
                     'state' => 'testaccepted',
                     'metaDataFields.contacts:2:givenName' => 'John Doe',
                     'metaDataFields.coin:exclude_from_push' => '0',
+                    'metaDataFields.coin:ss:idp_visible_only' => null,
                     'privacy' => 'privacy',
                 ),
             'type' => 'saml20_sp',
@@ -543,7 +546,7 @@ class JsonGeneratorTest extends MockeryTestCase
         $this->assertEquals('manageId', $data['metaDataId']);
         $this->assertEquals('saml20_sp', $data['type']);
         $this->assertIsArray($data['pathUpdates']);
-        $this->assertCount(4, $data['pathUpdates']);
+        $this->assertCount(5, $data['pathUpdates']);
         $this->assertStringContainsString('Change request by user A.F.Th. van der Heijden with email address "j.doe@example.com"', $data['note']);
         $this->assertStringContainsString('CHR-5421', $data['note']);
         $this->assertStringContainsString('revisionnote', $data['note']);

--- a/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
@@ -30,8 +30,6 @@ use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\JiraTicketNumber;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
-use function file_get_contents;
-use function json_decode;
 
 class OidcngJsonGeneratorTest extends MockeryTestCase
 {

--- a/tests/unit/Application/Metadata/fixture/oidc10_rp_response.json
+++ b/tests/unit/Application/Metadata/fixture/oidc10_rp_response.json
@@ -61,7 +61,8 @@
       "OrganizationName:nl": "orgnl",
       "OrganizationDisplayName:nl": "orgdisnl",
       "OrganizationURL:nl": "http://orgnl",
-      "isPublicClient": true
+      "isPublicClient": true,
+      "coin:ss:idp_visible_only": true
     },
     "allowedEntities": [],
     "allowedResourceServers": [],

--- a/tests/unit/Application/Metadata/fixture/oidc10_rp_response_changed.json
+++ b/tests/unit/Application/Metadata/fixture/oidc10_rp_response_changed.json
@@ -61,7 +61,8 @@
       "OrganizationName:nl": "Drop Supplies",
       "OrganizationDisplayName:nl": "orgdisnl",
       "OrganizationURL:nl": "http://orgnl",
-      "isPublicClient": true
+      "isPublicClient": true,
+      "coin:ss:idp_visible_only": true
     },
     "allowedEntities": [],
     "allowedResourceServers": [],

--- a/tests/unit/Application/Metadata/fixture/saml20_sp_response.json
+++ b/tests/unit/Application/Metadata/fixture/saml20_sp_response.json
@@ -58,7 +58,8 @@
       "OrganizationDisplayName:nl": "orgdisnl",
       "OrganizationURL:nl": "http://orgnl",
       "coin:service_team_id": "service-institution-id",
-      "coin:original_metadata_url": "https:\/\/engine.surfconext.nl\/authentication\/sp\/metadata"
+      "coin:original_metadata_url": "https:\/\/engine.surfconext.nl\/authentication\/sp\/metadata",
+      "coin:ss:idp_visible_only": false
     },
     "eid": 31
   }

--- a/tests/unit/Application/Service/EntityMergeServiceTest.php
+++ b/tests/unit/Application/Service/EntityMergeServiceTest.php
@@ -107,6 +107,7 @@ class EntityMergeServiceTest extends TestCase
         $contact->setEmail('j.doe@example.com');
         $command->setTechnicalContact($contact);
         $command->setService($service);
+        $command->setIsPublicInDashboard(true);
         return $command;
     }
 }

--- a/tests/unit/Domain/Entity/Entity/CoinTest.php
+++ b/tests/unit/Domain/Entity/Entity/CoinTest.php
@@ -70,19 +70,19 @@ class CoinTest extends TestCase
     public function provideCoinTestData()
     {
         yield [
-            new Coin('signatureMethod', '23', 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1, null),
-            new Coin('signatureMethod', '23', 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1, null),
-            new Coin('signatureMethod', '23', 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1, null)
+            new Coin('signatureMethod', '23', 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1, null, true),
+            new Coin('signatureMethod', '23', 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1, null, true),
+            new Coin('signatureMethod', '23', 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1, null, true)
         ];
         yield [
-            new Coin('signatureMethod', '23', 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1, null),
-            new Coin('signatureMethod', null, 'https://www.example.com', null, 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1, null),
-            new Coin('signatureMethod', null, 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1, null),
+            new Coin('signatureMethod', '23', 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1, null, true),
+            new Coin('signatureMethod', null, 'https://www.example.com', null, 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1, null, null),
+            new Coin('signatureMethod', null, 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1, null, null),
         ];
         yield [
-            new Coin('signatureMethod', '23', 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1, null),
-            new Coin(null, null, null, null, null, new TypeOfServiceCollection(), null, null, null),
-            new Coin(null, null, null, '1', null, new TypeOfServiceCollection(), null, null, null)
+            new Coin('signatureMethod', '23', 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1, null, false),
+            new Coin(null, null, null, null, null, new TypeOfServiceCollection(), null, null, null, false),
+            new Coin(null, null, null, '1', null, new TypeOfServiceCollection(), null, null, null, false)
         ];
     }
     public function provideCoinTestDataWithTypeOfService()

--- a/tests/unit/Domain/Entity/Entity/MetaDataTest.php
+++ b/tests/unit/Domain/Entity/Entity/MetaDataTest.php
@@ -241,7 +241,7 @@ class MetaDataTest extends TestCase
         $contactList = m::mock(ContactList::class);
         $contactList->shouldReceive('merge');
 
-        $coin = m::mock(Coin::class, [null, null, null, null, null, null, null, null, null]);
+        $coin = m::mock(Coin::class, [null, null, null, null, null, null, null, null, null, null]);
         $coin->shouldReceive('merge');
 
         $logo = m::mock(Logo::class);

--- a/tests/unit/Domain/Service/ContractualBaseServiceTest.php
+++ b/tests/unit/Domain/Service/ContractualBaseServiceTest.php
@@ -107,7 +107,7 @@ class ContractualBaseServiceTest extends TestCase
     {
         $metadata = $this->createMock(MetaData::class);
         // Use an acutal Coin instance, as the value for the contractual base is overwritten in the service
-        $coin = new Coin(null, null, null, null, null, null, null, null, null);
+        $coin = new Coin(null, null, null, null, null, null, null, null, null, null);
         $service = $this->createMock(Service::class);
         $protocol = $this->createMock(Protocol::class);
         $protocol->method('getProtocol')->willReturn($protocolValue);

--- a/tests/webtests/EntityDetailTest.php
+++ b/tests/webtests/EntityDetailTest.php
@@ -72,16 +72,17 @@ class EntityDetailTest extends WebTestCase
 
         $this->switchToService('SURFnet');
 
-        $crawler = self::$pantherClient->request('GET', '/entity/detail/1/9729d851-cfdd-4283-a8f1-a29ba5036261/production');
+        self::$pantherClient->request('GET', '/entity/detail/1/9729d851-cfdd-4283-a8f1-a29ba5036261/production');
 
         self::assertOnPage("Entity details");
 
         $this->assertDetailEquals(0, 'Metadata URL', 'https://sp1-entityid.example.com/metadata');
         $this->assertDetailsAscLocationEquals(1, 'ACS location', 'https://sp1-entityid.example.com/acs');
         $this->assertDetailEquals(2, 'Entity ID', 'https://sp1-entityid.example.com');
-        $this->assertDetailEquals(8, 'Name EN', 'SP3 Name English');
-        $this->assertDetailEquals(10, 'First name', 'givenname');
-        $this->assertDetailEquals(11, 'Last name', 'surname', false);
+        $this->assertChecked(4, 'Is your service publicly visible in the SURFconext dashboard?');
+        $this->assertDetailEquals(9, 'Name EN', 'SP3 Name English');
+        $this->assertDetailEquals(11, 'First name', 'givenname');
+        $this->assertDetailEquals(12, 'Last name', 'surname', false);
     }
 
 
@@ -201,6 +202,26 @@ class EntityDetailTest extends WebTestCase
             $expectedValue,
             $valueSpan,
             sprintf('Expected span "%s" at the row on position %d', $expectedValue, $position)
+        );
+    }
+
+    private function assertChecked($position, $expectedLabel)
+    {
+        $rows = self::$pantherClient->getCrawler()->filter('div.detail');
+        $row = $rows->eq($position);
+        $label = $row->filter('label')->text();
+        $icon = $row->filter('i')->last();
+        $classes = $icon->attr('class');
+
+        $this->assertEquals(
+            $expectedLabel,
+            $label,
+            sprintf('Expected label "%s" at the row on position %d', $expectedLabel, $position)
+        );
+        $this->assertEquals(
+            'fa fa-check-square',
+            $classes,
+            sprintf('Expected to find a checkbox for this option as pos %s', $position)
         );
     }
 


### PR DESCRIPTION
The SAML and OIDC entities now allow for setting the coin:ss:idp_visible_only metadata setting. See the story for the fine details.

See: https://www.pivotaltracker.com/story/show/187515050