### PR TITLE
Create role in invite when registering new service

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -31,6 +31,8 @@ authorization_attribute_name='eduPersonEntitlement'
 # When the `surf-autorsaties` attribute contains this value, the user is granted
 surfconext_representative_authorization='urn:mace:surfnet.nl:surfnet.nl:sab:role:SURFconext-verantwoordelijke'
 
+spdashboard_manage_id='4b0e422d-d0d0-4b9e-a521-fdd1ee5d2bad'
+
 ## Manage test instance
 manage_test_host='https://manage.dev.openconext.local'
 manage_test_username=sp-dashboard
@@ -47,6 +49,12 @@ manage_prod_publication_status=prodaccepted
 teams_host='https://teams.dev.openconext.local'
 teams_username=spdashboard
 teams_password=secret
+
+## Invite instance
+invite_host='https://invite.dev.openconext.local'
+invite_api_username='sp_dashboard'
+invite_api_password='secret'
+invite_landing_url='https://example.org'
 
 # Mail default settings
 mail_from=support@surfconext.nl

--- a/.env.dist
+++ b/.env.dist
@@ -81,6 +81,7 @@ manage_test_host='https://manage.dev.openconext.local'
 manage_test_username=sp-dashboard
 manage_test_password=secret
 manage_test_publication_status=testaccepted
+spdashboard_manage_id='4b0e422d-d0d0-4b9e-a521-fdd1ee5d2bad'
 
 ## Manage production instance
 manage_prod_host='https://manage.dev.openconext.local'
@@ -92,6 +93,12 @@ manage_prod_publication_status=prodaccepted
 teams_host='https://teams.dev.openconext.local'
 teams_username=spdashboard
 teams_password=secret
+
+## Invite instance
+invite_host='https://invite.dev.openconext.local'
+invite_api_username='sp_dashboard'
+invite_api_password='secret'
+invite_landing_url='https://example.org'
 
 # Mail default settings
 mail_from=support@surfconext.nl

--- a/ci/qa/phpstan-baseline.php
+++ b/ci/qa/phpstan-baseline.php
@@ -452,32 +452,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/PrivacyQuestions/PrivacyQuestionsCommandHandler.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Call to an undefined method Surfnet\\\\ServiceProviderDashboard\\\\Domain\\\\Repository\\\\PublishTeamsRepository\\:\\:createTeam\\(\\)\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/CreateServiceCommandHandler.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method Surfnet\\\\ServiceProviderDashboard\\\\Application\\\\CommandHandler\\\\Service\\\\CreateServiceCommandHandler\\:\\:createEmailsArray\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/CreateServiceCommandHandler.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method Surfnet\\\\ServiceProviderDashboard\\\\Application\\\\CommandHandler\\\\Service\\\\CreateServiceCommandHandler\\:\\:createTeamData\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/CreateServiceCommandHandler.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$organizationNameEn of method Surfnet\\\\ServiceProviderDashboard\\\\Domain\\\\Entity\\\\Service\\:\\:setOrganizationNameEn\\(\\) expects string, string\\|null given\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/CreateServiceCommandHandler.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$organizationNameNl of method Surfnet\\\\ServiceProviderDashboard\\\\Domain\\\\Entity\\\\Service\\:\\:setOrganizationNameNl\\(\\) expects string, string\\|null given\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/CreateServiceCommandHandler.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$email of method Surfnet\\\\ServiceProviderDashboard\\\\Application\\\\CommandHandler\\\\Service\\\\CreateServiceCommandHandler\\:\\:createTeamData\\(\\) expects string, string\\|null given\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/CreateServiceCommandHandler.php',
 ];
@@ -4177,6 +4157,11 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Infrastructure/HttpClient/ResourcePathFormatter.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Method Surfnet\\\\ServiceProviderDashboard\\\\Infrastructure\\\\Invite\\\\InviteHttpClient\\:\\:post\\(\\) has parameter \\$payload with no value type specified in iterable type array\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Infrastructure/Invite/InviteHttpClient.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Expression on left side of \\?\\? is not nullable\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Infrastructure/Jira/Factory/IssueFieldFactory.php',
@@ -4777,11 +4762,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Infrastructure/Teams/Client/DeleteEntityClient.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot access offset \'id\' on mixed\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Infrastructure/Teams/Client/PublishEntityClient.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot call method getReasonPhrase\\(\\) on mixed\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Infrastructure/Teams/Client/PublishEntityClient.php',
@@ -4789,11 +4769,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method getStatusCode\\(\\) on mixed\\.$#',
 	'count' => 2,
-	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Infrastructure/Teams/Client/PublishEntityClient.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method Surfnet\\\\ServiceProviderDashboard\\\\Infrastructure\\\\Teams\\\\Client\\\\PublishEntityClient\\:\\:createTeam\\(\\) has parameter \\$team with no value type specified in iterable type array\\.$#',
-	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Infrastructure/Teams/Client/PublishEntityClient.php',
 ];
 $ignoreErrors[] = [

--- a/migrations/Version20241029125655.php
+++ b/migrations/Version20241029125655.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Surfnet\ServiceProviderDashboard\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20241029125655 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE service ADD invite_role_id INT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE service DROP invite_role_id');
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/CreateServiceCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/CreateServiceCommand.php
@@ -36,6 +36,9 @@ class CreateServiceCommand implements Command
     #[Assert\Uuid(strict: false)]
     private $guid;
 
+    #[Assert\Uuid(strict: false)]
+    private string $manageId;
+
     /**
      * @var                                string
      */
@@ -79,6 +82,14 @@ class CreateServiceCommand implements Command
 
     #[Assert\NotBlank]
     private ?string $organizationNameEn = null;
+
+    /**
+     * @param string $manageId
+     */
+    public function __construct(string $manageId)
+    {
+        $this->manageId = $manageId;
+    }
 
     /**
      * @param string $guid
@@ -148,6 +159,11 @@ class CreateServiceCommand implements Command
     public function getGuid()
     {
         return $this->guid;
+    }
+
+    public function getManageId(): string
+    {
+        return $this->manageId;
     }
 
     /**
@@ -225,9 +241,6 @@ class CreateServiceCommand implements Command
         $this->organizationNameNl = $organizationNameNl;
     }
 
-    /**
-     * @return string
-     */
     public function getOrganizationNameEn(): ?string
     {
         return $this->organizationNameEn;

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Service.php
@@ -137,6 +137,9 @@ class Service
     #[ORM\Column(length: 255, nullable: false)]
     private ?string $organizationNameEn = null;
 
+    #[ORM\Column(nullable: true)]
+    private ?int $inviteRoleId = null;
+
     public function __construct()
     {
         $this->contacts = new ArrayCollection();
@@ -336,5 +339,16 @@ class Service
     public function setOrganizationNameEn(string $organizationNameEn): void
     {
         $this->organizationNameEn = $organizationNameEn;
+    }
+
+    public function getInviteRoleId(): ?int
+    {
+        return $this->inviteRoleId;
+    }
+
+    public function registerInvite(string $urn, int $roleId): void
+    {
+        $this->teamName = $urn;
+        $this->inviteRoleId = $roleId;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Repository/InviteRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Repository/InviteRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Surfnet\ServiceProviderDashboard\Domain\Repository;
+
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\CreateRoleResponse;
+use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\InviteException;
+
+interface InviteRepository
+{
+    /**
+     * @throws InviteException
+     */
+    public function createRole(
+        string $name,
+        string $shortName,
+        string $description,
+        string $landingPage,
+        string $manageId,
+    ): CreateRoleResponse;
+}

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Repository/PublishTeamsRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Repository/PublishTeamsRepository.php
@@ -21,25 +21,6 @@ namespace Surfnet\ServiceProviderDashboard\Domain\Repository;
 interface PublishTeamsRepository
 {
     /**
-     * Create a new team in Teams.
-     *
-     * Expects an array with the following structure:
-     *
-     {
-        "name": "Champions ",
-        "description": "Team champions",
-        "personalNote": "Team created by SP Dashboard",
-        "viewable": true,
-        "emails": {
-            "test@test.com": "ADMIN"
-        },
-        "roleOfCurrentUser": "ADMIN",
-        "invitationMessage": "Please..",
-        "language": "DUTCH"
-     }
-    public function createTeam(array $team): mixed;
-
-    /**
      * Change the membership role for a given id with a given role.
      */
     public function changeMembership(int $id, string $role): mixed;

--- a/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/CreateRoleResponse.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/CreateRoleResponse.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Surfnet\ServiceProviderDashboard\Domain\ValueObject;
+
+class CreateRoleResponse
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly string $name,
+        public readonly string $shortName,
+        public readonly string $description,
+        public readonly string $urn
+    ) {
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/ServiceController.php
@@ -57,6 +57,9 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
  */
 class ServiceController extends AbstractController
 {
+    /**
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     */
     public function __construct(
         private readonly CommandBus $commandBus,
         private readonly AuthorizationService $authorizationService,
@@ -67,6 +70,7 @@ class ServiceController extends AbstractController
         private readonly QueryTeamsRepository $queryClient,
         private readonly LoggerInterface $logger,
         private readonly string $defaultStemName,
+        private readonly string $manageId,
     ) {
     }
 
@@ -129,7 +133,7 @@ class ServiceController extends AbstractController
     public function create(Request $request): RedirectResponse|Response
     {
         $request->getSession()->getFlashBag()->clear();
-        $command = new CreateServiceCommand();
+        $command = new CreateServiceCommand($this->manageId);
 
         $form = $this->createForm(CreateServiceType::class, $command);
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -22,6 +22,8 @@ services:
     arguments:
       $prefixPart1: '%env(team_prefix_default_stem_name)%'
       $prefixPart2: '%env(team_prefix_group_name_context)%'
+      $inviteRepository: '@Surfnet\ServiceProviderDashboard\Infrastructure\Invite\InviteRepository'
+      $landingUrl: '%env(invite_landing_url)%'
 
   surfnet.dashboard.command_handler.delete_service:
     class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Service\DeleteServiceCommandHandler
@@ -463,6 +465,7 @@ services:
     arguments:
       $defaultStemName: '%env(team_prefix_default_stem_name)%'
       $logger: '@logger'
+      $manageId: '%env(spdashboard_manage_id)%'
 
   Surfnet\ServiceProviderDashboard\Infrastructure\Teams\TeamsClient:
     arguments:
@@ -678,3 +681,13 @@ services:
       $entityAclService: '@Surfnet\ServiceProviderDashboard\Application\Service\EntityAclService'
       $testIdps: '@Surfnet\ServiceProviderDashboard\Domain\ValueObject\ConfiguredTestIdpCollection'
       $identityProviderRepository: '@surfnet.manage.client.identity_provider_client.test_environment'
+
+
+  Surfnet\ServiceProviderDashboard\Infrastructure\Invite\InviteRepository:
+
+  Surfnet\ServiceProviderDashboard\Infrastructure\Invite\InviteHttpClient:
+    arguments:
+      $host: '%env(string:invite_host)%'
+      $path: '/api/external/v1'
+      $username: '%env(string:invite_api_username)%'
+      $password: '%env(string:invite_api_password)%'

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -520,7 +520,6 @@ teams.management.table.actions.resend.invite: Resend invitation
 teams.management.table.actions.delete.invite: Delete invitation
 teams.management.table.actions.delete.membership: Delete membership
 teams.create.description: "Members of this team have access to SP %teamName% via the SP Dashboard (sp.surfconext.nl) and can add/manage their entities on the SURFconext platform."
-teams.create.personalNote: Team created by SP Dashboard.
 teams.create.invitationMessage: Please accept this invitation by logging in with your institutional account or eduID account (create one at eduID.nl).
 
 mail.jira.publish_production_failed.subject: 'SP Dashboard: Jira issue creation failed'
@@ -541,3 +540,5 @@ entity.add.template.title.tooltip.srText: What does this mean?
 entity.add.template.title.tooltip.text: <p>If you select an existing entity as the basis for your new entity, its data will be copied into the new entity.  That way you can avoid filling in a lot of duplicate info.  <strong>Do make sure you check all metadata to ensure it's correct for the new entity!</strong></p>
 entity.add.create: Create
 entity.add.cancel: Cancel
+
+invite.role_create.description: "SPdashboard access for the service %serviceName% of %organisationName%"

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/HttpClient/Exceptions/RuntimeException/InviteException.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/HttpClient/Exceptions/RuntimeException/InviteException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException;
+
+class InviteException extends RuntimeException
+{
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Invite/InviteHttpClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Invite/InviteHttpClient.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\Invite;
+
+use SensitiveParameter;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class InviteHttpClient
+{
+
+    private HttpClientInterface $httpClient;
+
+    public function __construct(
+        string $host,
+        string $path,
+        string $username,
+        #[SensitiveParameter]  string $password,
+    ) {
+        $options = [
+            'auth_basic' => [$username, $password],
+
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
+            ],
+        ];
+
+        $this->httpClient = HttpClient::createForBaseUri(
+            $host . $path,
+            $options
+        );
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     */
+    public function post(string $path, array $payload): ResponseInterface
+    {
+        return $this->httpClient->request(
+            'POST',
+            $path,
+            ['json' => $payload],
+        );
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Invite/InviteRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Invite/InviteRepository.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\Invite;
+
+use Psr\Log\LoggerInterface;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\InviteRepository as InviteRepositoryInterface;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\CreateRoleResponse;
+use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\InviteException;
+use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\RuntimeException;
+
+readonly class InviteRepository implements InviteRepositoryInterface
+{
+    public function __construct(
+        private InviteHttpClient $client,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InviteException
+     */
+    public function createRole(
+        string $name,
+        string $shortName,
+        string $description,
+        string $landingPage,
+        string $manageId,
+    ): CreateRoleResponse {
+        $team = $this->createPayload($name, $shortName, $description, $landingPage, $manageId);
+
+        try {
+            $this->logger->info(sprintf('Creating new role \'%s\' in invite', $name));
+
+            $response = $this->client->post('/internal/invite/roles', $team);
+            return (new InviteResponseFactory)->createFromResponse($response, $name);
+        } catch (RuntimeException $e) {
+            $this->logger->error(get_class($e) . ': ' . $e->getMessage());
+            throw new InviteException(
+                $e->getMessage(),
+                0,
+                $e
+            );
+        }
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function createPayload(
+        string $name,
+        string $shortName,
+        string $description,
+        string $landingPage,
+        string $manageId,
+    ): array {
+        return [
+            "name" => $name,
+            "shortName" => $shortName,
+            "description" => $description,
+            "defaultExpiryDays" => 365,
+            "applicationUsages" => [
+                [
+                    "landingPage" => $landingPage,
+                    "application" => [
+                        "manageId" => $manageId,
+                        "manageType" => "SAML20_SP"
+                    ]
+                ]
+            ]
+        ];
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Invite/InviteResponseFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Invite/InviteResponseFactory.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\Invite;
+
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\CreateRoleResponse;
+use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\InviteException;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class InviteResponseFactory
+{
+
+    public function createFromResponse(ResponseInterface $response, string $name): CreateRoleResponse
+    {
+        if ($response->getStatusCode() === Response::HTTP_CONFLICT) {
+            throw new InviteException(
+                sprintf('The name "%s" already exists, please use a unique name.', $name)
+            );
+        }
+
+        try {
+            if ($response->getStatusCode() === Response::HTTP_BAD_REQUEST) {
+                throw new InviteException(
+                    sprintf('Unable to create role for %s in invite due to a bad request.', $name)
+                );
+            }
+            if ($response->getStatusCode() !== Response::HTTP_CREATED) {
+                throw new InviteException(
+                    sprintf('Unable to create role for %s in invite. Error code "%s"', $name, $response->getStatusCode())
+                );
+            }
+            if (!$this->isValidCreateResponse($response)) {
+                throw new InviteException(
+                    sprintf('Unable to create role for %s in invite, invalid response', $name)
+                );
+            }
+
+            $data = $response->toArray();
+
+            return new CreateRoleResponse($data['id'], $data['name'], $data['shortName'], $data['description'], $data['urn']);
+        } catch (TransportExceptionInterface $e) {
+            throw new InviteException(
+                sprintf('Unable to create role for %s in invite due to a transport error', $name)
+            );
+        } catch (ClientExceptionInterface|DecodingExceptionInterface|RedirectionExceptionInterface|ServerExceptionInterface $e) {
+            throw new InviteException(
+                sprintf('Unable to create role for %s in invite. Could not parse response.', $name)
+            );
+        }
+    }
+
+    private function isValidCreateResponse(ResponseInterface $response): bool
+    {
+        $data = $response->toArray();
+
+        if (!isset($data['urn'], $data['id'])) {
+            return false;
+        }
+
+        if (trim($data['urn']) === '') {
+            return false;
+        }
+
+        if ($data['id'] < 0) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Teams/Client/PublishEntityClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Teams/Client/PublishEntityClient.php
@@ -22,9 +22,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use Psr\Log\LoggerInterface;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\PublishTeamsRepository as PublishTeamsRepositoryInterface;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\HttpException\HttpException;
-use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\ChangeMembershipRoleException
-    as ChangeMembershipRoleException;
-use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\CreateTeamsException;
+use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\ChangeMembershipRoleException;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\ResendInviteException;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\RuntimeException;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\SendInviteException;
@@ -36,35 +34,6 @@ class PublishEntityClient implements PublishTeamsRepositoryInterface
         private readonly HttpClient $client,
         private readonly LoggerInterface $logger,
     ) {
-    }
-
-    /**
-     * @throws CreateTeamsException
-     */
-    public function createTeam(array $team): mixed
-    {
-        try {
-            $this->logger->info(sprintf('Creating new team \'%s\' in teams', $team['name']));
-
-            $response = $this->client->post(
-                json_encode($team),
-                '/api/spdashboard/teams'
-            );
-
-            if (!isset($response['id'])) {
-                throw new CreateTeamsException(
-                    sprintf('Unable to create a team for %s in teams', $team['name'])
-                );
-            }
-
-            return $response;
-        } catch (HttpException|GuzzleException|RuntimeException $e) {
-            throw new CreateTeamsException(
-                sprintf('Unable to create a team for %s in teams', $team['name']),
-                0,
-                $e
-            );
-        }
     }
 
     /**

--- a/tests/unit/Infrastructure/Invite/InviteRepositoryTest.php
+++ b/tests/unit/Infrastructure/Invite/InviteRepositoryTest.php
@@ -1,0 +1,165 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\Invite;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\InviteException;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Invite\InviteHttpClient;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Invite\InviteRepository;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class InviteRepositoryTest extends TestCase
+{
+    private InviteRepository $repository;
+    private InviteHttpClient $httpClient;
+
+    protected function setUp(): void
+    {
+        $this->httpClient = $this->createMock(InviteHttpClient::class);
+        $this->repository = new InviteRepository($this->httpClient, new NullLogger());
+    }
+
+    public function testSuccessfulRoleCreation(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(Response::HTTP_CREATED);
+        $response->method('toArray')->willReturn([
+            'id' => '123',
+            'name' => 'Test Role',
+            'shortName' => 'test-role',
+            'description' => 'Test Description',
+            'urn' => 'urn:test:role'
+        ]);
+
+        $this->httpClient
+            ->expects($this->once())
+            ->method('post')
+            ->with(
+                '/internal/invite/roles',
+                $this->callback(function ($payload) {
+                    return $payload['name'] === 'Test Role' &&
+                        $payload['shortName'] === 'test-role' &&
+                        $payload['description'] === 'Test Description';
+                })
+            )
+            ->willReturn($response);
+
+        $result = $this->repository->createRole(
+            'Test Role',
+            'test-role',
+            'Test Description',
+            'https://example.com',
+            'manage-id-123'
+        );
+
+        $this->assertEquals('123', $result->id);
+        $this->assertEquals('Test Role', $result->name);
+        $this->assertEquals('test-role', $result->shortName);
+        $this->assertEquals('Test Description', $result->description);
+        $this->assertEquals('urn:test:role', $result->urn);
+    }
+
+    public function testConflictThrowsException(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(Response::HTTP_CONFLICT);
+
+        $this->httpClient
+            ->method('post')
+            ->willReturn($response);
+
+        $this->expectException(InviteException::class);
+        $this->expectExceptionMessage('The name "Test Role" already exists, please use a unique name.');
+
+        $this->repository->createRole(
+            'Test Role',
+            'test-role',
+            'Test Description',
+            'https://example.com',
+            'manage-id-123'
+        );
+    }
+
+    public function testBadRequestThrowsException(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(Response::HTTP_BAD_REQUEST);
+
+        $this->httpClient
+            ->method('post')
+            ->willReturn($response);
+
+        $this->expectException(InviteException::class);
+        $this->expectExceptionMessage('Unable to create role for Test Role in invite due to a bad request.');
+
+        $this->repository->createRole(
+            'Test Role',
+            'test-role',
+            'Test Description',
+            'https://example.com',
+            'manage-id-123'
+        );
+    }
+
+    public function testUnexpectedStatusCodeThrowsException(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(Response::HTTP_INTERNAL_SERVER_ERROR);
+
+        $this->httpClient
+            ->method('post')
+            ->willReturn($response);
+
+        $this->expectException(InviteException::class);
+        $this->expectExceptionMessage('Unable to create role for Test Role in invite. Error code "500"');
+
+        $this->repository->createRole(
+            'Test Role',
+            'test-role',
+            'Test Description',
+            'https://example.com',
+            'manage-id-123'
+        );
+    }
+
+    public function testInvalidResponseDataThrowsException(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(Response::HTTP_CREATED);
+        $response->method('toArray')->willReturn(['invalid' => 'response']);
+
+        $this->httpClient
+            ->method('post')
+            ->willReturn($response);
+
+        $this->expectException(InviteException::class);
+        $this->expectExceptionMessage('Unable to create role for Test Role in invite, invalid response');
+
+        $this->repository->createRole(
+            'Test Role',
+            'test-role',
+            'Test Description',
+            'https://example.com',
+            'manage-id-123'
+        );
+    }
+}

--- a/tests/unit/Infrastructure/Teams/Client/TeamsPublishEntityClientTest.php
+++ b/tests/unit/Infrastructure/Teams/Client/TeamsPublishEntityClientTest.php
@@ -22,7 +22,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\ChangeMembershipRoleException;
-use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\CreateTeamsException;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\ResendInviteException;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\SendInviteException;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Teams\Client\PublishEntityClient;
@@ -64,32 +63,6 @@ class TeamsPublishEntityClientTest extends MockeryTestCase
             ),
             $this->logger
         );
-    }
-
-    /**
-     * @throws CreateTeamsException
-     */
-    public function testItCanCreateATeam()
-    {
-        $team = [
-            "name" => "Champions ",
-            "description" => "Team champions",
-            "personalNote" => "Team created by SP Dashboard",
-            "viewable" => true,
-            "emails" => [
-                "test@test.com" => "ADMIN"
-            ],
-            "roleOfCurrentUser" => "ADMIN",
-            "invitationMessage" => "Please..",
-            "language" => "DUTCH"
-        ];
-
-        $json = file_get_contents(__DIR__ . '/fixture/team.json');
-        $this->mockHandler->append(new Response(201, [], $json));
-        $this->logger->shouldReceive('info');
-
-        $response = $this->client->createTeam($team);
-        $this->assertEquals(json_decode($json, true), $response);
     }
 
     /**

--- a/tests/webtests/EditServiceTest.php
+++ b/tests/webtests/EditServiceTest.php
@@ -63,6 +63,7 @@ class EditServiceTest extends WebTestCase
         $this->switchToService('SURFnet');
 
         $crawler = self::$pantherClient->request('GET', '/service/1/edit');
+        self::$pantherClient->waitForVisibility('.service-form', 5);
 
         // Step 1: Admin sets privacy questions enabled to false
         $formData = [

--- a/tests/webtests/Manage/Client/FakeInviteRepository.php
+++ b/tests/webtests/Manage/Client/FakeInviteRepository.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Webtests\Manage\Client;
+
+use RuntimeException;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
+use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\InviteRepository;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\PublishEntityRepository as PublishEntityRepositoryInterface;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\CreateRoleResponse;
+use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\InviteException;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Uid\Uuid;
+
+class FakeInviteRepository implements InviteRepository
+{
+    private string $path = __DIR__ . '/../../../../var/webtest-invite-repository.json';
+
+    public function reset()
+    {
+        $this->write([]);
+
+        // This code is run as root in the container by the test runner.
+        // But when the webtest submits the form, the php process is owned by the www-data user.
+        // So the www-data user needs write access to the fixture database
+        exec(sprintf('chgrp www-data %s', realpath($this->path)));
+        exec(sprintf('chmod g+w %s', realpath($this->path)));
+    }
+
+    public function registerPublishResponse(string $entityId, string $response)
+    {
+        $data = $this->read();
+        if(isset($data[$entityId])){
+            $responseArray = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+            throw new InviteException(
+                sprintf('The name "%s" already exists, please use a unique name.', $responseArray['name'])
+            );
+        }
+        $data[$entityId] = $response;
+        $this->write($data);
+    }
+
+
+    public function createRole(
+        string $name,
+        string $shortName,
+        string $description,
+        string $landingPage,
+        string $manageId,
+    ): CreateRoleResponse {
+        $uuid = Uuid::v4()->toRfc4122();
+
+        $data = $this->responseTemplate();
+        $data['urn'] = 'urn:mace:surf.nl:test.surfaccess.nl:'.$uuid.':required_role_name';
+        $data['identifier'] = $uuid;
+
+        $this->registerPublishResponse($manageId, json_encode($data, JSON_THROW_ON_ERROR));
+
+
+        return new CreateRoleResponse($data['id'], $data['name'], $data['shortName'], $data['description'], $data['urn']);
+    }
+
+    private function read()
+    {
+        return json_decode(file_get_contents($this->path), true);
+    }
+
+    private function write(array $data): void
+    {
+        file_put_contents($this->path, json_encode($data));
+    }
+
+    private function responseTemplate(){
+        return json_decode(
+            file_get_contents(__DIR__ . '/../../fixtures/invite-role-create.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+    }
+}

--- a/tests/webtests/Resources/config/services.yml
+++ b/tests/webtests/Resources/config/services.yml
@@ -67,6 +67,25 @@ services:
         class: Surfnet\ServiceProviderDashboard\Webtests\Manage\Client\FakePublishEntityClient
         public: true
 
+    surfnet.dashboard.command_handler.create_service:
+        class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Service\CreateServiceCommandHandler
+        public: true
+        tags:
+            - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Service\CreateServiceCommand }
+        arguments:
+            $serviceRepository: '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository\ServiceRepository'
+            $translator: '@identity_translator'
+            $prefixPart1: '%env(team_prefix_default_stem_name)%'
+            $prefixPart2: '%env(team_prefix_group_name_context)%'
+            $inviteRepository: '@Surfnet\ServiceProviderDashboard\Webtests\Manage\Client\FakeInviteRepository'
+            $landingUrl: '%env(invite_landing_url)%'
+
+    Surfnet\ServiceProviderDashboard\Webtests\Manage\Client\FakeInviteRepository:
+
+    Surfnet\ServiceProviderDashboard\Domain\Repository\InviteRepository:
+        class: Surfnet\ServiceProviderDashboard\Webtests\Manage\Client\FakeInviteRepository
+        public: true
+
     surfnet.manage.client.delete_client.prod_environment:
         class: Surfnet\ServiceProviderDashboard\Webtests\Manage\Client\FakeDeleteManageEntityClient
         public: true

--- a/tests/webtests/ServiceCreateTest.php
+++ b/tests/webtests/ServiceCreateTest.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Webtests;
 
+use Facebook\WebDriver\WebDriverBy;
 use Symfony\Component\Uid\Uuid;
 
 class ServiceCreateTest extends WebTestCase
@@ -59,4 +60,21 @@ class ServiceCreateTest extends WebTestCase
         $services = $this->getServiceRepository()->findAll();
         $this->assertCount(4, $services);
     }
+
+    public function test_shows_correct_error_if_role_exists_in_invite()
+    {
+        $this->inviteRepository->createRole('New Service #1 New Service #1', 'New Service #1 New Service #1', '', '', '4b0e422d-d0d0-4b9e-a521-fdd1ee5d2bad');
+
+        $crawler = self::$pantherClient->request('GET', '/service/create');
+
+        $form = $crawler->findElement(WebDriverBy::cssSelector('form[name="dashboard_bundle_service_type"]'));
+        $this->fillFormField($form, '#dashboard_bundle_service_type_general_name', 'New Service #1');
+        $this->fillFormField($form, '#dashboard_bundle_service_type_general_organizationNameNl', 'Nieuwe Service #1');
+        $this->fillFormField($form, '#dashboard_bundle_service_type_general_organizationNameEn', 'New Service #1');
+        $this->fillFormField($form, '#dashboard_bundle_service_type_general_guid', 'f59100e1-4232-4646-8ac5-50f3c2bc32a3');
+        $this->fillFormField($form, '#dashboard_bundle_service_type_teams_teamManagerEmail', 'mail@example.org');
+        $form->submit();
+        $this->assertOnPage('The name "Demo role name" already exists, please use a unique name.');
+    }
+
 }

--- a/tests/webtests/WebTestCase.php
+++ b/tests/webtests/WebTestCase.php
@@ -35,6 +35,7 @@ use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\DeleteManageEntityRepository;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\IdentityProviderRepository;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\InviteRepository;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\PublishEntityRepository;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\QueryManageRepository;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\QueryTeamsRepository;
@@ -85,6 +86,8 @@ class WebTestCase extends PantherTestCase
      * @var DeleteManageEntityRepository
      */
     protected $testDeleteClient;
+
+    protected InviteRepository $inviteRepository;
 
     /** @var QueryTeamsRepository&FakeTeamsQueryClient */
     protected $teamsQueryClient;
@@ -172,6 +175,10 @@ class WebTestCase extends PantherTestCase
             ->getParameter('surfnet.dashboard.security.authentication.authorization_attribute_name');
         $this->surfConextRepresentativeAttributeValue = self::getContainer()
             ->getParameter('surfnet.dashboard.security.authentication.surfconext_representative_authorization');
+
+        $this->inviteRepository = self::getContainer()
+            ->get(InviteRepository::class);
+        $this->inviteRepository->reset();
     }
 
     protected function registerManageEntity(

--- a/tests/webtests/fixtures/invite-role-create.json
+++ b/tests/webtests/fixtures/invite-role-create.json
@@ -1,0 +1,44 @@
+{
+  "id": 42114,
+  "name": "Demo role name",
+  "shortName": "required_role_name",
+  "description": "Required role description",
+  "urn": "urn:mace:surf.nl:test.surfaccess.nl:74fd8059-7558-4454-8393-fd84f74c4907:required_role_name",
+  "defaultExpiryDays": 365,
+  "enforceEmailEquality": false,
+  "eduIDOnly": false,
+  "blockExpiryDate": false,
+  "overrideSettingsAllowed": false,
+  "teamsOrigin": false,
+  "identifier": "74fd8059-7558-4454-8393-fd84f74c4907",
+  "remoteApiUser": "SP Dashboard",
+  "applicationUsages": [
+    {
+      "id": 49203,
+      "landingPage": "http://landingpage.com",
+      "application": {
+        "id": 41904,
+        "manageId": "4",
+        "manageType": "SAML20_SP"
+      }
+    }
+  ],
+  "auditable": {
+    "createdAt": 1729254283,
+    "createdBy": "sp_dashboard"
+  },
+  "applicationMaps": [
+    {
+      "OrganizationName:en": "SURF bv",
+      "landingPage": "http://landingpage.com",
+      "logo": "https://static.surfconext.nl/media/idp/surfconext.png",
+      "entityid": "https://research",
+      "name:en": "Research EN",
+      "id": "4",
+      "_id": "4",
+      "type": "saml20_sp",
+      "url": "https://default-url-research.org",
+      "name:nl": "Research NL"
+    }
+  ]
+}


### PR DESCRIPTION
Prior to this change, the Service was registered in teams, which is going to be removed.
This change registers the Service as a role in Invite, so an invite can be sent later.

See https://www.pivotaltracker.com/story/show/188011488