### PR TITLE
Prior to this change, the entity id would be converted to lowercase b…

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngEntityCommand.php
@@ -361,7 +361,7 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      */
     public function setEntityId($entityId): void
     {
-        $this->entityId = strtolower($entityId);
+        $this->entityId = $entityId;
     }
 
     /**
@@ -369,7 +369,11 @@ class SaveOidcngEntityCommand implements SaveEntityCommandInterface
      */
     public function getClientId(): ?string
     {
-        return $this->entityId;
+        if (is_string($this->entityId)) {
+            return strtolower($this->entityId);
+        }
+
+        return null;
     }
 
     /**

--- a/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngResourceServerEntityCommand.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Command/Entity/SaveOidcngResourceServerEntityCommand.php
@@ -223,7 +223,7 @@ class SaveOidcngResourceServerEntityCommand implements SaveEntityCommandInterfac
      */
     public function setEntityId($entityId): void
     {
-        $this->entityId = strtolower($entityId);
+        $this->entityId = $entityId;
     }
 
     /**
@@ -231,7 +231,11 @@ class SaveOidcngResourceServerEntityCommand implements SaveEntityCommandInterfac
      */
     public function getClientId(): ?string
     {
-        return $this->entityId;
+        if (is_string($this->entityId)) {
+            return strtolower($this->entityId);
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
Cherrypicked from: #1387

Manage would detect this as a change, and engineblock does not like case variation in the entity id.

This change prevents sp-dashboard changing the casing of oidc entity ids, only lowercasing the clientid.

Fixes https://github.com/SURFnet/sp-dashboard/issues/1378 See https://github.com/SURFnet/sp-dashboard/pull/472 See https://github.com/SURFnet/sp-dashboard/pull/476