### PR TITLE
Feature/add release gha

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,10 +2,9 @@ name: Build docker container for the SP Dashboard
 
 on:
   pull_request:
-  release:
-    types: [published]
   push:
-    branches: [develop]
+    tags:
+      - "*.*.*"
   workflow_dispatch:
 
 jobs:
@@ -13,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     permissions:
       packages: write
-      contents: read
+      contents: write
 
     steps:
       - name: Check out the repo
@@ -62,3 +61,11 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          generate_release_notes: true
+        if: startsWith(github.ref, 'refs/tags/')
+        

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-## 6.1.0
+## 6.2.0
+- New field to set 'coin:ss:idp_visible_only'
+- An SP needs to explicitly connect an IdP, so it's more obvious when a dummy IdP is connected
 - Adds a SURFConext representative role to SPD, which grants access to a new page that displays SP/IdP connections
 - Type Of Service can now be configured on SAML and OIDC entities
 - Revision notes are more detailed (change request and new entity creation)
 - The new Manage ARP params (release_as and name_id_override) are supported by SPD
+- The [devconf](https://github.com/OpenConext/OpenConext-devconf) project is now used as a basis for development
+- A release is automatically created when a tag is set, no more manual releases
 
 ## 6.0.2
 - Fix the mixup of DPA_TYPE_MODEL_SURF and DPA_TYPE_IN_SURF_AGREEMENT #614


### PR DESCRIPTION
Add a GitHub action to do automatic releases
Updated the Changelog to reflect all changes. 
Tag 6.1 never lead to a real release, so we decided to create on big 6.2 release. 