### PR TITLE
Unblue the `/connections` name column values

### DIFF
--- a/assets/scss/pages/service-connection.scss
+++ b/assets/scss/pages/service-connection.scss
@@ -34,9 +34,6 @@
           border: none;
         }
       }
-      td.name {
-        color: $blue
-      }
     }
   }
 }


### PR DESCRIPTION
The names of the services preivously were blue. Implying you can click on them. But they are no anchor or otherwise interactable. So having them grey makes more sense.

See: https://www.pivotaltracker.com/story/show/186881796/comments/242257354