### PR TITLE
Improve contrast on form labels

### DIFF
--- a/assets/scss/excludes/forms.scss
+++ b/assets/scss/excludes/forms.scss
@@ -12,7 +12,7 @@ h2:not(.section-title) {
 }
 
 label:not(.button):not(.link) {
-  color: $medium-grey;
+  color: $dark-grey;
   display: block;
 
   a {

--- a/assets/scss/pages/service_edit.scss
+++ b/assets/scss/pages/service_edit.scss
@@ -135,7 +135,7 @@ form {
     }
     .form-row label {
       border-bottom: none;
-      color: $medium-grey;
+      color: $dark-grey;
       font-size: 100%;
       margin-bottom: 0;
       padding-bottom: 0;


### PR DESCRIPTION
Prior to this change, the contrast on form labels was too low.

Resolves https://github.com/SURFnet/sp-dashboard/issues/1318