### PR TITLE
Fix webtests in dev env.

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -33,13 +33,13 @@ surfconext_representative_authorization='urn:mace:surfnet.nl:surfnet.nl:sab:role
 
 ## Manage test instance
 manage_test_host='https://manage.dev.openconext.local'
-manage_test_username=sp-portal
+manage_test_username=sp-dashboard
 manage_test_password=secret
 manage_test_publication_status=testaccepted
 
 ## Manage production instance
 manage_prod_host='https://manage.dev.openconext.local'
-manage_prod_username=sp-portal
+manage_prod_username=sp-dashboard
 manage_prod_password=secret
 manage_prod_publication_status=prodaccepted
 

--- a/.env.dist
+++ b/.env.dist
@@ -135,7 +135,7 @@ global_site_notice_date='11.05.2021'
 global_site_notice_allowed_tags='<a><u><i><br><wbr><strong><em><blink><marquee><p><ul><ol><dl><li><dd><dt><div><span><blockquote><hr><h2></h2><h3><h4><h5><h6>'
 
 # Teams urn prefix, see: https://www.pivotaltracker.com/story/show/179572218/comments/227653860
-team_prefix_default_stem_name='urn:collab:group:vm.openconext.org:'
+team_prefix_default_stem_name='urn:collab:group:dev.openconext.local:'
 team_prefix_group_name_context='demo:openconext:org:'
 
 acs_location_route_name=dashboard_saml_consume_assertion

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Then start the command line in the container with `docker compose exec -ti spdas
 
 Run `composer install`. This will install all PHP dependencies, including the development dependencies.
 Run `yarn install`. This will install all js dependencies, including the development dependencies.
+Run `yarn encore dev`. This will build the frontend.
 
 Install database migrations
 ```

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DataFixtures/ORM/WebTestFixtures.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/DataFixtures/ORM/WebTestFixtures.php
@@ -27,8 +27,8 @@ use Symfony\Component\Uid\Uuid;
 
 class WebTestFixtures extends Fixture
 {
-    public const TEAMNAME_SURF = 'urn:collab:group:vm.openconext.org:demo:openconext:org:surf.nl';
-    public const TEAMNAME_IBUILDINGS = 'urn:collab:group:vm.openconext.org:demo:openconext:org:ibuildings.nl';
+    public const TEAMNAME_SURF = 'urn:collab:group:dev.openconext.local:demo:openconext:org:surf.nl';
+    public const TEAMNAME_IBUILDINGS = 'urn:collab:group:dev.openconext.local:demo:openconext:org:ibuildings.nl';
     public const TEAMNAME_ACME = 'demo:openconext:org:acme.com';
 
     public function load(ObjectManager $manager): void

--- a/tests/webtests/EditServiceTest.php
+++ b/tests/webtests/EditServiceTest.php
@@ -46,7 +46,7 @@ class EditServiceTest extends WebTestCase
         $this->fillFormField($form, '#dashboard_bundle_edit_service_type_general_name', 'The A Team');
         $this->fillFormField($form, '#dashboard_bundle_edit_service_type_general_organizationNameNl', 'Groepje A');
         $this->checkFormField($form, '#dashboard_bundle_edit_service_type_serviceStatus_surfconextRepresentativeApproved_1');
-        $this->fillFormField($form, '#dashboard_bundle_edit_service_type_teams_teamName', 'urn:collab:group:vm.openconext.org:demo:openconext:org:team-a');
+        $this->fillFormField($form, '#dashboard_bundle_edit_service_type_teams_teamName', 'urn:collab:group:dev.openconext.local:demo:openconext:org:team-a');
         self::$pantherClient->executeScript("document.getElementsByClassName('service-form').item(0).submit();");
         self::assertOnPage('Your changes were saved!');
     }

--- a/tests/webtests/fixtures/entity-copy/remote-entity-info.json
+++ b/tests/webtests/fixtures/entity-copy/remote-entity-info.json
@@ -53,7 +53,7 @@
       "description:nl": "OpenConext SSO Proxy",
       "name:en": "OpenConext Engine EN",
       "name:nl": "OpenConext Engine",
-      "coin:service_team_id": "urn:collab:group:vm.openconext.org:demo:openconext:org:surf.nl",
+      "coin:service_team_id": "urn:collab:group:dev.openconext.local:demo:openconext:org:surf.nl",
       "coin:eula": "https://eulaurl",
       "coin:application_url": "https://appurl",
       "coin:original_metadata_url": "https://engine.dev.openconext.local/authentication/sp/metadata",

--- a/tests/webtests/fixtures/entity-copy/remote-oidcng-entity-info.json
+++ b/tests/webtests/fixtures/entity-copy/remote-oidcng-entity-info.json
@@ -16,7 +16,7 @@
       "contacts:0:givenName": "Aad",
       "contacts:0:surName": "Janssen",
       "contacts:0:emailAddress": "ajanssen@foobar.com",
-      "coin:service_team_id": "urn:collab:group:vm.openconext.org:demo:openconext:org:surf.nl",
+      "coin:service_team_id": "urn:collab:group:dev.openconext.local:demo:openconext:org:surf.nl",
       "coin:application_url": "https:\/\/prod.dev.playground.openconext.nl\/playground",
       "coin:eula": "https:\/\/prod.dev.playground.openconext.nl\/playground\/EULA",
       "NameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",


### PR DESCRIPTION
Prior to this change, the webtests would fail when ran in the dev env, unless the `team_prefix_default_stem_name` env was adjusted manually.

This change updates the .dist env and several webtest fixtures to use the updated stem.

See: https://www.pivotaltracker.com/n/projects/1400064/stories/179572218/comments/227653860

Also scouted: Fix wrong manage credentials in `.env.dev`
Scouted: Add missing `yarn encore dev` to Readme