### PR TITLE
fix: take first contact per type from Manage (issue #1449)

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/ContactList.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/ContactList.php
@@ -48,11 +48,16 @@ class ContactList implements Comparable
             }
         }
 
-        // 2. Build the Contact DTOs
+        // 2. Build the Contact DTOs — take the first contact of each type, ignore duplicates
         $list = new self();
+        $seenTypes = [];
         foreach ($contactsData as $contact) {
-            if (array_key_exists('contactType', $contact) && in_array($contact['contactType'], self::$supportedContactTypes)) {
+            if (array_key_exists('contactType', $contact)
+                && in_array($contact['contactType'], self::$supportedContactTypes)
+                && !in_array($contact['contactType'], $seenTypes)
+            ) {
                 $list->add(Contact::from($contact));
+                $seenTypes[] = $contact['contactType'];
             }
         }
 

--- a/tests/unit/Domain/Entity/Entity/ContactListTest.php
+++ b/tests/unit/Domain/Entity/Entity/ContactListTest.php
@@ -70,6 +70,27 @@ class ContactListTest extends TestCase
         ];
     }
 
+    public function test_it_takes_first_contact_per_type_from_api_response(): void
+    {
+        $metaDataFields = [
+            'contacts:0:contactType'  => 'technical',
+            'contacts:0:givenName'    => 'Jan',
+            'contacts:0:surName'      => 'Doe',
+            'contacts:0:emailAddress' => 'jan@example.com',
+            'contacts:1:contactType'  => 'support',
+            'contacts:1:emailAddress' => 'support@example.com',
+            'contacts:2:contactType'  => 'administrative',
+            'contacts:2:emailAddress' => 'admin@example.com',
+            'contacts:3:contactType'  => 'technical', // duplicate, empty
+        ];
+
+        $list = ContactList::fromApiResponse($metaDataFields);
+
+        $technical = $list->findTechnicalContact();
+        self::assertNotNull($technical);
+        self::assertEquals('jan@example.com', $technical->getEmail());
+    }
+
     private function contactList($contacts = null)
     {
         $contactList = new ContactList();


### PR DESCRIPTION
## Summary

- `ContactList::fromApiResponse()` now takes the **first** contact of each type and ignores subsequent duplicates
- Fixes silent data loss when Manage has e.g. two `technical` contacts where the second is empty — previously the empty one overwrote the valid one, breaking display and save

## Test plan

- [ ] Run `./vendor/bin/phpunit -c ci/qa/phpunit.xml tests/unit/Domain/Entity/Entity/ContactListTest.php` — 4 tests pass
- [ ] Open a service in SP Dashboard that previously had duplicate contacts — technical contact shows correctly
- [ ] Save the entity — no unexpected validation error

Closes #1449