### PR TITLE
Adapt to updated manage response

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -33,13 +33,13 @@ surfconext_representative_authorization='urn:mace:surfnet.nl:surfnet.nl:sab:role
 
 ## Manage test instance
 manage_test_host='https://manage.dev.openconext.local'
-manage_test_username=sp-portal
+manage_test_username=sp-dashboard
 manage_test_password=secret
 manage_test_publication_status=testaccepted
 
 ## Manage production instance
 manage_prod_host='https://manage.dev.openconext.local'
-manage_prod_username=sp-portal
+manage_prod_username=sp-dashboard
 manage_prod_password=secret
 manage_prod_publication_status=prodaccepted
 

--- a/ci/qa/phpstan-baseline.php
+++ b/ci/qa/phpstan-baseline.php
@@ -4327,17 +4327,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot access offset \'status\' on mixed\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot call method diff\\(\\) on Surfnet\\\\ServiceProviderDashboard\\\\Domain\\\\Entity\\\\ManageEntity\\|null\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$context of method Psr\\\\Log\\\\LoggerInterface\\:\\:error\\(\\) expects array, mixed given\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php',
 ];

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/Manage/Client/PublishEntityClient.php
@@ -113,12 +113,30 @@ class PublishEntityClient implements PublishEntityRepositoryInterface
             throw new PushMetadataException('Unable to push the metadata to Engineblock', 0, $e);
         }
 
-        if ($response['status'] != "OK") {
+        if (!is_array($response)) {
             $this->logger->error(
-                'Manage rejected the push to Engineblock',
-                $response ?? []
+                'Manage did not return a valid response',
+                ['response' => $response]
             );
             throw new PushMetadataException('Pushing did not succeed.');
+        }
+
+        if (count($response) === 0) {
+            $this->logger->error(
+                'Manage did not return an inner response',
+                ['response' => $response]
+            );
+            throw new PushMetadataException('Pushing did not succeed.');
+        }
+
+        foreach ($response as $system => $innerResponse) {
+            if ($innerResponse['status'] !== 'OK') {
+                $this->logger->error(
+                    sprintf('Manage "%s" rejected the push to Engineblock', $system),
+                    $innerResponse ?? []
+                );
+                throw new PushMetadataException('Pushing did not succeed.');
+            }
         }
         return $response;
     }

--- a/tests/unit/Infrastructure/Manage/Client/PublishEntityClientTest.php
+++ b/tests/unit/Infrastructure/Manage/Client/PublishEntityClientTest.php
@@ -198,10 +198,24 @@ class PublishEntityClientTest extends MockeryTestCase
 
     public function test_it_can_push_to_engineblock()
     {
-        $this->mockHandler->append(new Response(200, [], '{"status":"OK"}'));
+        $responseJson = '{
+          "pdp": {
+            "status": "OK"
+          },
+          "eb": {
+            "status": "OK"
+          },
+          "oidc": {
+            "status": "OK"
+          }
+        }';
+
+        $this->mockHandler->append(new Response(200, [], $responseJson));
 
         $response = $this->client->pushMetadata();
-        $this->assertEquals('OK', $response['status']);
+        $this->assertEquals('OK', $response['pdp']['status']);
+        $this->assertEquals('OK', $response['eb']['status']);
+        $this->assertEquals('OK', $response['oidc']['status']);
     }
 
     public function test_it_handles_failing_push_action()
@@ -220,8 +234,21 @@ class PublishEntityClientTest extends MockeryTestCase
     {
         $this->expectExceptionMessage("Pushing did not succeed");
         $this->expectException(PushMetadataExceptionAlias::class);
-        // First call represents the 'xml to json' POST on the Manage endpoint
-        $this->mockHandler->append(new Response(200, [], '{"status": "failed", "validation": "invalid enum"}'));
+
+        $responseJson = '{
+          "pdp": {
+            "status": "OK"
+          },
+          "eb": {
+            "status": "failed",
+            "validation": "invalid enum"
+          },
+          "oidc": {
+            "status": "OK"
+          }
+        }';
+
+        $this->mockHandler->append(new Response(200, [], $responseJson));
 
         $this->logger
             ->shouldReceive('error')

--- a/tests/webtests/Manage/Client/FakePublishEntityClient.php
+++ b/tests/webtests/Manage/Client/FakePublishEntityClient.php
@@ -62,7 +62,31 @@ class FakePublishEntityClient implements PublishEntityRepositoryInterface
 
     public function pushMetadata(): mixed
     {
-        $response = $this->pushOk ? '{"status":"OK"}' : '{"status":"400"}';
+        if ($this->pushOk) {
+            $response = '{
+                "pdp": {
+                    "status": "OK"
+                },
+                "eb": {
+                    "status": "OK"
+                },
+                "oidc": {
+                    "status": "OK"
+                }
+            }';
+        } else {
+            $response = '{
+                "pdp": {
+                    "status": "400"
+                },
+                "eb": {
+                    "status": "400"
+                },
+                "oidc": {
+                    "status": "400"
+                }
+            }';
+        }
         return json_decode($response, true);
     }
 


### PR DESCRIPTION
Prior to this change, parsing the response from manage failed because manage changed the output.
This change adapts to the new format so no incorrect error messages are shown.

Fixes https://github.com/SURFnet/sp-dashboard/issues/1382