### PR TITLE
When webtest fails, upload a screenshot of the error to github actions.

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -11,3 +11,4 @@ jira_test_mode_storage_path='/var/www/html/var/issues.json'
 authorization_attribute_name='eduPersonEntitlement'
 surfconext_representative_authorization='urn:mace:surfnet.nl:surfnet.nl:sab:role:SURFconext-verantwoordelijke'
 test_idp_entity_ids='["http://mock-idp","test-idp-1"]'
+PANTHER_ERROR_SCREENSHOT_DIR="./var/error-screenshots"

--- a/.github/workflows/test-integration-webtest.yml
+++ b/.github/workflows/test-integration-webtest.yml
@@ -58,3 +58,11 @@ jobs:
         working-directory: spdashboard
         run: |
           ${DOCKER_COMPOSE_PHP} sh -c 'composer webtest'
+
+      - name: Upload error screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: error-screenshots
+          path: spdashboard/var/error-screenshots
+          retention-days: 2


### PR DESCRIPTION
Example output:
https://github.com/SURFnet/sp-dashboard/actions/runs/11608163793