### PR TITLE
Add all IdPs to the export when ACL allowAll=true

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/IdpService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/IdpService.php
@@ -20,6 +20,7 @@ declare(strict_types = 1);
 
 namespace Surfnet\ServiceProviderDashboard\Application\Service;
 
+use Surfnet\ServiceProviderDashboard\Domain\Entity\IdentityProvider;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\IdentityProviderRepository;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\ConfiguredTestIdpCollection;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\IdpCollection;
@@ -46,5 +47,13 @@ class IdpService implements IdpServiceInterface
     public function findInstitutionIdps(InstitutionId $institutionId): InstitutionIdpCollection
     {
         return new InstitutionIdpCollection($this->identityProviderRepository->findByInstitutionId($institutionId));
+    }
+
+    /**
+     * @return array<string, IdentityProvider>
+     */
+    public function findAll(): array
+    {
+        return $this->identityProviderRepository->findAll();
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/IdpServiceInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/IdpServiceInterface.php
@@ -20,6 +20,7 @@ declare(strict_types = 1);
 
 namespace Surfnet\ServiceProviderDashboard\Application\Service;
 
+use Surfnet\ServiceProviderDashboard\Domain\Entity\IdentityProvider;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\IdpCollection;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\InstitutionId;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\InstitutionIdpCollection;
@@ -29,4 +30,9 @@ interface IdpServiceInterface
     public function createCollection(): IdpCollection;
 
     public function findInstitutionIdps(InstitutionId $institutionId): InstitutionIdpCollection;
+
+    /**
+     * @return array<string, IdentityProvider>
+     */
+    public function findAll(): array;
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/ServiceConnectionService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/ServiceConnectionService.php
@@ -67,6 +67,7 @@ class ServiceConnectionService
                 $institutionId,
                 $this->getTestIdpsIndexed(),
                 $connectedOtherIdps,
+                $this->idpService->findAll()
             );
         }
         return $collection;
@@ -81,7 +82,8 @@ class ServiceConnectionService
             $collection,
             $institutionId,
             $this->getTestIdpsIndexed(),
-            $connectedOtherIdps
+            $connectedOtherIdps,
+            $this->idpService->findAll()
         );
         return $collection;
     }
@@ -97,12 +99,14 @@ class ServiceConnectionService
     /**
      * @param array<string, IdentityProvider> $testIdpsIndexed
      * @param array<string, IdentityProvider> $otherIdpsIndexed
+     * @param array<string, IdentityProvider> $allIdps
      */
     private function addEntitiesToCollection(
         EntityConnectionCollection $collection,
         InstitutionId $institutionId,
         array $testIdpsIndexed,
         array $otherIdpsIndexed,
+        array $allIdps,
     ): void {
         $list = [];
         $entities = $this->entityService->findPublishedTestEntitiesByInstitutionId($institutionId);
@@ -131,10 +135,11 @@ class ServiceConnectionService
                     $serviceName,
                     $testIdpsIndexed,
                     $otherIdpsIndexed,
-                    $testIdpsIndexed + $otherIdpsIndexed,
+                    $allIdps,
                     $supportContact,
                     $technicalContact,
-                    $adminContact
+                    $adminContact,
+                    true
                 );
                 continue;
             }
@@ -148,7 +153,8 @@ class ServiceConnectionService
                 $this->gatherConnectedIdps($entity, $testIdpsIndexed),
                 $supportContact,
                 $technicalContact,
-                $adminContact
+                $adminContact,
+                false
             );
         }
         $collection->addEntityConnections($list);

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityConnection.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityConnection.php
@@ -23,6 +23,9 @@ use Symfony\Component\Serializer\Attribute\Ignore;
 
 class EntityConnection
 {
+    /**
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList) - Could be decomposed, but for now makes no sense.
+     */
     public function __construct(
         public string $entityName,
         public string $entityId,
@@ -36,6 +39,7 @@ class EntityConnection
         public string $supportContact,
         public string $technicalContact,
         public string $administativeContact,
+        public bool $isAllowAll,
     ) {
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Repository/IdentityProviderRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Repository/IdentityProviderRepository.php
@@ -24,7 +24,7 @@ use Surfnet\ServiceProviderDashboard\Domain\ValueObject\InstitutionId;
 interface IdentityProviderRepository
 {
     /**
-     * @return IdentityProvider[]
+     * @return array<string, IdentityProvider>
      */
     public function findAll();
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/IdentityProviderClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/IdentityProviderClient.php
@@ -59,7 +59,8 @@ class IdentityProviderClient implements IdentityProviderRepository
                 return $list;
             }
             foreach ($result as $manageResult) {
-                $list[] = IdentityProviderFactory::fromManageResult($manageResult);
+                $idp = IdentityProviderFactory::fromManageResult($manageResult);
+                $list[$idp->getEntityId()] = $idp;
             }
             return $list;
         } catch (HttpException $e) {

--- a/tests/unit/Application/ViewObject/EntityConnectionTest.php
+++ b/tests/unit/Application/ViewObject/EntityConnectionTest.php
@@ -49,6 +49,7 @@ class EntityConnectionTest extends TestCase
             'James',
             'Jenny',
             'John',
+            false,
         );
 
         $this->assertEquals($availableTest, $connection->listAvailableTestIdps());
@@ -88,6 +89,7 @@ class EntityConnectionTest extends TestCase
             'James',
             'Jenny',
             'John',
+            false
         );
 
         $this->assertEquals($availableTest, $connection->listAvailableTestIdps());

--- a/tests/unit/Infrastructure/Manage/Client/IdentityProviderClientTest.php
+++ b/tests/unit/Infrastructure/Manage/Client/IdentityProviderClientTest.php
@@ -74,6 +74,8 @@ class IdentityProviderClientTest extends MockeryTestCase
             ->andReturn('testaccepted');
 
         $idps = $this->client->findAll();
+        // Re-index the results to allow for numeric access to the collection.
+        $idps = array_values($idps);
         $this->assertCount(4, $idps);
 
         $this->assertInstanceOf(IdentityProvider::class, $idps[0]);
@@ -105,7 +107,7 @@ class IdentityProviderClientTest extends MockeryTestCase
 
         $this->assertInstanceOf(IdentityProvider::class, $idps[3]);
         $this->assertSame(
-            'https://engine.dev.support.surfconext.nl/authentication/idp/metadata2',
+            'https://engine.dev.support.surfconext.nl/authentication/idp/metadata3',
             $idps[3]->getEntityId()
         );
         $this->assertSame('0c3febd2-3f67-4b8a-b90d-ce56a3b0abb6', $idps[3]->getManageId());

--- a/tests/unit/Infrastructure/Manage/Client/fixture/identity_provider_response.json
+++ b/tests/unit/Infrastructure/Manage/Client/fixture/identity_provider_response.json
@@ -42,7 +42,7 @@
     "_id": "0c3febd2-3f67-4b8a-b90d-ce56a3b0abb6",
     "version": 0,
     "data": {
-      "entityid": "https://engine.dev.support.surfconext.nl/authentication/idp/metadata2",
+      "entityid": "https://engine.dev.support.surfconext.nl/authentication/idp/metadata3",
       "state": "prodaccepted",
       "notes": null,
       "metaDataFields": {

--- a/tests/webtests/Manage/Client/FakeIdentityProviderClient.php
+++ b/tests/webtests/Manage/Client/FakeIdentityProviderClient.php
@@ -46,7 +46,8 @@ class FakeIdentityProviderClient implements IdentityProviderRepository
         $this->load();
         $list = [];
         foreach ($this->entities as $manageResult) {
-            $list[] = IdentityProviderFactory::fromManageResult($manageResult->getEntityResult());
+            $idp = IdentityProviderFactory::fromManageResult($manageResult->getEntityResult());
+            $list[$idp->getEntityId()] = $idp;
         }
         return $list;
     }


### PR DESCRIPTION
It makes sense to show all connected IdP's in the CSV export for the surfconext representative. When the ACL is set to allow all IdPs connected to the SP, we should list all IdPs of the test env there.

This can be a long list. But now we would only show the Organizations IdPs, and the explicitly marked test-idps.

See: https://www.pivotaltracker.com/story/show/187805216/comments/242257758