### PR TITLE
fix: global site notice hidden on service overview pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 Remove integration with Teams
 Add integration with Invite
+- Fix: global site notice was not rendered on the service overview and my-services pages because both templates override the full `body_container` block, swallowing the notice render call that lived in the base template.
 
 The following environment variables have become obsolete.
 ```dotenv

--- a/templates/Service/my-services.html.twig
+++ b/templates/Service/my-services.html.twig
@@ -4,6 +4,8 @@
 
 {% block body_container %}
     <main>
+        {{ render(controller('Surfnet\\ServiceProviderDashboard\\Infrastructure\\DashboardBundle\\Controller\\SiteNoticeController::showGlobalSiteNotice')) }}
+
         {% include "@Dashboard/FlashMessage/flashMessages.html.twig" %}
 
         <h1 id="main" class="service-title">

--- a/templates/Service/overview.html.twig
+++ b/templates/Service/overview.html.twig
@@ -2,6 +2,8 @@
 
 {% block body_container %}
     <main>
+        {{ render(controller('Surfnet\\ServiceProviderDashboard\\Infrastructure\\DashboardBundle\\Controller\\SiteNoticeController::showGlobalSiteNotice')) }}
+
         {% include "@Dashboard/FlashMessage/flashMessages.html.twig" %}
 
         <h1 id="main" class="service-title">

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -47,9 +47,8 @@
             </div>
         </header>
         <div class="page-container">
-            {{ render(controller('Surfnet\\ServiceProviderDashboard\\Infrastructure\\DashboardBundle\\Controller\\SiteNoticeController::showGlobalSiteNotice')) }}
-
             {% block body_container %}
+                {{ render(controller('Surfnet\\ServiceProviderDashboard\\Infrastructure\\DashboardBundle\\Controller\\SiteNoticeController::showGlobalSiteNotice')) }}
                 <h1>{% block page_heading %}{% endblock %}</h1>
                 <div class="card">
                     {% block body %}{% endblock %}


### PR DESCRIPTION
## What

The global site notice was never rendered on the service overview (\`/\`) and my-services pages.

## Why

\`overview.html.twig\` and \`my-services.html.twig\` override the entire \`body_container\` block from \`base.html.twig\`. The \`render(SiteNoticeController)\` call lived *outside* the block in the base template — so it was silently swallowed by both overrides.

## Fix

- Move the \`render()\` call to the *inside* of \`body_container\` in \`base.html.twig\` (default content for pages that don't override the block)
- Add the \`render()\` call explicitly as the first line inside the overridden block in \`overview.html.twig\` and \`my-services.html.twig\`

## Changes

- \`templates/base.html.twig\`
- \`templates/Service/overview.html.twig\`
- \`templates/Service/my-services.html.twig\`
- \`CHANGELOG.md\`: note the fix under Unreleased