### PR TITLE
Write contractual base to production entities

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityProductionCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityProductionCommandHandler.php
@@ -27,13 +27,15 @@ use Surfnet\ServiceProviderDashboard\Application\Service\EntityServiceInterface;
 use Surfnet\ServiceProviderDashboard\Application\Service\MailService;
 use Surfnet\ServiceProviderDashboard\Application\Service\TicketService;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\JiraTicketNumber;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\PublishEntityRepository;
+use Surfnet\ServiceProviderDashboard\Domain\Service\ContractualBaseService;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\PublishMetadataException;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class PublishEntityProductionCommandHandler implements CommandHandler
 {
     private readonly string $summaryTranslationKey;
@@ -42,6 +44,7 @@ class PublishEntityProductionCommandHandler implements CommandHandler
 
     public function __construct(
         private readonly PublishEntityRepository $publishClient,
+        private readonly ContractualBaseService $contractualBaseHelper,
         private readonly EntityServiceInterface $entityService,
         private readonly TicketService $ticketService,
         private readonly RequestStack $requestStack,
@@ -81,6 +84,7 @@ class PublishEntityProductionCommandHandler implements CommandHandler
                     $entity->getMetaData()->getNameEn()
                 )
             );
+            $this->contractualBaseHelper->writeContractualBase($entity);
             $publishResponse = $this->publishClient->publish(
                 $entity,
                 $pristineEntity,

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityMergeService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityMergeService.php
@@ -222,6 +222,7 @@ class EntityMergeService
             $command->getApplicationUrl(),
             $typeOfServiceCollection,
             $command->getEulaUrl(),
+            null,
             null
         );
     }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Constants.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Constants.php
@@ -41,6 +41,11 @@ class Constants
     final public const STATE_PUBLICATION_REQUESTED = 'requested';
     final public const STATE_REMOVAL_REQUESTED = 'removal requested';
 
+    final public const SERVICE_TYPE_INSTITUTE = 'institute';
+    final public const SERVICE_TYPE_NON_INSTITUTE = 'non-institute';
+    final public const CONTRACTUAL_BASE_IX = 'IX';
+    final public const CONTRACTUAL_BASE_AO = 'AO';
+
     final public const TYPE_SAML = 'saml20';
     final public const TYPE_OPENID_CONNECT_TNG = 'oidcng';
     final public const TYPE_OPENID_CONNECT_TNG_RESOURCE_SERVER = 'oauth20_rs';

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Coin.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/Coin.php
@@ -27,12 +27,15 @@ use Webmozart\Assert\Assert;
 
 class Coin implements Comparable
 {
+
+
     public static function fromApiResponse(array $metaDataFields): self
     {
         $signatureMethod = $metaDataFields['coin:signature_method'] ?? '';
         $serviceTeamId = $metaDataFields['coin:service_team_id'] ?? '';
         $originalMetadataUrl = $metaDataFields['coin:original_metadata_url'] ?? '';
         $applicationUrl = $metaDataFields['coin:application_url'] ?? '';
+        $contractualBase = $metaDataFields['coin:contractual_base'] ?? null;
         $eula = $metaDataFields['coin:eula'] ?? '';
         $excludeFromPush = isset($metaDataFields['coin:exclude_from_push'])
             ? (int)$metaDataFields['coin:exclude_from_push'] : null;
@@ -48,6 +51,7 @@ class Coin implements Comparable
         Assert::string($eula);
         Assert::nullOrIntegerish($excludeFromPush);
         Assert::integer($oidcClient);
+        Assert::nullOrString($contractualBase);
 
         return new self(
             $signatureMethod,
@@ -57,7 +61,8 @@ class Coin implements Comparable
             $applicationUrl,
             $typeOfService,
             $eula,
-            $oidcClient
+            $oidcClient,
+            $contractualBase,
         );
     }
 
@@ -70,6 +75,7 @@ class Coin implements Comparable
         private ?TypeOfServiceCollection $typeOfService,
         private ?string $eula,
         private ?int $oidcClient,
+        private ?string $contractualBase,
     ) {
     }
 
@@ -115,6 +121,17 @@ class Coin implements Comparable
         }
         return $this->typeOfService;
     }
+
+    public function getContractualBase(): ?string
+    {
+        return $this->contractualBase;
+    }
+
+    public function setContractualBase(string $contractualBase): void
+    {
+        $this->contractualBase = $contractualBase;
+    }
+
     /**
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
@@ -131,6 +148,7 @@ class Coin implements Comparable
         $this->eula = is_null($coin->getEula()) ? null : $coin->getEula();
         $this->oidcClient = is_null($coin->getOidcClient()) ? null : $coin->getOidcClient();
         $this->typeOfService = $coin->getTypeOfService();
+        $this->contractualBase = $coin->getContractualBase();
     }
 
     public function asArray(): array
@@ -143,6 +161,7 @@ class Coin implements Comparable
             'metaDataFields.coin:original_metadata_url' => $this->getOriginalMetadataUrl(),
             'metaDataFields.coin:ss:type_of_service:en' => $this->getTypeOfService()->getServicesAsEnglishString(),
             'metaDataFields.coin:ss:type_of_service:nl' => $this->getTypeOfService()->getServicesAsDutchString(),
+            'metaDataFields.coin:contractual_base' => $this->getContractualBase(),
         ];
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Service/ContractualBaseService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Service/ContractualBaseService.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Domain\Service;
+
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
+
+class ContractualBaseService
+{
+    public function writeContractualBase(ManageEntity $entity): void
+    {
+        // 1. The entity must be targeted at the production env
+        if ($entity->getEnvironment() !== Constants::ENVIRONMENT_PRODUCTION) {
+            return;
+        }
+
+        // 2. It must be a SAML or OIDC entity
+        $protocol = $entity->getProtocol()->getProtocol();
+        if (!in_array($protocol, [Constants::TYPE_SAML, Constants::TYPE_OPENID_CONNECT_TNG], true)) {
+            return;
+        }
+
+        // 3. Determine the contractual base, based on the service type
+        $serviceType = $entity->getService()->getServiceType();
+        $contractualBase = match ($serviceType) {
+            Constants::SERVICE_TYPE_INSTITUTE => Constants::CONTRACTUAL_BASE_IX,
+            Constants::SERVICE_TYPE_NON_INSTITUTE => Constants::CONTRACTUAL_BASE_AO,
+            default => null,
+        };
+
+        if ($contractualBase === null) {
+            return;
+        }
+
+        // 4. Set the coin value on the entity
+        $entity->getMetaData()?->getCoin()->setContractualBase($contractualBase);
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -116,6 +116,7 @@ services:
     class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\PublishEntityProductionCommandHandler
     arguments:
       - '@surfnet.manage.client.publish_client.prod_environment'
+      - '@Surfnet\ServiceProviderDashboard\Domain\Service\ContractualBaseService'
       - '@Surfnet\ServiceProviderDashboard\Application\Service\EntityService'
       - '@Surfnet\ServiceProviderDashboard\Application\Service\TicketService'
       - '@request_stack'
@@ -643,6 +644,8 @@ services:
 
   Surfnet\ServiceProviderDashboard\Domain\Repository\ServiceRepository:
     '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\ServiceRepository'
+
+  Surfnet\ServiceProviderDashboard\Domain\Service\ContractualBaseService:
 
   Surfnet\ServiceProviderDashboard\Application\Service\AttributeServiceInterface:
     '@Surfnet\ServiceProviderDashboard\Application\Service\AttributeService'

--- a/tests/integration/Application/CommandHandler/Entity/PublishEntityProductionCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/PublishEntityProductionCommandHandlerTest.php
@@ -32,8 +32,11 @@ use Surfnet\ServiceProviderDashboard\Application\Service\MailService;
 use Surfnet\ServiceProviderDashboard\Application\Service\TicketService;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Coin;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Protocol;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\PublishEntityRepository;
+use Surfnet\ServiceProviderDashboard\Domain\Service\ContractualBaseService;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Identity;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
@@ -88,6 +91,7 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
 
         $this->commandHandler = new PublishEntityProductionCommandHandler(
             $this->publishEntityClient,
+            new ContractualBaseService(),
             $this->entityService,
             $this->ticketService,
             $this->requestStack,
@@ -107,6 +111,17 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
             ->andReturn('Test Entity Name');
         $manageEntity->shouldReceive('isManageEntity')->andReturnTrue();
         $manageEntity->shouldReceive('getEnvironment')->andReturn('production');
+        $manageEntity->shouldReceive('getService->getServiceType')->andReturn(Constants::SERVICE_TYPE_INSTITUTE);
+
+        $coin = m::mock(Coin::class);
+        $coin->shouldReceive('setContractualBase')->with(Constants::CONTRACTUAL_BASE_IX);
+        $manageEntity->shouldReceive('getMetaData->getCoin')->andReturn($coin);
+
+        $protocol = m::mock(Protocol::class);
+        $protocol->shouldReceive('getProtocol')->andReturn(Constants::TYPE_SAML);
+
+        $manageEntity
+            ->shouldReceive('getProtocol')->andReturn($protocol);
 
         $manageEntity
             ->shouldReceive('getMetaData->getEntityId')
@@ -172,7 +187,17 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
             ->andReturn('123');
         $manageEntity->shouldReceive('isManageEntity')->andReturnTrue();
         $manageEntity->shouldReceive('getEnvironment')->andReturn('production');
+        $manageEntity->shouldReceive('getService->getServiceType')->andReturn(Constants::SERVICE_TYPE_INSTITUTE);
 
+        $coin = m::mock(Coin::class);
+        $coin->shouldReceive('setContractualBase')->with(Constants::CONTRACTUAL_BASE_IX);
+        $manageEntity->shouldReceive('getMetaData->getCoin')->andReturn($coin);
+
+        $protocol = m::mock(Protocol::class);
+        $protocol->shouldReceive('getProtocol')->andReturn(Constants::TYPE_SAML);
+
+        $manageEntity
+            ->shouldReceive('getProtocol')->andReturn($protocol);
         $manageEntity
             ->shouldReceive('setStatus')
             ->with(Constants::STATE_PUBLISHED);
@@ -272,6 +297,17 @@ class PublishEntityProductionCommandHandlerTest extends MockeryTestCase
         $manageEntity
             ->shouldReceive('getMetaData->getEntityId')
             ->andReturn('https://app.example.com/');
+        $manageEntity->shouldReceive('getService->getServiceType')->andReturn(Constants::SERVICE_TYPE_INSTITUTE);
+
+        $coin = m::mock(Coin::class);
+        $coin->shouldReceive('setContractualBase')->with(Constants::CONTRACTUAL_BASE_IX);
+        $manageEntity->shouldReceive('getMetaData->getCoin')->andReturn($coin);
+
+        $protocol = m::mock(Protocol::class);
+        $protocol->shouldReceive('getProtocol')->andReturn(Constants::TYPE_SAML);
+
+        $manageEntity
+            ->shouldReceive('getProtocol')->andReturn($protocol);
 
         $manageEntity
             ->shouldReceive('getId')

--- a/tests/unit/Application/Service/EntityMergeServiceTest.php
+++ b/tests/unit/Application/Service/EntityMergeServiceTest.php
@@ -53,7 +53,7 @@ class EntityMergeServiceTest extends TestCase
         $service = m::mock(Service::class);
         $service->shouldReceive('getOrganizationNameEn', 'getOrganizationNameNl', 'getOrganizationDisplayNameEn', 'getOrganizationDisplayNameNl')
             ->andReturn('Organization Name');
-        $manageEntity = $this->service->mergeEntityCommand($this->buildSamlCommand($service), null);
+        $manageEntity = $this->service->mergeEntityCommand($this->buildSamlCommand($service));
 
         self::assertNull($manageEntity->getId());
         self::assertFalse($manageEntity->isManageEntity());

--- a/tests/unit/Domain/Entity/Entity/CoinTest.php
+++ b/tests/unit/Domain/Entity/Entity/CoinTest.php
@@ -70,19 +70,19 @@ class CoinTest extends TestCase
     public function provideCoinTestData()
     {
         yield [
-            new Coin('signatureMethod', '23', 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1),
-            new Coin('signatureMethod', '23', 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1),
-            new Coin('signatureMethod', '23', 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1)
+            new Coin('signatureMethod', '23', 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1, null),
+            new Coin('signatureMethod', '23', 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1, null),
+            new Coin('signatureMethod', '23', 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1, null)
         ];
         yield [
-            new Coin('signatureMethod', '23', 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1),
-            new Coin('signatureMethod', null, 'https://www.example.com', null, 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1),
-            new Coin('signatureMethod', null, 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1),
+            new Coin('signatureMethod', '23', 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1, null),
+            new Coin('signatureMethod', null, 'https://www.example.com', null, 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1, null),
+            new Coin('signatureMethod', null, 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1, null),
         ];
         yield [
-            new Coin('signatureMethod', '23', 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1),
-            new Coin(null, null, null, null, null, new TypeOfServiceCollection(), null, null),
-            new Coin(null, null, null, '1', null, new TypeOfServiceCollection(), null, null)
+            new Coin('signatureMethod', '23', 'https://www.example.com', '1', 'https://example.com', new TypeOfServiceCollection(), 'https://example.com/eula', 1, null),
+            new Coin(null, null, null, null, null, new TypeOfServiceCollection(), null, null, null),
+            new Coin(null, null, null, '1', null, new TypeOfServiceCollection(), null, null, null)
         ];
     }
     public function provideCoinTestDataWithTypeOfService()

--- a/tests/unit/Domain/Entity/Entity/MetaDataTest.php
+++ b/tests/unit/Domain/Entity/Entity/MetaDataTest.php
@@ -243,7 +243,7 @@ class MetaDataTest extends TestCase
         $contactList = m::mock(ContactList::class);
         $contactList->shouldReceive('merge');
 
-        $coin = m::mock(Coin::class, [null, null, null, null, null, null, null, null]);
+        $coin = m::mock(Coin::class, [null, null, null, null, null, null, null, null, null]);
         $coin->shouldReceive('merge');
 
         $logo = m::mock(Logo::class);

--- a/tests/unit/Domain/Service/ContractualBaseServiceTest.php
+++ b/tests/unit/Domain/Service/ContractualBaseServiceTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Domain\DashboardBundle\Service;
+
+
+use PHPUnit\Framework\TestCase;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Coin;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\MetaData;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Protocol;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
+use Surfnet\ServiceProviderDashboard\Domain\Service\ContractualBaseService;
+
+class ContractualBaseServiceTest extends TestCase
+{
+    private ContractualBaseService $service;
+
+    protected function setUp(): void
+    {
+        $this->service = new ContractualBaseService();
+    }
+
+    /**
+     * @dataProvider contractualBaseDataProvider
+     */
+    public function testWriteContractualBase(
+        string $environment,
+        string $protocol,
+        string $serviceType,
+        ?string $expectedContractualBase
+    ): void {
+        $entity = $this->createMockEntity($environment, $protocol, $serviceType);
+
+        $this->service->writeContractualBase($entity);
+
+        $this->assertEquals($expectedContractualBase, $entity->getMetaData()->getCoin()->getContractualBase());
+    }
+
+    public function contractualBaseDataProvider(): array
+    {
+        return [
+            'Production SAML Institute' => [
+                Constants::ENVIRONMENT_PRODUCTION,
+                Constants::TYPE_SAML,
+                Constants::SERVICE_TYPE_INSTITUTE,
+                Constants::CONTRACTUAL_BASE_IX,
+            ],
+            'Production OIDC Institute' => [
+                Constants::ENVIRONMENT_PRODUCTION,
+                Constants::TYPE_OPENID_CONNECT_TNG,
+                Constants::SERVICE_TYPE_INSTITUTE,
+                Constants::CONTRACTUAL_BASE_IX,
+            ],
+            'Production SAML Non-Institute' => [
+                Constants::ENVIRONMENT_PRODUCTION,
+                Constants::TYPE_SAML,
+                Constants::SERVICE_TYPE_NON_INSTITUTE,
+                Constants::CONTRACTUAL_BASE_AO,
+            ],
+            'Production OIDC Non-Institute' => [
+                Constants::ENVIRONMENT_PRODUCTION,
+                Constants::TYPE_OPENID_CONNECT_TNG,
+                Constants::SERVICE_TYPE_NON_INSTITUTE,
+                Constants::CONTRACTUAL_BASE_AO,
+            ],
+            'Test Environment' => [
+                Constants::ENVIRONMENT_TEST,
+                Constants::TYPE_SAML,
+                Constants::SERVICE_TYPE_INSTITUTE,
+                null,
+            ],
+            'Unsupported Protocol' => [
+                Constants::ENVIRONMENT_PRODUCTION,
+                'unsupported_protocol',
+                Constants::SERVICE_TYPE_INSTITUTE,
+                null,
+            ],
+            'Unsupported Service Type' => [
+                Constants::ENVIRONMENT_PRODUCTION,
+                Constants::TYPE_SAML,
+                'unsupported_service_type',
+                null,
+            ],
+        ];
+    }
+
+    private function createMockEntity(string $environment, string $protocolValue, string $serviceType): ManageEntity
+    {
+        $metadata = $this->createMock(MetaData::class);
+        // Use an acutal Coin instance, as the value for the contractual base is overwritten in the service
+        $coin = new Coin(null, null, null, null, null, null, null, null, null);
+        $service = $this->createMock(Service::class);
+        $protocol = $this->createMock(Protocol::class);
+        $protocol->method('getProtocol')->willReturn($protocolValue);
+
+        $metadata->method('getCoin')->willReturn($coin);
+        $service->method('getServiceType')->willReturn($serviceType);
+
+        $entity = $this->createMock(ManageEntity::class);
+        $entity->method('getEnvironment')->willReturn($environment);
+        $entity->method('getProtocol')->willReturn($protocol);
+        $entity->method('getMetaData')->willReturn($metadata);
+        $entity->method('getService')->willReturn($service);
+
+        return $entity;
+    }
+}


### PR DESCRIPTION
The new service will ensure the business rules are followed for this feature. The tests have been updated to cover the new Coin entry on the Manage entity.

See: https://www.pivotaltracker.com/story/show/187977233