### PR TITLE
Show correct menu items according to the granted authorizations

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Menu/Builder.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Menu/Builder.php
@@ -63,7 +63,7 @@ class Builder
                 'routeParameters' => ['serviceId' => $this->authorizationService->getActiveServiceId()],
                 ]
             );
-        } elseif (!$this->authorizationService->isSurfConextRepresentative()) {
+        } elseif ($this->authorizationService->getAllowedServiceNamesById() !== []) {
             $menu->addChild('global.menu.services', ['route' => 'service_overview']);
         }
         if ($this->authorizationService->isSurfConextRepresentative()) {

--- a/tests/unit/Infrastructure/DashboardSamlBundle/Security/Authentication/Provider/SamlProviderTest.php
+++ b/tests/unit/Infrastructure/DashboardSamlBundle/Security/Authentication/Provider/SamlProviderTest.php
@@ -24,7 +24,6 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use SAML2\Assertion;
-use Surfnet\SamlBundle\Exception\RuntimeException;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
 use Surfnet\SamlBundle\SAML2\Response\AssertionAdapter;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;


### PR DESCRIPTION
As of 17th of July it was possible to both be SurfConextResponsible AND have a regular ROLE_USER at the same time. This was already correctly handled by the Authz logic, but the menu did not yet show the correct menu items for the roles the user is authorized for..

That's what fixed here. At first I thought the SamlProvider was broken, hence the (cosmetic) change in the Test.

See: https://www.pivotaltracker.com/story/show/186881796/comments/242257534