### PR TITLE
The test IdP ACL page showed a text twice. 

### DIFF
--- a/templates/EntityAcl/idps.html.twig
+++ b/templates/EntityAcl/idps.html.twig
@@ -28,7 +28,7 @@
             {{ 'entity.idps.test-idps.title'|trans }}
         </h2>
 
-        <p>{{ 'entity.idps.info.html'|trans|wysiwyg }}</p>
+        <p>{{ 'entity.idps.test-idps.html'|trans|wysiwyg }}</p>
 
         <div class="idps-container">
             {{ form_widget(form.testEntities) }}


### PR DESCRIPTION
This fixes the twig template to show the correct text