### PR TITLE
Improve UX of Create connection request form

### DIFF
--- a/assets/js/components/connection_request_widget.ts
+++ b/assets/js/components/connection_request_widget.ts
@@ -10,6 +10,7 @@ class CollectionWidget {
   private errorMessage: string;
   private $sendButton: JQuery;
   private $connectionRequestForm: JQuery;
+  private $emptyCollectionMessage: JQuery;
 
   /**
    * @param $collectionWidget The collection widget
@@ -19,7 +20,7 @@ class CollectionWidget {
   ) {
     this.$collectionWidget = $collectionWidget;
     this.$collectionList = this.$collectionWidget.find('table.collection-list');
-    this.$collectionList.hide();
+    this.$emptyCollectionMessage = this.$collectionWidget.find('.empty-connection-list-message');
     this.prototype = this.$collectionWidget.data('prototype');
     this.$input = $(this.prototype);
     this.$sendButton = $('button[id="connection_request_container_send"]');
@@ -96,6 +97,7 @@ class CollectionWidget {
     newElement.append('</tr>');
     collectionEntry.append(newElement);
     this.$collectionList.append(collectionEntry);
+    this.$emptyCollectionMessage.hide();
 
     this.index += 1;
   }
@@ -108,8 +110,8 @@ class CollectionWidget {
     const element = $(el.target);
 
     element.closest('.collection-entry').remove();
-    if (this.$collectionList.find('tr').length === 1) {
-      this.$collectionList.hide();
+    if (!this.hasConnectionRequests()) {
+      this.$emptyCollectionMessage.show()
     }
   }
 

--- a/assets/js/components/connection_request_widget.ts
+++ b/assets/js/components/connection_request_widget.ts
@@ -201,8 +201,8 @@ class CollectionWidget {
 
   private registerSendHandler($sendButton: JQuery<HTMLElement>) {
     const handleSubmit = () => {
-      this.disableInputs();
       if (this.hasConnectionRequests()) {
+        this.disableInputs();
         this.disableParsleyValidation();
       }
       $sendButton.click();

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -252,6 +252,7 @@ entity.change_request.none.text.html: "<p>No outstanding change requests</p>"
 entity.create_connection_request.title: Create connection request
 entity.create_connection_request.introduction.html: "<p><strong>Pellentesque habitant morbi tristique</strong> senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. <em>Aenean ultricies mi vitae est.</em> Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, <code>commodo vitae</code>, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. <a href=\"#\">Donec non enim</a> in turpis pulvinar facilisis. Ut felis.</p>"
 entity.create_connection_request.edit.flash.success: Your connection request were successfully sent
+entity.create_connection_request.emptyConnectionListPlaceholder: "No items have been added yet. Add items to this list using the + button, then click the Send button."
 entity.edit.comments.title: Comments
 entity.edit.comments.html: "<p>If there are any questions regarding your SURFconext connection or this form, please leave them here.</p>"
 entity.edit.oidcngResourceServers.title: Select the OIDC Resource Servers(s) that belong to this Client

--- a/templates/form/fields.html.twig
+++ b/templates/form/fields.html.twig
@@ -162,6 +162,9 @@
                     <th class="text">Email</th>
                     <th>&nbsp</th>
                 </tr>
+                <tr class="empty-connection-list-message">
+                    <td colspan="4">{{ 'entity.create_connection_request.emptyConnectionListPlaceholder'|trans }}</td>
+                </tr>
             </table>
         {% else %}
         <ul class="collection-list">

--- a/templates/form/fields.html.twig
+++ b/templates/form/fields.html.twig
@@ -160,7 +160,7 @@
                     <th class="text">Institution</th>
                     <th class="text">Name</th>
                     <th class="text">Email</th>
-                    <th>&nbsp</th>
+                    <th>&nbsp;</th>
                 </tr>
                 <tr class="empty-connection-list-message">
                     <td colspan="4">{{ 'entity.create_connection_request.emptyConnectionListPlaceholder'|trans }}</td>

--- a/tests/webtests/CreateConnectionRequestTest.php
+++ b/tests/webtests/CreateConnectionRequestTest.php
@@ -20,6 +20,7 @@ namespace Surfnet\ServiceProviderDashboard\Webtests;
 
 use Facebook\WebDriver\WebDriverBy;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\DataFixtures\ORM\WebTestFixtures;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class CreateConnectionRequestTest extends WebTestCase
 {
@@ -61,6 +62,10 @@ class CreateConnectionRequestTest extends WebTestCase
         self::assertSelectorIsDisabled('#connection_request_container_send');
         self::assertSelectorIsEnabled('#connection_request_container_cancel');
 
+        /** @var TranslatorInterface $translator */
+        $translator = self::getContainer()->get(TranslatorInterface::class);
+
+        self::assertSelectorTextContains('.empty-connection-list-message', $translator->trans('entity.create_connection_request.emptyConnectionListPlaceholder'));
         $this->fillFormField($form, '#connection_request_container_connectionRequests___name___institution', 'Institution 1');
         $this->fillFormField($form, '#connection_request_container_connectionRequests___name___name', 'Jesse');
         $this->fillFormField($form, '#connection_request_container_connectionRequests___name___email', 'jesse-james@gmail.com');
@@ -68,8 +73,9 @@ class CreateConnectionRequestTest extends WebTestCase
 
         self::assertSelectorExists('.collection-list');
         self::assertSelectorIsVisible('.collection-list');
+        self::assertSelectorTextNotContains('.empty-connection-list-message', $translator->trans('entity.create_connection_request.emptyConnectionListPlaceholder'));
 
-        self::assertSelectorTextContains('.collection-list td:nth-child(1)', 'Institution 1');
+        self::assertSelectorTextContains('.collection-list tr.collection-entry td:nth-child(1)', 'Institution 1');
         self::assertSelectorIsVisible('.remove_collection_entry');
 
         self::assertSelectorIsEnabled('#connection_request_container_send');


### PR DESCRIPTION
### Improve UX of Create connection request form
Prior to this change, when you enterd the form data, it was unclear you needed to press the + button in order to 'add' it. This change shows the list headers + a clarifying text to clarify this. The clarifying text should only be shown if there are no items in the list.

Resolves https://github.com/SURFnet/sp-dashboard/issues/1201

---

### Prevent 'Create connection request' broken form state
Prior to this change, when you would click '+' on an invalid row, then click 'Send', the row would become disabled while being invalid, effectively freezing the form, requiring a manual page refresh to continue.
This change will not disable the row unless the row is valid.

Old
https://github.com/user-attachments/assets/d98522a9-609f-45c7-90d1-cb72424de4d0

New
https://github.com/user-attachments/assets/3874871f-7c99-410c-a164-612d03a17617