### PR TITLE
Address some deprecations

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -1,6 +1,7 @@
 doctrine:
     dbal:
         url: '%env(resolve:DATABASE_URL)%'
+        use_savepoints: true
 
         # IMPORTANT: You MUST configure your server version,
         # either here or in the DATABASE_URL env var (see .env file)

--- a/tests/integration/Application/CommandHandler/Service/CreateServiceCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Service/CreateServiceCommandHandlerTest.php
@@ -18,7 +18,6 @@
 
 namespace Surfnet\ServiceProviderDashboard\Tests\Integration\Application\CommandHandler\Service;
 
-use Hamcrest\Core\IsEqual;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Surfnet\ServiceProviderDashboard\Application\Command\Service\CreateServiceCommand;
@@ -108,11 +107,16 @@ class CreateServiceCommandHandlerTest extends MockeryTestCase
         $command->setContractSigned($service->getContractSigned());
         $command->setInstitutionId($service->getInstitutionId());
 
-        $this->repository->shouldReceive('save')->with(IsEqual::equalTo($service))
+        $this->repository->shouldReceive('save')
+            ->withArgs(function($actualService) use ($service) {
+                return json_encode($actualService, JSON_THROW_ON_ERROR) === json_encode($service, JSON_THROW_ON_ERROR);
+            })
             ->andReturnUsing(function ($service) {
                 $service->setId(123);
                 return $service;
-            })->once();
+            })
+            ->once();
+
         $this->repository->shouldReceive('isUnique')->andReturn(true)->once();
         $this->commandHandler->handle($command);
 

--- a/tests/webtests/ServiceOverviewTest.php
+++ b/tests/webtests/ServiceOverviewTest.php
@@ -159,7 +159,6 @@ class ServiceOverviewTest extends WebTestCase
 
     public function test_service_overview_shows_message_when_no_service_selected()
     {
-        $this->loadFixtures();
         $this->logOut();
         $this->logIn();
 
@@ -172,7 +171,6 @@ class ServiceOverviewTest extends WebTestCase
     {
         $service = $this->getServiceRepository()->findByName('SURFnet');
         $this->logIn($service);
-        $this->loadFixtures();
         $crawler = self::$pantherClient->request('GET', '/');
         // Verify the checkbox is on the page (used to trigger the modal when clicking the link)
         $testCheckbox = $crawler->filter('#add-for-test-SURFnet');
@@ -182,7 +180,6 @@ class ServiceOverviewTest extends WebTestCase
 
     public function test_entity_list_shows_add_to_production_link()
     {
-        $this->loadFixtures();
         // Ibuildings is allowed to create production entities.
         $service = $this->getServiceRepository()->findByName('Ibuildings B.V.');
         $this->logIn($service);


### PR DESCRIPTION
Prior to this change, the ServiceOverviewTest would load the fixtures twice.
This would make doctrine complain about primary keys being forcefully reused on new enities.
This change does not load the fixtures twice, resolving the issue.

Prior to this change, doctrine would note that we need to make a decision whether to use savepoints or not.
This change explicitly enables savepoints, as Innodb engine and sqlite support savepoints.
This was always the default behavior, and by explicitly setting it to 
true, we keep it that way. Thil will tell doctrine that it can use 
nested database transactions.

Also rewrite test assertion to not rely on deprecated Hamcrest bundle.
