### PR TITLE
Fix: Do not overwrite contractual base on update

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityMergeService.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Service/EntityMergeService.php
@@ -71,7 +71,7 @@ class EntityMergeService
             $command->getNameNl(),
             $this->buildContactListFromCommand($command),
             $this->buildOrganizationFromCommand($command),
-            $this->buildCoinFromCommand($command),
+            $this->buildCoinFromCommand($command, $manageEntity),
             $this->buildLogoFromCommand($command)
         );
         $attributes = $this->buildAttributesFromCommand($command);
@@ -206,7 +206,7 @@ class EntityMergeService
         );
     }
 
-    private function buildCoinFromCommand(SaveEntityCommandInterface $command): Coin
+    private function buildCoinFromCommand(SaveEntityCommandInterface $command, ManageEntity $manageEntity): Coin
     {
         $typeOfServiceCollection = new TypeOfServiceCollection();
         foreach ($command->getTypeOfService() as $typeOfService) {
@@ -222,7 +222,7 @@ class EntityMergeService
             $typeOfServiceCollection,
             $command->getEulaUrl(),
             null,
-            null,
+            $manageEntity->getMetaData()?->getCoin()->getContractualBase(),
             // Note when the dashboard sets the isPublicInDashboard to be true
             // That means the metaDataFields.coin:ss:idp_visible_only must be false
             !$command->isPublicInDashboard(),


### PR DESCRIPTION
*wip*

Prior to this change, when updating an entity, the contractualBase would be overwritten to null. This change takes into account the original value from manage.

Fixes https://github.com/SURFnet/sp-dashboard/issues/1343