### PR TITLE
Remove usage of getimagesize

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -33,13 +33,13 @@ surfconext_representative_authorization='urn:mace:surfnet.nl:surfnet.nl:sab:role
 
 ## Manage test instance
 manage_test_host='https://manage.dev.openconext.local'
-manage_test_username=sp-portal
+manage_test_username=sp-dashboard
 manage_test_password=secret
 manage_test_publication_status=testaccepted
 
 ## Manage production instance
 manage_prod_host='https://manage.dev.openconext.local'
-manage_prod_username=sp-portal
+manage_prod_username=sp-dashboard
 manage_prod_password=secret
 manage_prod_publication_status=prodaccepted
 

--- a/ci/qa/phpstan-baseline.php
+++ b/ci/qa/phpstan-baseline.php
@@ -928,7 +928,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^If condition is always true\\.$#',
-	'count' => 2,
+	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php',
 ];
 $ignoreErrors[] = [
@@ -992,11 +992,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method Surfnet\\\\ServiceProviderDashboard\\\\Application\\\\Metadata\\\\JsonGenerator\\:\\:generateLogoMetadata\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Surfnet\\\\ServiceProviderDashboard\\\\Application\\\\Metadata\\\\JsonGenerator\\:\\:generateOrganizationMetadata\\(\\) return type has no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php',
@@ -1008,11 +1003,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$acsLocations of static method Surfnet\\\\ServiceProviderDashboard\\\\Application\\\\Metadata\\\\AcsLocationHelper\\:\\:addEmptyAcsLocationsToMetaData\\(\\) expects array, array\\|null given\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$filename of function getimagesize expects string, string\\|null given\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php',
 ];
@@ -1182,11 +1172,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/Metadata/OauthClientCredentialsClientJsonGenerator.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method Surfnet\\\\ServiceProviderDashboard\\\\Application\\\\Metadata\\\\OauthClientCredentialsClientJsonGenerator\\:\\:generateLogoMetadata\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/Metadata/OauthClientCredentialsClientJsonGenerator.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Surfnet\\\\ServiceProviderDashboard\\\\Application\\\\Metadata\\\\OauthClientCredentialsClientJsonGenerator\\:\\:generateMetadataFields\\(\\) never returns float so it can be removed from the return type\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/Metadata/OauthClientCredentialsClientJsonGenerator.php',
@@ -1219,11 +1204,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$entityId of static method Surfnet\\\\ServiceProviderDashboard\\\\Application\\\\Parser\\\\OidcngClientIdParser\\:\\:parse\\(\\) expects string, string\\|null given\\.$#',
 	'count' => 2,
-	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/Metadata/OauthClientCredentialsClientJsonGenerator.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$filename of function getimagesize expects string, string\\|null given\\.$#',
-	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/Metadata/OauthClientCredentialsClientJsonGenerator.php',
 ];
 $ignoreErrors[] = [
@@ -1342,11 +1322,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method Surfnet\\\\ServiceProviderDashboard\\\\Application\\\\Metadata\\\\OidcngJsonGenerator\\:\\:generateLogoMetadata\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Surfnet\\\\ServiceProviderDashboard\\\\Application\\\\Metadata\\\\OidcngJsonGenerator\\:\\:generateMetadataFields\\(\\) never returns float so it can be removed from the return type\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php',
@@ -1379,11 +1354,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$entityId of static method Surfnet\\\\ServiceProviderDashboard\\\\Application\\\\Parser\\\\OidcngClientIdParser\\:\\:parse\\(\\) expects string, string\\|null given\\.$#',
 	'count' => 2,
-	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$filename of function getimagesize expects string, string\\|null given\\.$#',
-	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php',
 ];
 $ignoreErrors[] = [
@@ -3867,11 +3837,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/CurlLogoValidationHelper.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method Surfnet\\\\ServiceProviderDashboard\\\\Infrastructure\\\\DashboardBundle\\\\Service\\\\LogoValidationHelperInterface\\:\\:validateLogo\\(\\) has no return type specified\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/LogoValidationHelperInterface.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Surfnet\\\\ServiceProviderDashboard\\\\Infrastructure\\\\DashboardBundle\\\\Service\\\\LogoValidationHelperInterface\\:\\:validateLogo\\(\\) has parameter \\$url with no type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/LogoValidationHelperInterface.php',
@@ -3954,16 +3919,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Access to an undefined property Symfony\\\\Component\\\\Validator\\\\Constraint\\:\\:\\$message\\.$#',
 	'count' => 2,
-	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/ValidLogoValidator.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method Surfnet\\\\ServiceProviderDashboard\\\\Infrastructure\\\\DashboardBundle\\\\Validator\\\\Constraints\\\\ValidLogoValidator\\:\\:getImageSizeValidation\\(\\) has parameter \\$value with no type specified\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/ValidLogoValidator.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method Surfnet\\\\ServiceProviderDashboard\\\\Infrastructure\\\\DashboardBundle\\\\Validator\\\\Constraints\\\\ValidLogoValidator\\:\\:validate\\(\\) has parameter \\$value with no type specified\\.$#',
-	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/ValidLogoValidator.php',
 ];
 $ignoreErrors[] = [

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGenerator.php
@@ -227,7 +227,7 @@ class JsonGenerator implements GeneratorInterface
             $metadata['coin:exclude_from_push'] = '0';
         }
         if ($entity->getMetaData()->getLogo() instanceof Logo && $entity->getMetaData()->getLogo()->getUrl() !== '') {
-            $metadata = array_merge($metadata, $this->generateLogoMetadata($entity));
+            $metadata['logo:0:url'] = $entity->getMetaData()->getLogo()->getUrl();
         }
         if ($entity->getMetaData()?->getCoin()->getContractualBase() !== null) {
             $metadata['coin:contractual_base'] = $entity->getMetaData()->getCoin()->getContractualBase();
@@ -305,41 +305,6 @@ class JsonGenerator implements GeneratorInterface
             $metadata[sprintf('contacts:%d:telephoneNumber', $index)] = $contact->getPhone();
         }
 
-        return $metadata;
-    }
-
-    /**
-     * Generate logo metadata fields.
-     *
-     * Logo dimensions are required in the SAML spec. They are always present,
-     * except when the user just created the entity in the interface. We
-     * determine the dimensions in those situations.
-     *
-     * @SuppressWarnings(PHPMD.ErrorControlOperator)
-     */
-    private function generateLogoMetadata(ManageEntity $entity): array
-    {
-        $logo = $entity->getMetaData()->getLogo();
-        $metadata = [];
-        if ($logo) {
-            $metadata = [
-                'logo:0:url' => $logo->getUrl(),
-            ];
-
-            $logoData = @getimagesize(
-                $logo->getUrl()
-            );
-
-            if ($logoData !== false) {
-                [$width, $height] = $logoData;
-            } else {
-                $width = 50;
-                $height = 50;
-            }
-
-            $metadata['logo:0:width'] = (string)$width;
-            $metadata['logo:0:height'] = (string)$height;
-        }
         return $metadata;
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OauthClientCredentialsClientJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OauthClientCredentialsClientJsonGenerator.php
@@ -192,7 +192,7 @@ class OauthClientCredentialsClientJsonGenerator implements GeneratorInterface
         $metadata += $this->generateOidcClient($entity);
 
         if ($entity->getMetaData()->getLogo() instanceof Logo && $entity->getMetaData()->getLogo()->getUrl() !== '') {
-            $metadata += $this->generateLogoMetadata($entity);
+            $metadata['logo:0:url'] = $entity->getMetaData()->getLogo()->getUrl();
         }
 
         return $metadata;
@@ -284,37 +284,6 @@ class OauthClientCredentialsClientJsonGenerator implements GeneratorInterface
         if ($contact->getPhone() !== null && $contact->getPhone() !== '' && $contact->getPhone() !== '0') {
             $metadata[sprintf('contacts:%d:telephoneNumber', $index)] = $contact->getPhone();
         }
-
-        return $metadata;
-    }
-
-    /**
-     * Generate logo metadata fields.
-     *
-     * Logo dimensions are required in the SAML spec. They are always present,
-     * except when the user just created the entity in the interface. We
-     * determine the dimensions in those situations.
-     *
-     * @SuppressWarnings(PHPMD.ErrorControlOperator)
-     */
-    private function generateLogoMetadata(ManageEntity $entity): array
-    {
-        $logoUrl = $entity->getMetaData()->getLogo()->getUrl();
-        $metadata = [
-            'logo:0:url' => $logoUrl,
-        ];
-
-        $logoData = @getimagesize($logoUrl);
-
-        if ($logoData !== false) {
-            [$width, $height] = $logoData;
-        } else {
-            $width = 50;
-            $height = 50;
-        }
-
-        $metadata['logo:0:width'] = (string) $width;
-        $metadata['logo:0:height'] = (string) $height;
 
         return $metadata;
     }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
@@ -196,7 +196,7 @@ class OidcngJsonGenerator implements GeneratorInterface
         $metadata += $this->generateOidcClient($entity);
 
         if ($entity->getMetaData()->getLogo() instanceof Logo && $entity->getMetaData()->getLogo()->getUrl() !== '') {
-            $metadata += $this->generateLogoMetadata($entity);
+            $metadata['logo:0:url'] = $entity->getMetaData()->getLogo()->getUrl();
         }
         if ($entity->getMetaData()?->getCoin()->getContractualBase() !== null) {
             $metadata['coin:contractual_base'] = $entity->getMetaData()->getCoin()->getContractualBase();
@@ -293,37 +293,6 @@ class OidcngJsonGenerator implements GeneratorInterface
         if ($contact->getPhone() !== null && $contact->getPhone() !== '' && $contact->getPhone() !== '0') {
             $metadata[sprintf('contacts:%d:telephoneNumber', $index)] = $contact->getPhone();
         }
-
-        return $metadata;
-    }
-
-    /**
-     * Generate logo metadata fields.
-     *
-     * Logo dimensions are required in the SAML spec. They are always present,
-     * except when the user just created the entity in the interface. We
-     * determine the dimensions in those situations.
-     *
-     * @SuppressWarnings(PHPMD.ErrorControlOperator)
-     */
-    private function generateLogoMetadata(ManageEntity $entity): array
-    {
-        $logoUrl = $entity->getMetaData()->getLogo()->getUrl();
-        $metadata = [
-            'logo:0:url' => $logoUrl,
-        ];
-
-        $logoData = @getimagesize($logoUrl);
-
-        if ($logoData !== false) {
-            [$width, $height] = $logoData;
-        } else {
-            $width = 50;
-            $height = 50;
-        }
-
-        $metadata['logo:0:width'] = (string) $width;
-        $metadata['logo:0:height'] = (string) $height;
 
         return $metadata;
     }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/CurlLogoValidationHelper.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/CurlLogoValidationHelper.php
@@ -33,12 +33,12 @@ class CurlLogoValidationHelper implements LogoValidationHelperInterface
      * Using Curl: tests:
      *  - is the curl response code erroneous (>= 400)
      *  - if the content type is correct
+     * Returns the location where the logo is stored temporarily
      *
-     * @param  $url
      * @throws LogoInvalidTypeException
      * @throws LogoNotFoundException
      */
-    public function validateLogo($url): void
+    public function validateLogo($url): string
     {
         $this->logger->debug(sprintf('Validating logo: "%s" using curl', $url));
 
@@ -50,7 +50,9 @@ class CurlLogoValidationHelper implements LogoValidationHelperInterface
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
         curl_setopt($ch, CURLOPT_TIMEOUT, 10);
 
-        curl_exec($ch);
+        $content = curl_exec($ch);
+        $fileLocation = '/tmp/logo-validation-' . uniqid();
+        file_put_contents($fileLocation, $content);
 
         $contentType = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
         $responseCode = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
@@ -76,5 +78,7 @@ class CurlLogoValidationHelper implements LogoValidationHelperInterface
             $this->logger->info('The logo file type is invalid');
             throw new LogoInvalidTypeException('The logo file type is invalid');
         }
+
+        return $fileLocation;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/CurlLogoValidationHelper.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/CurlLogoValidationHelper.php
@@ -46,7 +46,7 @@ class CurlLogoValidationHelper implements LogoValidationHelperInterface
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_VERBOSE, 1);
-        curl_setopt($ch, CURLOPT_HEADER, 1);
+        curl_setopt($ch, CURLOPT_HEADER, 0);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
         curl_setopt($ch, CURLOPT_TIMEOUT, 10);
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/LogoValidationHelperInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/LogoValidationHelperInterface.php
@@ -34,10 +34,10 @@ interface LogoValidationHelperInterface
 
     /**
      * Validates the logo, throws an exception if validation failed.
-     *
+     * Returns the local path to the curl'ed image
      * @param  $url
      * @throws LogoInvalidTypeException
      * @throws LogoNotFoundException
      */
-    public function validateLogo($url);
+    public function validateLogo($url): string;
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/ValidLogoValidator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/ValidLogoValidator.php
@@ -41,15 +41,15 @@ class ValidLogoValidator extends ConstraintValidator
     {
     }
 
-    public function validate($value, Constraint $constraint): void
+    public function validate(mixed $value, Constraint $constraint): void
     {
         if (empty($value)) {
             return;
         }
 
         try {
-            $this->logoValidationHelper->validateLogo($value);
-            $this->getImageSizeValidation($value, $constraint);
+            $filePath = $this->logoValidationHelper->validateLogo($value);
+            $this->getImageSizeValidation($filePath, $constraint);
         } catch (LogoNotFoundException) {
             $this->context->addViolation(self::STATUS_DOWNLOAD_FAILED);
             return;
@@ -64,7 +64,7 @@ class ValidLogoValidator extends ConstraintValidator
      *
      * @param $value
      */
-    private function getImageSizeValidation($value, Constraint $constraint): void
+    private function getImageSizeValidation(string $value, Constraint $constraint): void
     {
         try {
             $imgData = getimagesize($value);

--- a/tests/integration/Infrastructure/DashboardBundle/Validator/Constraints/ValidLogoValidatorTest.php
+++ b/tests/integration/Infrastructure/DashboardBundle/Validator/Constraints/ValidLogoValidatorTest.php
@@ -47,7 +47,7 @@ class ValidLogoValidatorTest extends ConstraintValidatorTestCase
 
         $this->validationHelper
             ->shouldReceive('validateLogo')
-            ->andReturn(null);
+            ->andReturn('file://'.__DIR__.'/fixture/logo_validator/small.png');
 
         $this->validator->validate('file://'.__DIR__.'/fixture/logo_validator/small.png', $constraint);
 
@@ -60,7 +60,7 @@ class ValidLogoValidatorTest extends ConstraintValidatorTestCase
 
         $this->validationHelper
             ->shouldReceive('validateLogo')
-            ->andReturn(null);
+            ->andReturn('file://'.__DIR__.'/fixture/logo_validator/small.gif');
 
         $this->validator->validate('file://'.__DIR__.'/fixture/logo_validator/small.gif', $constraint);
 
@@ -81,7 +81,7 @@ class ValidLogoValidatorTest extends ConstraintValidatorTestCase
 
         $this->validationHelper
             ->shouldReceive('validateLogo')
-            ->andReturn(null);
+            ->andReturn('file://'.__DIR__.'/fixture/logo_validator/ufjd');
 
         $this->validator->validate('ufjd', $constraint);
 


### PR DESCRIPTION
We can not use the url_fopen portion of the getimagesize function. This is the case when you use getimagesize with a remote file location.

1. For the ValidLogoValidator: We can exclusively use the curl based validation (already implemented in the CurlLogoValidationHelper
2. The message sent to Manage does not require a valid with and height to be set, as they will be esteablished on the logo 'cdn'

See: https://www.pivotaltracker.com/n/projects/1400064/stories/186921877