### PR TITLE
Hide nameIdFormat when `unspecified`

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Constants.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Constants.php
@@ -55,6 +55,7 @@ class Constants
         return [
             Constants::NAME_ID_FORMAT_TRANSIENT,
             Constants::NAME_ID_FORMAT_PERSISTENT,
+            Constants::NAME_ID_FORMAT_UNSPECIFIED,
         ];
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
@@ -34,6 +34,8 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -373,6 +375,18 @@ class OidcngEntityType extends AbstractType
 
             ->add('publishButton', SubmitType::class, ['label'=> $options['publish_button_label'], 'attr' => ['class' => 'button']])
             ->add('cancel', SubmitType::class, ['attr' => ['class' => 'button']]);
+
+        // When the Oidc entity is set to have an UNSPECIFIED subject type (in manage) do not show the field on the form
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event): void {
+            /** @var SaveOidcngEntityCommand $data */
+            $data = $event->getData();
+            if ($data->getSubjectType() === Constants::NAME_ID_FORMAT_UNSPECIFIED) {
+                $form = $event->getForm();
+                if ($form->has('metadata') && $form->get('metadata')->has('subjectType')) {
+                    $form->get('metadata')->remove('subjectType');
+                }
+            }
+        });
     }
 
     private function buildAttributeTypes(FormBuilderInterface $container): FormBuilderInterface

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/SamlEntityType.php
@@ -31,6 +31,8 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -323,6 +325,18 @@ class SamlEntityType extends AbstractType
 
             ->add('publishButton', SubmitType::class, ['label'=> $options['publish_button_label'], 'attr' => ['class' => 'button']])
             ->add('cancel', SubmitType::class, ['attr' => ['class' => 'button']]);
+
+        // When the SAML2.0 entity is set to have an UNSPECIFIED name id format (in manage) do not show the field on the form
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event): void {
+            /** @var SaveSamlEntityCommand $data */
+            $data = $event->getData();
+            if ($data->getNameIdFormat() === Constants::NAME_ID_FORMAT_UNSPECIFIED) {
+                $form = $event->getForm();
+                if ($form->has('metadata') && $form->get('metadata')->has('nameIdFormat')) {
+                    $form->get('metadata')->remove('nameIdFormat');
+                }
+            }
+        });
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/tests/webtests/EntityEditTest.php
+++ b/tests/webtests/EntityEditTest.php
@@ -19,6 +19,7 @@
 namespace Surfnet\ServiceProviderDashboard\Webtests;
 
 use Surfnet\ServiceProviderDashboard\Application\Service\AttributeService;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\DataFixtures\ORM\WebTestFixtures;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity\AttributeType;
 
@@ -78,6 +79,33 @@ class EntityEditTest extends WebTestCase
             'SP1 Name English',
             $nameEnfield->getValue(),
             'Expect the NameEN field to be set with value from command'
+        );
+    }
+
+    public function test_it_hides_name_id_format_unspecified()
+    {
+        // 1. When NameIdFormat is not Unspecified, the form field does appear on the form
+        $crawler = self::$pantherClient->request('GET', "/entity/edit/test/{$this->manageId}/1");
+        $this->assertOnPage(
+            'Name id format',
+            $crawler
+        );
+        // 2. But when the nameIdFormat is unspecified, the form field is not displayed on the form
+        $this->registerManageEntity(
+            'test',
+            'saml20_sp',
+            '88888888-1111-1111-1111-888888888888',
+            'SP1',
+            'https://spx-entityid.example.com',
+            'https://spx-entityid.example.com/metadata',
+            WebTestFixtures::TEAMNAME_SURF,
+            '12',
+            Constants::NAME_ID_FORMAT_UNSPECIFIED
+        );
+        $crawler = self::$pantherClient->request('GET', "/entity/edit/test/88888888-1111-1111-1111-888888888888/1");
+        $this->assertNotOnPage(
+            'Name id format',
+            $crawler
         );
     }
 

--- a/tests/webtests/Manage/Client/ClientResult.php
+++ b/tests/webtests/Manage/Client/ClientResult.php
@@ -41,6 +41,7 @@ class ClientResult implements ClientResultInterface
     private $teamName;
 
     private string $institutionId;
+    private string $nameIdFormat;
 
     public function __construct(
         string $protocol,
@@ -50,6 +51,7 @@ class ClientResult implements ClientResultInterface
         string $name,
         ?string $teamName,
         ?string $institutionId,
+        ?string $nameIdFormat,
     ) {
         $this->id = $id;
         $this->protocol = $protocol;
@@ -64,6 +66,7 @@ class ClientResult implements ClientResultInterface
         if ($teamName === null) {
             $this->teamName = WebTestFixtures::TEAMNAME_SURF;
         }
+        $this->nameIdFormat = $nameIdFormat ?? 'nameidformat';
     }
 
     public function getEntityResult(): array
@@ -93,7 +96,8 @@ class ClientResult implements ClientResultInterface
             $this->name,
             str_replace('_', '-', $this->protocol),
             $this->teamName,
-            $this->institutionId
+            $this->institutionId,
+            $this->nameIdFormat,
         );
         return json_decode($data, true);
     }
@@ -124,6 +128,7 @@ class ClientResult implements ClientResultInterface
             $data['name'],
             $data['teamName'],
             $data['institutionId'],
+            $data['nameIdFormat'],
         );
     }
 
@@ -137,6 +142,7 @@ class ClientResult implements ClientResultInterface
             'name' => $this->name,
             'teamName' => $this->teamName,
             'institutionId' => $this->institutionId,
+            'nameIdFormat' => $this->nameIdFormat,
         ];
     }
 }

--- a/tests/webtests/Manage/Client/FakeIdentityProviderClient.php
+++ b/tests/webtests/Manage/Client/FakeIdentityProviderClient.php
@@ -34,7 +34,7 @@ class FakeIdentityProviderClient implements IdentityProviderRepository
 
     public function registerEntity(string $protocol, string $id, string $entityId, string $name, string $institutionId = '')
     {
-        $this->entities[$id] = new ClientResult($protocol, $id, $entityId, null, $name, null, $institutionId);
+        $this->entities[$id] = new ClientResult($protocol, $id, $entityId, null, $name, null, $institutionId, null);
         $this->storeEntities();
     }
 

--- a/tests/webtests/Manage/Client/FakeQueryClient.php
+++ b/tests/webtests/Manage/Client/FakeQueryClient.php
@@ -58,8 +58,9 @@ class FakeQueryClient implements QueryManageRepository
         string $name,
         ?string $teamName = null,
         ?string $institutionId = '',
+        ?string $nameIdFormat = '',
     ) {
-        $this->entities[$id] = new ClientResult($protocol, $id, $entityId, $metadataUrl, $name, $teamName, $institutionId);
+        $this->entities[$id] = new ClientResult($protocol, $id, $entityId, $metadataUrl, $name, $teamName, $institutionId, $nameIdFormat);
         $this->storeEntities();
     }
 

--- a/tests/webtests/Manage/Client/template/ccc.json
+++ b/tests/webtests/Manage/Client/template/ccc.json
@@ -22,7 +22,7 @@
       "grants": [
         "client_credentials"
       ],
-      "NameIDFormat": "nameidformat",
+      "NameIDFormat": "%9$s",
       "isResourceServer": false,
       "contacts:0:emailAddress": "emailaddress@example.com",
       "contacts:0:contactType": "support",

--- a/tests/webtests/Manage/Client/template/oidc10.json
+++ b/tests/webtests/Manage/Client/template/oidc10.json
@@ -50,7 +50,7 @@
         "authorization_code",
         "refresh_token"
       ],
-      "NameIDFormat": "nameidformat",
+      "NameIDFormat": "%9$s",
       "isResourceServer": false,
       "contacts:0:emailAddress": "emailaddress@example.com",
       "contacts:0:contactType": "support",

--- a/tests/webtests/Manage/Client/template/saml20_sp.json
+++ b/tests/webtests/Manage/Client/template/saml20_sp.json
@@ -45,7 +45,7 @@
     "metaDataFields": {
       "AssertionConsumerService:0:Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
       "AssertionConsumerService:0:Location": "%3$s\/acs",
-      "NameIDFormat": "nameidformat",
+      "NameIDFormat": "%9$s",
       "description:en": "%5$s Description English",
       "description:nl": "%5$s Description Dutch",
       "name:en": "%5$s Name English",

--- a/tests/webtests/WebTestCase.php
+++ b/tests/webtests/WebTestCase.php
@@ -31,6 +31,7 @@ use Facebook\WebDriver\WebDriverKeys;
 use PHPUnit\Framework\ExpectationFailedException;
 use RuntimeException;
 use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\DeleteManageEntityRepository;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\IdentityProviderRepository;
@@ -182,6 +183,7 @@ class WebTestCase extends PantherTestCase
         ?string $metadataUrl = null,
         ?string $teamName = null,
         ?string $institutionId = '',
+        ?string $nameIdFormat = Constants::NAME_ID_FORMAT_PERSISTENT
     ) {
         switch ($protocol) {
             case 'saml20_sp':
@@ -196,6 +198,7 @@ class WebTestCase extends PantherTestCase
                     $metadataUrl,
                     $teamName,
                     $institutionId,
+                    $nameIdFormat,
                 );
                 break;
             case 'saml20_idp':
@@ -242,6 +245,7 @@ class WebTestCase extends PantherTestCase
         ?string $metadataUrl = null,
         ?string $teamName = null,
         ?string $institutionId = '',
+        ?string $nameIdFormat = '',
     ) {
         switch ($env) {
             case 'production':
@@ -252,7 +256,8 @@ class WebTestCase extends PantherTestCase
                     $metadataUrl,
                     $name,
                     $teamName,
-                    $institutionId
+                    $institutionId,
+                    $nameIdFormat
                 );
                 break;
             case 'test':
@@ -263,7 +268,8 @@ class WebTestCase extends PantherTestCase
                     $metadataUrl,
                     $name,
                     $teamName,
-                    $institutionId
+                    $institutionId,
+                    $nameIdFormat
                 );
                 break;
             default:


### PR DESCRIPTION
When the 'subjectType' or 'nameIdFormat' is unspecified. The matching form field is not displayed on the form. That way we do not allow the user to overwrite this value in Manage (which is explicitly set for that SP by a product owner)

To test this, the mock SP storage needed to track the nameIdFormat value as a manage entity. That requires quite some test code to be edited..

See: https://www.pivotaltracker.com/story/show/185952423