### PR TITLE
Fix null secret crash when copying public OIDC RP

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/Metadata/OidcngJsonGenerator.php
@@ -217,9 +217,8 @@ class OidcngJsonGenerator implements GeneratorInterface
                 if ($secret !== '' && $secret !== '0') {
                     $metadata['secret'] = $secret;
                 }
-            } else {
-                $metadata['secret'] = null;
             }
+            // Public clients have no secret; omitting the field prevents Manage's SecretHook from crashing on null
             // Reset the redirect URI list in order to get a correct JSON formatting (See #163646662)
             $metadata['redirectUrls'] = $entity->getOidcClient()->getRedirectUris();
             $metadata['grants'] = $entity->getOidcClient()->getGrants();

--- a/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
+++ b/tests/unit/Application/Metadata/OidcngJsonGeneratorTest.php
@@ -274,6 +274,64 @@ class OidcngJsonGeneratorTest extends MockeryTestCase
         );
     }
 
+    public function test_generate_for_new_entity_omits_secret_for_public_clients()
+    {
+        // Regression test for: copying an OIDC RP fails with NPE in Manage's SecretHook when secret is null
+        $generator = new OidcngJsonGenerator(
+            $this->arpMetadataGenerator,
+            $this->privacyQuestionsMetadataGenerator,
+            $this->spDashboardMetadataGenerator
+        );
+
+        $this->arpMetadataGenerator
+            ->shouldReceive('build')
+            ->andReturn(['arp' => 'arp']);
+
+        // The fixture has isPublicClient: true
+        $entity = $this->createManageEntity();
+        $data = $generator->generateForNewEntity($entity, 'testaccepted', $this->getContact());
+
+        $this->assertArrayNotHasKey('secret', $data['data']['metaDataFields']);
+        $this->assertTrue($data['data']['metaDataFields']['isPublicClient']);
+    }
+
+    public function test_generate_for_new_entity_includes_secret_for_confidential_clients()
+    {
+        $generator = new OidcngJsonGenerator(
+            $this->arpMetadataGenerator,
+            $this->privacyQuestionsMetadataGenerator,
+            $this->spDashboardMetadataGenerator
+        );
+
+        $this->arpMetadataGenerator
+            ->shouldReceive('build')
+            ->andReturn(['arp' => 'arp']);
+
+        // Build a fixture with isPublicClient: false and a secret
+        $fixtureData = json_decode(
+            file_get_contents(__DIR__ . '/fixture/oidc10_rp_response.json'),
+            true
+        );
+        $fixtureData['data']['metaDataFields']['isPublicClient'] = false;
+        $fixtureData['data']['metaDataFields']['secret'] = 'my-client-secret';
+
+        $entity = ManageEntity::fromApiResponse($fixtureData);
+        $service = new Service();
+        $service->setGuid('543b4e5b-76b5-453f-af1e-5648378bb266');
+        $service->setInstitutionId('service-institution-id');
+        $entity->setService($service);
+        $entity->setComments('revisionnote');
+        $entity = m::mock($entity);
+        $entity->shouldReceive('getAllowedIdentityProviders->isAllowAll')->andReturn(true);
+        $entity->shouldReceive('getAllowedIdentityProviders->getAllowedIdentityProviders')->andReturn([]);
+
+        $data = $generator->generateForNewEntity($entity, 'testaccepted', $this->getContact());
+
+        $this->assertArrayHasKey('secret', $data['data']['metaDataFields']);
+        $this->assertEquals('my-client-secret', $data['data']['metaDataFields']['secret']);
+        $this->assertFalse($data['data']['metaDataFields']['isPublicClient']);
+    }
+
     public function test_it_builds_an_entity_change_request()
     {
         $generator = new OidcngJsonGenerator(


### PR DESCRIPTION
## Problem

Copying an OIDC RP entity failed with a NullPointerException in Manage's `SecretHook.isBCryptEncoded()` because `this.text` was `null`.

Fixes #1448

## Root cause

`OidcngJsonGenerator::generateOidcClient()` was explicitly sending `"secret": null` for public OIDC clients. Manage's `SecretHook` doesn't handle a null value and crashes with an NPE.

## Fix

For public clients, the `secret` field is now omitted from the JSON payload entirely. Public clients have no secret by definition (OAuth2), so the field should not be sent to Manage at all.

Confidential clients (non-public) are unaffected — their secret is still included as before.

## Tests

Added two regression tests to `OidcngJsonGeneratorTest`:
- Asserts `secret` key is **absent** in `metaDataFields` for public clients
- Asserts `secret` key is **present** in `metaDataFields` for confidential clients