### PR TITLE
After creating a Service, send an Invite through invite

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/CreateServiceCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/CreateServiceCommand.php
@@ -30,6 +30,8 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 class CreateServiceCommand implements Command
 {
+    private ?int $serviceId = null;
+
     /**
      * @var string
      */
@@ -269,5 +271,15 @@ class CreateServiceCommand implements Command
     public function setTeamManagerEmail(string $teamManagerEmail): void
     {
         $this->teamManagerEmail = $teamManagerEmail;
+    }
+
+    public function getServiceId(): ?int
+    {
+        return $this->serviceId;
+    }
+
+    public function setServiceId(int $serviceId): void
+    {
+        $this->serviceId = $serviceId;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/SendInviteCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/SendInviteCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\Command\Service;
+
+use Surfnet\ServiceProviderDashboard\Application\Command\Command;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class SendInviteCommand implements Command
+{
+    public function __construct(
+        #[Assert\NotBlank]
+        #[Assert\Email]
+        public readonly string $email,
+        #[Assert\NotBlank]
+        public readonly string $message,
+        #[Assert\Choice(choices: ["en"])]
+        public readonly string $language,
+        public readonly int $roleIdentifier,
+    ) {
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/CreateServiceCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/CreateServiceCommandHandler.php
@@ -23,7 +23,7 @@ namespace Surfnet\ServiceProviderDashboard\Application\CommandHandler\Service;
 use Surfnet\ServiceProviderDashboard\Application\Command\Service\CreateServiceCommand;
 use Surfnet\ServiceProviderDashboard\Application\CommandHandler\CommandHandler;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
-use Surfnet\ServiceProviderDashboard\Domain\Repository\InviteRepository;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\Invite\CreateRoleRepository;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\ServiceRepository;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -31,7 +31,7 @@ class CreateServiceCommandHandler implements CommandHandler
 {
     public function __construct(
         private readonly ServiceRepository $serviceRepository,
-        private readonly InviteRepository $inviteRepository,
+        private readonly CreateRoleRepository $inviteRepository,
         private readonly TranslatorInterface $translator,
         private readonly string $prefixPart1,
         private readonly string $prefixPart2,
@@ -81,5 +81,6 @@ class CreateServiceCommandHandler implements CommandHandler
         $service->registerInvite($response->urn, $response->id);
 
         $this->serviceRepository->save($service);
+        $command->setServiceId($service->getId());
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/SendInviteCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Service/SendInviteCommandHandler.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Application\CommandHandler\Service;
+
+use Psr\Log\LoggerInterface;
+use Surfnet\ServiceProviderDashboard\Application\Command\Service\SendInviteCommand;
+use Surfnet\ServiceProviderDashboard\Application\CommandHandler\CommandHandler;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\Invite\SendInviteRepository;
+use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\InviteException;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class SendInviteCommandHandler implements CommandHandler
+{
+    public function __construct(
+        private readonly SendInviteRepository $sendInviteRepository,
+        private readonly ValidatorInterface $validator,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InviteException
+     */
+    public function handle(SendInviteCommand $command): void
+    {
+        $result = $this->validator->validate($command);
+
+        if ($result->count() > 0) {
+            $message = sprintf('Could not create invite, validation failed: %s', $result->get(0)->getMessage());
+            $this->logger->error($message);
+            throw new InviteException($message);
+        }
+
+        $this->sendInviteRepository->sendInvite(
+            $command->email,
+            $command->message,
+            $command->language,
+            $command->roleIdentifier,
+        );
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Repository/Invite/CreateRoleRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Repository/Invite/CreateRoleRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Surfnet\ServiceProviderDashboard\Domain\Repository\Invite;
+
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\CreateRoleResponse;
+use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\InviteException;
+
+interface CreateRoleRepository
+{
+    /**
+     * @throws InviteException
+     */
+    public function createRole(
+        string $name,
+        string $shortName,
+        string $description,
+        string $landingPage,
+        string $manageId,
+    ): CreateRoleResponse;
+}

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Repository/Invite/SendInviteRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Repository/Invite/SendInviteRepository.php
@@ -15,21 +15,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-namespace Surfnet\ServiceProviderDashboard\Domain\Repository;
+namespace Surfnet\ServiceProviderDashboard\Domain\Repository\Invite;
 
-use Surfnet\ServiceProviderDashboard\Domain\ValueObject\CreateRoleResponse;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\SendInviteResponse;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\InviteException;
 
-interface InviteRepository
+interface SendInviteRepository
 {
     /**
      * @throws InviteException
      */
-    public function createRole(
-        string $name,
-        string $shortName,
-        string $description,
-        string $landingPage,
-        string $manageId,
-    ): CreateRoleResponse;
+    public function sendInvite(
+        string $email,
+        string $message,
+        string $language,
+        int $roleIdentifier,
+    ): SendInviteResponse;
 }

--- a/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/SendInviteResponse.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/ValueObject/SendInviteResponse.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Surfnet\ServiceProviderDashboard\Domain\ValueObject;
+
+class SendInviteResponse
+{
+    public function __construct(
+        public readonly string $recipient,
+        public readonly string $invitationURL,
+    ) {
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Repository/ServiceRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Repository/ServiceRepository.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository;
 
+use Doctrine\DBAL\Exception;
 use Doctrine\ORM\EntityRepository as DoctrineEntityRepository;
 use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -22,8 +22,17 @@ services:
     arguments:
       $prefixPart1: '%env(team_prefix_default_stem_name)%'
       $prefixPart2: '%env(team_prefix_group_name_context)%'
-      $inviteRepository: '@Surfnet\ServiceProviderDashboard\Infrastructure\Invite\InviteRepository'
+      $inviteRepository: '@Surfnet\ServiceProviderDashboard\Infrastructure\Invite\CreateRoleRepository'
       $landingUrl: '%env(invite_landing_url)%'
+
+  Surfnet\ServiceProviderDashboard\Application\CommandHandler\Service\SendInviteCommandHandler:
+    autowire: true
+    tags:
+      - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Service\CreateServiceCommand }
+    arguments:
+      $sendInviteRepository: '@Surfnet\ServiceProviderDashboard\Infrastructure\Invite\SendInviteRepository'
+
+  Surfnet\ServiceProviderDashboard\Infrastructure\Invite\SendInviteRepository:
 
   surfnet.dashboard.command_handler.delete_service:
     class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Service\DeleteServiceCommandHandler
@@ -71,7 +80,6 @@ services:
 
   surfnet.dashboard.command_handler.load_metadata:
     class: Surfnet\ServiceProviderDashboard\Application\CommandHandler\Entity\LoadMetadataCommandHandler
-    public: true
     arguments:
       - '@Surfnet\ServiceProviderDashboard\Application\Service\AttributeNameService'
       - '@Surfnet\ServiceProviderDashboard\Legacy\Metadata\Fetcher'
@@ -466,6 +474,7 @@ services:
       $defaultStemName: '%env(team_prefix_default_stem_name)%'
       $logger: '@logger'
       $manageId: '%env(spdashboard_manage_id)%'
+      $inviteUrl: '%env(string:invite_host)%'
 
   Surfnet\ServiceProviderDashboard\Infrastructure\Teams\TeamsClient:
     arguments:
@@ -683,7 +692,7 @@ services:
       $identityProviderRepository: '@surfnet.manage.client.identity_provider_client.test_environment'
 
 
-  Surfnet\ServiceProviderDashboard\Infrastructure\Invite\InviteRepository:
+  Surfnet\ServiceProviderDashboard\Infrastructure\Invite\CreateRoleRepository:
 
   Surfnet\ServiceProviderDashboard\Infrastructure\Invite\InviteHttpClient:
     arguments:

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -399,6 +399,7 @@ service.create.description: "Members of this team have access to SP %Name% via t
 service.create.personalNote: "Team created by SP Dashboard"
 service.create.invitationMessage: "Please accept this invitation by logging in with your institutional account or eduID account (create one at eduID.nl)."
 service.create.flash.success: "Your service was added successfully."
+service.create-invite-flash.failed: "The service and role have been created. However, the creation of the admin membership failed. Please proceed to %inviteDeeplink% to proceed and invite the administrator"
 service.edit.title: Edit service
 service.edit.flash.success: "Your changes were saved!"
 service.delete.title: "Delete service"

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Invite/CreateRoleRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Invite/CreateRoleRepository.php
@@ -19,12 +19,12 @@
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\Invite;
 
 use Psr\Log\LoggerInterface;
-use Surfnet\ServiceProviderDashboard\Domain\Repository\InviteRepository as InviteRepositoryInterface;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\Invite\CreateRoleRepository as InviteRepositoryInterface;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\CreateRoleResponse;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\InviteException;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\RuntimeException;
 
-readonly class InviteRepository implements InviteRepositoryInterface
+readonly class CreateRoleRepository implements InviteRepositoryInterface
 {
     public function __construct(
         private InviteHttpClient $client,
@@ -60,7 +60,7 @@ readonly class InviteRepository implements InviteRepositoryInterface
     }
 
     /**
-     * @return array<mixed>
+     * @return array<string,mixed>
      */
     private function createPayload(
         string $name,

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Invite/SendInviteRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Invite/SendInviteRepository.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\Invite;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use Psr\Log\LoggerInterface;
+use \Surfnet\ServiceProviderDashboard\Domain\Repository\Invite\SendInviteRepository as SendInviteRepositoryInterface;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\SendInviteResponse;
+use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\InviteException;
+use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\RuntimeException;
+
+readonly class SendInviteRepository implements SendInviteRepositoryInterface
+{
+    public function __construct(
+        private InviteHttpClient $client,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InviteException
+     */
+    public function sendInvite(
+        string $email,
+        string $message,
+        string $language,
+        int $roleIdentifier,
+    ): SendInviteResponse {
+        $expiryDate = new DateTimeImmutable("+14 days");
+
+        $team = $this->createSendInvitePayload(
+            $email,
+            $message,
+            $language,
+            $roleIdentifier,
+            $expiryDate,
+        );
+
+        try {
+            $this->logger->info(sprintf('Creating new role \'%s\' in invite', $email));
+
+            $response = $this->client->post('/internal/invite/invitations', $team);
+            return (new SendInviteResponseFactory())->createFromSendInviteResponse($response, $email);
+        } catch (RuntimeException $e) {
+            $this->logger->error(get_class($e) . ': ' . $e->getMessage());
+            throw new InviteException(
+                $e->getMessage(),
+                0,
+                $e
+            );
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function createSendInvitePayload(
+        string $email,
+        string $message,
+        string $language,
+        int $roleIdentifier,
+        DateTimeInterface $expiryDate,
+    ): array {
+
+        return [
+            'intendedAuthority' => 'INVITER',
+            'message' => $message,
+            'language' => $language,
+            'guestRoleIncluded' => true,
+            'invites' => [
+                $email,
+            ],
+            'roleIdentifiers' => [
+                $roleIdentifier,
+            ],
+            'expiryDate' => $expiryDate->getTimestamp(),
+            ];
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Invite/SendInviteResponseFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Invite/SendInviteResponseFactory.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\Invite;
+
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\CreateRoleResponse;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\SendInviteResponse;
+use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\InviteException;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class SendInviteResponseFactory
+{
+    public function createFromSendInviteResponse(ResponseInterface $response, string $name): SendInviteResponse
+    {
+        try {
+            if ($response->getStatusCode() === Response::HTTP_NOT_FOUND) {
+                throw new InviteException(
+                    sprintf('Unable to send invite. Role "%s" not found in Invite.', $name)
+                );
+            }
+
+            if ($response->getStatusCode() === Response::HTTP_BAD_REQUEST) {
+                throw new InviteException(
+                    sprintf('Unable to send invite for "%s". Bad request.', $name)
+                );
+            }
+
+            if ($response->getStatusCode() !== Response::HTTP_CREATED) {
+                throw new InviteException(
+                    sprintf('Unable to send invite for %s. Error code "%s"', $name, $response->getStatusCode())
+                );
+            }
+            if (!$this->isValidSendInviteResponse($response)) {
+                throw new InviteException(
+                    sprintf('Unable to send invite for %s, invalid response', $name)
+                );
+            }
+
+            $data = $response->toArray();
+
+            return new SendInviteResponse($data['recipientInvitationURLs'][0]['recipient'], $data['recipientInvitationURLs'][0]['invitationURL']);
+        } catch (TransportExceptionInterface $e) {
+            throw new InviteException(
+                sprintf('Unable to send invite for %s due to a transport error', $name)
+            );
+        } catch (ClientExceptionInterface|DecodingExceptionInterface|RedirectionExceptionInterface|ServerExceptionInterface $e) {
+            throw new InviteException(
+                sprintf('Unable to send invite for %s. Could not parse response.', $name)
+            );
+        }
+    }
+
+    private function isValidSendInviteResponse(ResponseInterface $response): bool
+    {
+        $data = $response->toArray();
+
+        if (!isset($data['recipientInvitationURLs'][0])) {
+            return false;
+        }
+
+        $urls = $data['recipientInvitationURLs'][0];
+
+        return is_string($urls['recipient']) && is_string($urls['invitationURL']);
+    }
+}

--- a/tests/integration/Application/Command/SendInviteCommandTest.php
+++ b/tests/integration/Application/Command/SendInviteCommandTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Integration\Application\CommandHandler\Service;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Surfnet\ServiceProviderDashboard\Application\Command\Service\SendInviteCommand;
+use Surfnet\ServiceProviderDashboard\Application\CommandHandler\Service\SendInviteCommandHandler;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\Invite\SendInviteRepository;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class SendInviteCommandTest extends MockeryTestCase
+{
+
+    private ValidatorInterface $validator;
+
+    public function setUp(): void
+    {
+        $this->validator = Validation::createValidatorBuilder()
+            ->enableAttributeMapping()
+            ->getValidator();
+    }
+
+    public function testInvalidEmail(): void
+    {
+        $command = new SendInviteCommand(
+            'invalid-email',
+            'Test message',
+            'en',
+            1,
+        );
+        $violations = $this->validator->validate($command);
+
+        $this->assertCount(1, $violations);
+        $this->assertEquals('This value is not a valid email address.', $violations[0]->getMessage());
+    }
+
+    public function testBlankEmail(): void
+    {
+        $command = new SendInviteCommand(
+            '',
+            'Test message',
+            'en',
+            1,
+        );
+        $violations = $this->validator->validate($command);
+
+        $this->assertCount(1, $violations);
+        $this->assertEquals('This value should not be blank.', $violations[0]->getMessage());
+    }
+
+    public function testValidCommand(): void
+    {
+        $command = new SendInviteCommand(
+            'test@example.com',
+            'Test message',
+            'en',
+            1,
+        );
+
+        $violations = $this->validator->validate($command);
+        $this->assertCount(0, $violations);
+    }
+
+    public function testBlankMessage(): void
+    {
+        $command = new SendInviteCommand(
+            'test@example.com',
+            '',
+            'en',
+            1,
+        );
+
+        $violations = $this->validator->validate($command);
+        $this->assertCount(1, $violations);
+        $this->assertEquals('message', $violations[0]->getPropertyPath());
+    }
+
+    public function testInvalidLanguage(): void
+    {
+        $command = new SendInviteCommand(
+            'test@example.com',
+            'Test message',
+            'fr',
+            1,
+        );
+
+        $violations = $this->validator->validate($command);
+        $this->assertCount(1, $violations);
+        $this->assertEquals('language', $violations[0]->getPropertyPath());
+    }
+}

--- a/tests/integration/Application/CommandHandler/Service/SendInviteCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Service/SendInviteCommandHandlerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Integration\Application\CommandHandler\Service;
+
+use DateTime;
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Psr\Log\NullLogger;
+use Surfnet\ServiceProviderDashboard\Application\Command\Service\SendInviteCommand;
+use Surfnet\ServiceProviderDashboard\Application\CommandHandler\Service\SendInviteCommandHandler;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\Invite\SendInviteRepository;
+use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\InviteException;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class SendInviteCommandHandlerTest extends MockeryTestCase
+{
+
+    private SendInviteCommandHandler $commandHandler;
+
+    private TranslatorInterface $translator;
+
+    private ValidatorInterface $validator;
+
+    public function setUp(): void
+    {
+        $inviteRepository = m::mock(SendInviteRepository::class);
+        $this->translator = m::mock(TranslatorInterface::class);
+
+        $this->validator = Validation::createValidatorBuilder()
+            ->enableAttributeMapping()
+            ->getValidator();
+
+        $this->commandHandler = new SendInviteCommandHandler(
+            $inviteRepository,
+            $this->validator,
+            new NullLogger(),
+        );
+    }
+
+    public function testValidatesCommand(): void
+    {
+        $command = new SendInviteCommand(
+            'invalid-email',
+            'Test message',
+            'en',
+            1,
+            new DateTime('+1 day'),
+            new DateTime('+1 week')
+        );
+
+        $this->expectException(InviteException::class);
+        $this->expectExceptionMessage('Could not create invite, validation failed: This value is not a valid email address.');
+
+        $this->commandHandler->handle($command);
+    }
+
+}

--- a/tests/unit/Infrastructure/Invite/InviteRepositoryTest.php
+++ b/tests/unit/Infrastructure/Invite/InviteRepositoryTest.php
@@ -23,19 +23,19 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\InviteException;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Invite\InviteHttpClient;
-use Surfnet\ServiceProviderDashboard\Infrastructure\Invite\InviteRepository;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Invite\CreateRoleRepository;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class InviteRepositoryTest extends TestCase
 {
-    private InviteRepository $repository;
+    private CreateRoleRepository $repository;
     private InviteHttpClient $httpClient;
 
     protected function setUp(): void
     {
         $this->httpClient = $this->createMock(InviteHttpClient::class);
-        $this->repository = new InviteRepository($this->httpClient, new NullLogger());
+        $this->repository = new CreateRoleRepository($this->httpClient, new NullLogger());
     }
 
     public function testSuccessfulRoleCreation(): void

--- a/tests/unit/Infrastructure/Invite/SendInviteRepositoryTest.php
+++ b/tests/unit/Infrastructure/Invite/SendInviteRepositoryTest.php
@@ -1,0 +1,162 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\Invite;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\InviteException;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Invite\InviteHttpClient;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Invite\SendInviteRepository;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class SendInviteRepositoryTest extends TestCase
+{
+    private SendInviteRepository $repository;
+    private InviteHttpClient $httpClient;
+
+    private DateTimeImmutable $now;
+
+    protected function setUp(): void
+    {
+        $this->httpClient = $this->createMock(InviteHttpClient::class);
+        $this->repository = new SendInviteRepository($this->httpClient, new NullLogger());
+        $this->now = new DateTimeImmutable();
+    }
+
+    public function testSuccessfulInviteCreation(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(Response::HTTP_CREATED);
+        $response->method('toArray')->willReturn(
+            json_decode(
+                '{
+  "status": 201,
+  "recipientInvitationURLs": [
+    {
+      "recipient": "admin@service.nl",
+      "invitationURL": "https://invite.test.surfconext.nl/invitation/accept?{hash}"
+    }
+  ]
+}',
+                true,
+                512,
+                JSON_THROW_ON_ERROR
+            )
+        );
+
+        $this->httpClient
+            ->expects($this->once())
+            ->method('post')
+            ->with(
+                '/internal/invite/invitations',
+                $this->callback(function ($payload) {
+                    $expectedValues = [
+                        'intendedAuthority' => 'INVITER',
+                        'message' => 'Hallo, message.',
+                        'language' => 'nl',
+                        'guestRoleIncluded' => true,
+                        'invites' => ['admin@service.nl'],
+                        'roleIdentifiers' => [99],
+                    ];
+
+                    foreach ($expectedValues as $key => $value) {
+                        if (!isset($payload[$key]) || $payload[$key] !== $value) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                })
+            )
+            ->willReturn($response);
+
+        $result = $this->repository->sendInvite(
+            'admin@service.nl',
+            'Hallo, message.',
+            'nl',
+            99,
+        );
+
+        $this->assertEquals('admin@service.nl', $result->recipient);
+        $this->assertEquals('https://invite.test.surfconext.nl/invitation/accept?{hash}', $result->invitationURL);
+    }
+
+    public function testBadRequestThrowsException(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(Response::HTTP_BAD_REQUEST);
+
+        $this->httpClient
+            ->method('post')
+            ->willReturn($response);
+
+        $this->expectException(InviteException::class);
+        $this->expectExceptionMessage('Unable to send invite for "admin@service.nl". Bad request.');
+
+        $this->repository->sendInvite(
+            'admin@service.nl',
+            'Hallo, message.',
+            'nl',
+            99,
+        );
+    }
+
+    public function testUnexpectedStatusCodeThrowsException(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(Response::HTTP_INTERNAL_SERVER_ERROR);
+
+        $this->httpClient
+            ->method('post')
+            ->willReturn($response);
+
+        $this->expectException(InviteException::class);
+        $this->expectExceptionMessage('Unable to send invite for admin@service.nl. Error code "500"');
+
+        $this->repository->sendInvite(
+            'admin@service.nl',
+            'Hallo, message.',
+            'nl',
+            99,
+        );
+    }
+
+    public function testInvalidResponseDataThrowsException(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(Response::HTTP_CREATED);
+        $response->method('toArray')->willReturn(['invalid' => 'response']);
+
+        $this->httpClient
+            ->method('post')
+            ->willReturn($response);
+
+        $this->expectException(InviteException::class);
+        $this->expectExceptionMessage('Unable to send invite for admin@service.nl, invalid response');
+
+        $this->repository->sendInvite(
+            'admin@service.nl',
+            'Hallo, message.',
+            'nl',
+            99,
+        );
+    }
+}

--- a/tests/webtests/Manage/Client/FakeCreateRoleRepository.php
+++ b/tests/webtests/Manage/Client/FakeCreateRoleRepository.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Webtests\Manage\Client;
+
+use Surfnet\ServiceProviderDashboard\Domain\Repository\Invite\CreateRoleRepository;
+use Surfnet\ServiceProviderDashboard\Domain\ValueObject\CreateRoleResponse;
+use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\InviteException;
+use Symfony\Component\Uid\Uuid;
+
+class FakeCreateRoleRepository implements CreateRoleRepository
+{
+    private string $path = __DIR__ . '/../../../../var/webtest-invite-repository.json';
+
+    public function reset()
+    {
+        $this->write([]);
+
+        // This code is run as root in the container by the test runner.
+        // But when the webtest submits the form, the php process is owned by the www-data user.
+        // So the www-data user needs write access to the fixture database
+        exec(sprintf('chgrp www-data %s', realpath($this->path)));
+        exec(sprintf('chmod g+w %s', realpath($this->path)));
+    }
+
+    public function registerPublishResponse(string $entityId, string $response)
+    {
+        $data = $this->read();
+        if(isset($data[$entityId])){
+            $responseArray = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+            throw new InviteException(
+                sprintf('The name "%s" already exists, please use a unique name.', $responseArray['name'])
+            );
+        }
+        $data[$entityId] = $response;
+        $this->write($data);
+    }
+
+
+    public function createRole(
+        string $name,
+        string $shortName,
+        string $description,
+        string $landingPage,
+        string $manageId,
+    ): CreateRoleResponse {
+        $uuid = Uuid::v4()->toRfc4122();
+
+        $data = $this->responseTemplate();
+        $data['urn'] = 'urn:mace:surf.nl:test.surfaccess.nl:'.$uuid.':required_role_name';
+        $data['identifier'] = $uuid;
+
+        $this->registerPublishResponse($name, json_encode($data, JSON_THROW_ON_ERROR));
+
+
+        return new CreateRoleResponse($data['id'], $data['name'], $data['shortName'], $data['description'], $data['urn']);
+    }
+
+    private function read()
+    {
+        return json_decode(file_get_contents($this->path), true);
+    }
+
+    private function write(array $data): void
+    {
+        file_put_contents($this->path, json_encode($data));
+    }
+
+    private function responseTemplate(){
+        return json_decode(
+            file_get_contents(__DIR__ . '/../../fixtures/invite-role-create.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+    }
+}

--- a/tests/webtests/Resources/config/services.yml
+++ b/tests/webtests/Resources/config/services.yml
@@ -77,13 +77,23 @@ services:
             $translator: '@identity_translator'
             $prefixPart1: '%env(team_prefix_default_stem_name)%'
             $prefixPart2: '%env(team_prefix_group_name_context)%'
-            $inviteRepository: '@Surfnet\ServiceProviderDashboard\Webtests\Manage\Client\FakeInviteRepository'
+            $inviteRepository: '@Surfnet\ServiceProviderDashboard\Webtests\Manage\Client\FakeCreateRoleRepository'
             $landingUrl: '%env(invite_landing_url)%'
 
-    Surfnet\ServiceProviderDashboard\Webtests\Manage\Client\FakeInviteRepository:
+    Surfnet\ServiceProviderDashboard\Application\CommandHandler\Service\SendInviteCommandHandler:
+        public: true
+        autowire: true
+        tags:
+            - { name: tactician.handler, command: Surfnet\ServiceProviderDashboard\Application\Command\Service\SendInviteCommand }
+        arguments:
+            $sendInviteRepository: '@Surfnet\ServiceProviderDashboard\Webtests\Manage\Client\FakeSendInviteRepository'
 
-    Surfnet\ServiceProviderDashboard\Domain\Repository\InviteRepository:
-        class: Surfnet\ServiceProviderDashboard\Webtests\Manage\Client\FakeInviteRepository
+    Surfnet\ServiceProviderDashboard\Webtests\Manage\Client\FakeSendInviteRepository:
+
+    Surfnet\ServiceProviderDashboard\Webtests\Manage\Client\FakeCreateRoleRepository:
+
+    Surfnet\ServiceProviderDashboard\Domain\Repository\Invite\CreateRoleRepository:
+        class: Surfnet\ServiceProviderDashboard\Webtests\Manage\Client\FakeCreateRoleRepository
         public: true
 
     surfnet.manage.client.delete_client.prod_environment:
@@ -138,3 +148,7 @@ services:
         class: Surfnet\SamlBundle\SAML2\BridgeContainer
         public: true
         arguments: ['@logger']
+
+    Surfnet\ServiceProviderDashboard\Domain\Repository\Invite\SendInviteRepository:
+        public: true
+        class: Surfnet\ServiceProviderDashboard\Webtests\Manage\Client\FakeSendInviteRepository

--- a/tests/webtests/ServiceCreateTest.php
+++ b/tests/webtests/ServiceCreateTest.php
@@ -46,7 +46,7 @@ class ServiceCreateTest extends WebTestCase
         self::assertOnPage('This value is not a valid UUID.');
     }
 
-    public function test_empty_institution_id_field_is_allowed()
+    public function test_empty_institution_id_field_is_allowed_and_saves()
     {
         self::$pantherClient->request('GET', '/service/create');
         $form = self::findBy('form[name="dashboard_bundle_service_type"]');
@@ -57,13 +57,14 @@ class ServiceCreateTest extends WebTestCase
         self::fillFormField($form, 'input[name="dashboard_bundle_service_type[general][organizationNameEn]"]', 'team-a');
         self::fillFormField($form, 'input[name="dashboard_bundle_service_type[teams][teamManagerEmail]"]', 'loeki@example.org');
         self::findBy('#dashboard_bundle_service_type_save')->click();
-        $services = $this->getServiceRepository()->findAll();
-        $this->assertCount(4, $services);
+
+        $this->assertCount(4, $this->getServiceRepository()->findAll());
+        $this->assertEquals(1, $this->sendInviteRepository->count());
     }
 
     public function test_shows_correct_error_if_role_exists_in_invite()
     {
-        $this->inviteRepository->createRole('New Service #1 New Service #1', 'New Service #1 New Service #1', '', '', '4b0e422d-d0d0-4b9e-a521-fdd1ee5d2bad');
+        $this->createRoleRepository->createRole('New Service #1 New Service #1', 'New Service #1 New Service #1', '', '', '4b0e422d-d0d0-4b9e-a521-fdd1ee5d2bad');
 
         $crawler = self::$pantherClient->request('GET', '/service/create');
 
@@ -75,6 +76,21 @@ class ServiceCreateTest extends WebTestCase
         $this->fillFormField($form, '#dashboard_bundle_service_type_teams_teamManagerEmail', 'mail@example.org');
         $form->submit();
         $this->assertOnPage('The name "Demo role name" already exists, please use a unique name.');
+    }
+
+    public function test_shows_correct_error_if_it_cannot_send_the_role_invite_to_invite()
+    {
+        $crawler = self::$pantherClient->request('GET', '/service/create');
+
+        $form = $crawler->findElement(WebDriverBy::cssSelector('form[name="dashboard_bundle_service_type"]'));
+        $this->fillFormField($form, '#dashboard_bundle_service_type_general_name', 'New Service #1');
+        $this->fillFormField($form, '#dashboard_bundle_service_type_general_organizationNameNl', 'Nieuwe Service #1');
+        $this->fillFormField($form, '#dashboard_bundle_service_type_general_organizationNameEn', 'New Service #1');
+        $this->fillFormField($form, '#dashboard_bundle_service_type_general_guid', 'f59100e1-4232-4646-8ac5-50f3c2bc32a3');
+        $this->fillFormField($form, '#dashboard_bundle_service_type_teams_teamManagerEmail', 'general@failure.com');
+        $form->submit();
+
+        $this->assertOnPage('The service and role have been created. However, the creation of the admin membership failed. Please proceed to https://invite.dev.openconext.local/roles/42114');
     }
 
 }

--- a/tests/webtests/WebTestCase.php
+++ b/tests/webtests/WebTestCase.php
@@ -26,8 +26,6 @@ use Doctrine\ORM\EntityManager;
 use Facebook\WebDriver\Chrome\ChromeOptions;
 use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\WebDriverElement;
-use Facebook\WebDriver\WebDriverKeyboard;
-use Facebook\WebDriver\WebDriverKeys;
 use PHPUnit\Framework\ExpectationFailedException;
 use RuntimeException;
 use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
@@ -35,7 +33,8 @@ use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\DeleteManageEntityRepository;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\IdentityProviderRepository;
-use Surfnet\ServiceProviderDashboard\Domain\Repository\InviteRepository;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\Invite\CreateRoleRepository;
+use Surfnet\ServiceProviderDashboard\Domain\Repository\Invite\SendInviteRepository;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\PublishEntityRepository;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\QueryManageRepository;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\QueryTeamsRepository;
@@ -87,7 +86,8 @@ class WebTestCase extends PantherTestCase
      */
     protected $testDeleteClient;
 
-    protected InviteRepository $inviteRepository;
+    protected CreateRoleRepository $createRoleRepository;
+    protected SendInviteRepository $sendInviteRepository;
 
     /** @var QueryTeamsRepository&FakeTeamsQueryClient */
     protected $teamsQueryClient;
@@ -176,9 +176,13 @@ class WebTestCase extends PantherTestCase
         $this->surfConextRepresentativeAttributeValue = self::getContainer()
             ->getParameter('surfnet.dashboard.security.authentication.surfconext_representative_authorization');
 
-        $this->inviteRepository = self::getContainer()
-            ->get(InviteRepository::class);
-        $this->inviteRepository->reset();
+        $this->createRoleRepository = self::getContainer()
+            ->get(CreateRoleRepository::class);
+        $this->createRoleRepository->reset();
+
+        $this->sendInviteRepository = self::getContainer()
+            ->get(SendInviteRepository::class);
+        $this->sendInviteRepository->reset();
     }
 
     protected function registerManageEntity(


### PR DESCRIPTION
In a previous commit, a role was created in invite when adding a new
service.
This change, also sends the invite command to invite so invite sends an
actual invite email to the person to be invited.

See https://github.com/SURFnet/sp-dashboard/issues/1168