### PR TITLE
Ensure correct invite url

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Invite/InviteHttpClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Invite/InviteHttpClient.php
@@ -43,8 +43,10 @@ class InviteHttpClient
             ],
         ];
 
+        $baseUri = InviteHttpClientUrlSanitizer::buildBaseUri($path, $host);
+
         $this->httpClient = HttpClient::createForBaseUri(
-            $host . $path,
+            $baseUri,
             $options
         );
     }
@@ -54,6 +56,7 @@ class InviteHttpClient
      */
     public function post(string $path, array $payload): ResponseInterface
     {
+        $path = InviteHttpClientUrlSanitizer::ensureRelativePath($path);
         return $this->httpClient->request(
             'POST',
             $path,
@@ -66,6 +69,7 @@ class InviteHttpClient
      */
     public function delete(string $path): ResponseInterface
     {
+        $path = InviteHttpClientUrlSanitizer::ensureRelativePath($path);
         return $this->httpClient->request(
             'DELETE',
             $path,

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Invite/InviteHttpClientUrlSanitizer.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Invite/InviteHttpClientUrlSanitizer.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\Invite;
+
+class InviteHttpClientUrlSanitizer
+{
+
+    public static function buildBaseUri(string $path, string $host): string
+    {
+        if (trim($path) === '') {
+            return self::ensureEndsWithSingleSlash($host);
+        }
+
+        $path = self::ensureRelativePath($path);
+        $path = self::ensureEndsWithSingleSlash($path);
+
+        $host = self::ensureEndsWithSingleSlash($host);
+
+        return $host . $path;
+    }
+
+    /**
+     * Ensure the relative path does not start with a slash.
+     * The client basePath needs to end with a slash or the part after the host will get silently removed.
+     * And the paths in the post/delete methods need to be relative or the path in the basePath will not get used.
+     *
+     * See https://symfony.com/doc/7.2/reference/configuration/framework.html#base-uri
+     * @param string $path
+     * @return string
+     */
+    public static function ensureRelativePath(string $path): string
+    {
+        return ltrim($path, '/');
+    }
+
+    private static function ensureEndsWithSingleSlash(string $string): string
+    {
+        return rtrim($string, '/') . '/';
+    }
+}

--- a/tests/unit/Infrastructure/Invite/InviteHttpClientUrlSanitizerTest.php
+++ b/tests/unit/Infrastructure/Invite/InviteHttpClientUrlSanitizerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\Invite;
+
+use PHPUnit\Framework\TestCase;
+use Surfnet\ServiceProviderDashboard\Infrastructure\Invite\InviteHttpClientUrlSanitizer;
+
+class InviteHttpClientUrlSanitizerTest extends TestCase
+{
+
+    public function testHandlesBaseUriCorrectly(): void
+    {
+        $baseUri = InviteHttpClientUrlSanitizer::buildBaseUri('/api/external/v1', 'http://localhost');
+        self::assertSame('http://localhost/api/external/v1/', $baseUri);
+    }
+
+    public function testEnsuresRelativePathCorrectly(): void
+    {
+        $relativePath = InviteHttpClientUrlSanitizer::ensureRelativePath('/internal/delete');
+        self::assertSame('internal/delete', $relativePath);
+    }
+
+    public function testHandlesEmptyPathInBaseUri(): void
+    {
+        $baseUri = InviteHttpClientUrlSanitizer::buildBaseUri('', 'http://localhost');
+        self::assertSame('http://localhost/', $baseUri);
+    }
+
+    public function testHandlesEmptyHostInBaseUri(): void
+    {
+        $baseUri = InviteHttpClientUrlSanitizer::buildBaseUri('/api/external/v1', '');
+        self::assertSame('/api/external/v1/', $baseUri);
+    }
+
+    public function testHandlesEmptyPathInRelativePath(): void
+    {
+        $relativePath = InviteHttpClientUrlSanitizer::ensureRelativePath('');
+        self::assertSame('', $relativePath);
+    }
+
+    public function testCombinesBaseUriAndRelativePathCorrectly(): void
+    {
+        $baseUri = InviteHttpClientUrlSanitizer::buildBaseUri('/api/external/v1', 'http://localhost');
+        $relativePath = InviteHttpClientUrlSanitizer::ensureRelativePath('/internal/delete');
+        $fullUri = $baseUri . $relativePath;
+        self::assertSame('http://localhost/api/external/v1/internal/delete', $fullUri);
+    }
+}


### PR DESCRIPTION
Prior to this change, the api call to invite would fail because the relative path would collapse. This change ensures the baseUri and call path are absolute/relative when needed so the calls get executed as expected.

See https://symfony.com/doc/7.2/reference/configuration/framework.html#reference-http-client-base-uri