### PR TITLE
Add some pragmatic phpcs sniffs

### DIFF
--- a/ci/qa/phpcs
+++ b/ci/qa/phpcs
@@ -3,4 +3,4 @@
 cd $(dirname $0)/../../
 
 # https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage
-./vendor/bin/phpcs --runtime-set ignore_warnings_on_exit 1 --standard=ci/qa/phpcs.xml --warning-severity=6 --error-severity=1 src
+./vendor/bin/phpcs --standard=ci/qa/phpcs.xml src

--- a/ci/qa/phpcs.xml
+++ b/ci/qa/phpcs.xml
@@ -19,6 +19,7 @@
     </rule>
     <!-- Forbid empty comments -->
     <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
+    <rule ref="Generic.Commenting.Todo"/>
     <!-- Forbid useless comments -->
     <rule ref="SlevomatCodingStandard.Commenting.ForbiddenComments">
         <properties>
@@ -39,7 +40,7 @@
     <!-- Lines can be a little bit longer before they break the build -->
     <rule ref="Generic.Files.LineLength">
         <properties>
-            <property name="lineLimit" value="120" />
+            <property name="lineLimit" value="150" />
             <property name="absoluteLineLimit" value="150"/>
         </properties>
     </rule>

--- a/ci/qa/phpcs.xml
+++ b/ci/qa/phpcs.xml
@@ -11,6 +11,31 @@
     <!-- This is the rule we inherit from. If you want to exlude some specific rules, see the docs on how to do that -->
     <rule ref="PSR2" />
 
+    <!-- Include some choice rules from Doctrine -->
+    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
+        <properties>
+            <property name="searchAnnotations" value="true"/>
+        </properties>
+    </rule>
+    <!-- Forbid empty comments -->
+    <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
+    <!-- Forbid useless comments -->
+    <rule ref="SlevomatCodingStandard.Commenting.ForbiddenComments">
+        <properties>
+            <property name="forbiddenCommentPatterns" type="array">
+                <element value="~^(?:(?!private|protected|static)\S+ )?(?:con|de)structor\.\z~i"/>
+                <element value="~^Created by .+\.\z~i"/>
+                <element value="~^(User|Date|Time): \S+\z~i"/>
+                <element value="~^\S+ [gs]etter\.\z~i"/>
+                <element value="~^(Class|Interface|Trait) \S+\z~i"/>
+            </property>
+        </properties>
+    </rule>
+    <!-- Forbid empty statements -->
+    <rule ref="Generic.CodeAnalysis.EmptyStatement">
+        <!-- But allow empty catch -->
+        <exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedCatch"/>
+    </rule>
     <!-- Lines can be a little bit longer before they break the build -->
     <rule ref="Generic.Files.LineLength">
         <properties>

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/PublishProductionCommandInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/PublishProductionCommandInterface.php
@@ -18,7 +18,6 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Command\Entity;
 
-use Surfnet\ServiceProviderDashboard\Application\Command\Command;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/ResetOidcSecretCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/ResetOidcSecretCommand.php
@@ -21,7 +21,6 @@ namespace Surfnet\ServiceProviderDashboard\Application\Command\Entity;
 use Surfnet\ServiceProviderDashboard\Application\Command\Command;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
-use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints as SpDashboardAssert;
 
 class ResetOidcSecretCommand implements Command
 {

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOauthClientCredentialClientCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOauthClientCredentialClientCommand.php
@@ -18,13 +18,11 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Command\Entity;
 
-use Exception;
 use InvalidArgumentException;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
-use Surfnet\ServiceProviderDashboard\Domain\ValueObject\TypeOfService;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints as SpDashboardAssert;
 use Symfony\Component\Validator\Constraints as Assert;
 use function in_array;

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
@@ -25,7 +25,6 @@ use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\OidcGrantType;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\TypeOfService;
-use Surfnet\ServiceProviderDashboard\Domain\ValueObject\TypeOfServiceCollection;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints as SpDashboardAssert;
 use Symfony\Component\Validator\Constraints as Assert;
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/UpdateEntityAclCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/UpdateEntityAclCommand.php
@@ -22,7 +22,6 @@ use Surfnet\ServiceProviderDashboard\Application\Command\Command;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\IdentityProvider;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class UpdateEntityAclCommand implements Command

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/CreateServiceCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Service/CreateServiceCommand.php
@@ -22,7 +22,6 @@ namespace Surfnet\ServiceProviderDashboard\Application\Command\Service;
 
 use Surfnet\ServiceProviderDashboard\Application\Command\Command;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
-use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints as SpDashboardAssert;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/EntityChangeRequestCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/EntityChangeRequestCommandHandler.php
@@ -30,7 +30,6 @@ use Surfnet\ServiceProviderDashboard\Application\Service\MailService;
 use Surfnet\ServiceProviderDashboard\Application\Service\TicketService;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\JiraTicketNumber;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityChangeRequestRepository;
-use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Issue;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\PublishMetadataException;
 use Symfony\Component\HttpFoundation\RequestStack;
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityTestCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityTestCommandHandler.php
@@ -24,13 +24,10 @@ use Surfnet\ServiceProviderDashboard\Application\CommandHandler\CommandHandler;
 use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
 use Surfnet\ServiceProviderDashboard\Application\Service\EntityServiceInterface;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\JiraTicketNumber;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\PublishEntityRepository;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\PublishMetadataException;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use function array_key_exists;
 
 class PublishEntityTestCommandHandler implements CommandHandler

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PushMetadataCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PushMetadataCommandHandler.php
@@ -24,7 +24,6 @@ use Surfnet\ServiceProviderDashboard\Application\CommandHandler\CommandHandler;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\PushMetadataException;
 use Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Service\ManagePublishService;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 
 class PushMetadataCommandHandler implements CommandHandler
 {

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/RequestDeletePublishedEntityCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/RequestDeletePublishedEntityCommandHandler.php
@@ -26,7 +26,6 @@ use Surfnet\ServiceProviderDashboard\Application\Service\TicketService;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\QueryManageRepository;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Ticket;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Webmozart\Assert\Assert;
 
 /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/Dto/ServiceStatusDto.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Dto/ServiceStatusDto.php
@@ -23,7 +23,7 @@ use JsonSerializable;
 class ServiceStatusDto implements JsonSerializable
 {
     /**
-     * ServiceStatusDto constructor.
+     *
      *
      * @param string[] $states
      * @param string[] $labels

--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGeneratorStrategy.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/JsonGeneratorStrategy.php
@@ -18,7 +18,6 @@
 
 namespace Surfnet\ServiceProviderDashboard\Application\Metadata;
 
-use Surfnet\ServiceProviderDashboard\Application\Dto\MetadataConversionDto;
 use Surfnet\ServiceProviderDashboard\Application\Exception\JsonGeneratorStrategyNotFoundException;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\JiraTicketNumber;

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Attribute.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/Attribute.php
@@ -20,7 +20,6 @@ declare(strict_types = 1);
 namespace Surfnet\ServiceProviderDashboard\Application\ViewObject;
 
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Dto\Attribute as AttributeDto;
-use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Dto\AttributeFormLanguage;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Dto\AttributeTypeInformation;
 use function in_array;
 

--- a/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityConnection.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/ViewObject/EntityConnection.php
@@ -19,7 +19,6 @@ declare(strict_types = 1);
 namespace Surfnet\ServiceProviderDashboard\Application\ViewObject;
 
 use Surfnet\ServiceProviderDashboard\Domain\Entity\IdentityProvider;
-use Symfony\Component\Serializer\Attribute\Ignore;
 
 class EntityConnection
 {

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/ManageEntity.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/ManageEntity.php
@@ -30,6 +30,7 @@ use Surfnet\ServiceProviderDashboard\Domain\ValueObject\SecretInterface;
 use function in_array;
 
 /**
+ * // phpcs:ignore
  * TODO: All factory logic should be offloaded to Application or Infra layers where the
  * entity is used in a specific context. This particularly applies for the factory
  * methods found in the 'Entity/Entity' namespace.

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Repository/TicketRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Repository/TicketRepository.php
@@ -23,6 +23,7 @@ use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Ticket;
 interface TicketRepository
 {
     /**
+     * // phpcs:ignore
      * TODO set the required parameters to build an issue.
      *
      * @return Ticket

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/Api/ServiceController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/Api/ServiceController.php
@@ -20,8 +20,6 @@ declare(strict_types = 1);
 
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Controller\Api;
 
-use League\Tactician\CommandBus;
-
 use Surfnet\ServiceProviderDashboard\Application\Assembler\ServiceStatusAssembler;
 use Surfnet\ServiceProviderDashboard\Application\Service\ServiceService;
 use Surfnet\ServiceProviderDashboard\Application\Service\ServiceStatusService;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityPublishedController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityPublishedController.php
@@ -30,9 +30,6 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class EntityPublishedController extends AbstractController
 {
-    /**
-     *
-     */
     #[IsGranted('ROLE_USER')]
     #[Route(path: '/entity/published/production', name: 'entity_published_production', methods: ['GET'])]
     #[Route(path: '/entity/published/test', name: 'entity_published_test', methods: ['GET'])]
@@ -69,9 +66,6 @@ class EntityPublishedController extends AbstractController
         return $this->render('@Dashboard/EntityPublished/publishedProduction.html.twig', $parameters);
     }
 
-    /**
-     *
-     */
     #[IsGranted('ROLE_USER')]
     #[Route(path: '/entity/change-request', name: 'entity_change_request', methods: ['GET'])]
     public function changeRequest(): Response

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/EventListener/ExceptionListener.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/EventListener/ExceptionListener.php
@@ -20,7 +20,6 @@ declare(strict_types = 1);
 
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\EventListener;
 
-use Psr\Log\LoggerInterface;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Exception\UnknownServiceException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/InstitutionIdpListType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/InstitutionIdpListType.php
@@ -20,7 +20,6 @@ declare(strict_types = 1);
 
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity;
 
-use Surfnet\ServiceProviderDashboard\Application\Service\EntityAclService;
 use Surfnet\ServiceProviderDashboard\Application\Service\IdpServiceInterface;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\IdentityProvider;
 use Symfony\Component\Form\AbstractType;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/TestIdpListType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/TestIdpListType.php
@@ -20,7 +20,6 @@ declare(strict_types = 1);
 
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Entity;
 
-use Surfnet\ServiceProviderDashboard\Application\Service\EntityAclService;
 use Surfnet\ServiceProviderDashboard\Application\Service\IdpServiceInterface;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\IdentityProvider;
 use Symfony\Component\Form\AbstractType;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Repository/ServiceRepository.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Repository/ServiceRepository.php
@@ -18,7 +18,6 @@
 
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Repository;
 
-use Doctrine\DBAL\Exception;
 use Doctrine\ORM\EntityRepository as DoctrineEntityRepository;
 use Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/AuthorizationService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/AuthorizationService.php
@@ -25,7 +25,6 @@ use Surfnet\ServiceProviderDashboard\Application\Service\ServiceService;
 use Surfnet\ServiceProviderDashboard\Application\ViewObject\Apis\ApiConfig;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Service;
-use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Identity;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Twig/ServiceSwitcherExtension.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Twig/ServiceSwitcherExtension.php
@@ -18,7 +18,6 @@
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Twig;
 
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Form\Service\ServiceSwitcherType;
-use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\AuthorizationService;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Twig\Environment;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/ValidEntityIdValidator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/ValidEntityIdValidator.php
@@ -19,7 +19,6 @@
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints;
 
 use Exception;
-use Symfony\Component\Form\Extension\Core\EventListener\FixUrlProtocolListener;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Controller/SamlController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/Controller/SamlController.php
@@ -18,15 +18,10 @@
 
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Controller;
 
-use Psr\Log\LoggerInterface;
-use Surfnet\SamlBundle\Entity\IdentityProvider;
-use Surfnet\SamlBundle\Entity\ServiceProvider;
 use Surfnet\SamlBundle\Exception\LogicException;
-use Surfnet\SamlBundle\Http\PostBinding;
 use Surfnet\SamlBundle\Http\XMLResponse;
 use Surfnet\SamlBundle\Metadata\MetadataFactory;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
 
 class SamlController extends AbstractController

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/DashboardSamlBundle.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardSamlBundle/DashboardSamlBundle.php
@@ -20,7 +20,6 @@ declare(strict_types = 1);
 
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle;
 
-use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardSamlBundle\Security\Factory\SamlFactory;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Invite/SendInviteResponseFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Invite/SendInviteResponseFactory.php
@@ -18,7 +18,6 @@
 
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\Invite;
 
-use Surfnet\ServiceProviderDashboard\Domain\ValueObject\CreateRoleResponse;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\SendInviteResponse;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\InviteException;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/DeleteManageEntityClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/DeleteManageEntityClient.php
@@ -20,7 +20,6 @@ declare(strict_types = 1);
 
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client;
 
-use Psr\Log\LoggerInterface;
 use Surfnet\ServiceProviderDashboard\Application\Exception\UnableToDeleteEntityException;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\Protocol;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/IdentityProviderClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/IdentityProviderClient.php
@@ -21,7 +21,6 @@ namespace Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client;
 use Surfnet\ServiceProviderDashboard\Application\ViewObject\Apis\ApiConfig as Config;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\IdentityProvider;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\IdentityProviderRepository;
-use Surfnet\ServiceProviderDashboard\Domain\ValueObject\EntityId;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\InstitutionId;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\HttpException\HttpException;
 use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\QueryIdentityProviderException;

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/QueryClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/QueryClient.php
@@ -122,6 +122,7 @@ class QueryClient implements QueryManageRepository
     public function findByManageId($manageId)
     {
         try {
+            // phpcs:ignore
             // TODO: investigate if we can add the protocol to the param list of this method to prevent the try/retry
             //  construction below.
             $data = $this->read(Protocol::SAML20_SP, $manageId);

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Factory/SaveCommandFactory.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Factory/SaveCommandFactory.php
@@ -26,11 +26,9 @@ use Surfnet\ServiceProviderDashboard\Application\Command\Entity\SaveSamlEntityCo
 use Surfnet\ServiceProviderDashboard\Application\Service\AttributeServiceInterface;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Constants;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\AttributeList;
-use Surfnet\ServiceProviderDashboard\Domain\Entity\Entity\OidcClientInterface;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Attribute;
 use Surfnet\ServiceProviderDashboard\Domain\ValueObject\Contact;
-use Surfnet\ServiceProviderDashboard\Legacy\Repository\AttributesMetadataRepository;
 use function is_array;
 use function reset;
 


### PR DESCRIPTION
Prior to this change, there were a lot of unused imports, which require developer time to address. This change configures phpcs to automatically remove unused imports, so the imports are always clean.

Also add some other sniffs without much impact, based on the doctrine coding-standard.