### PR TITLE
fix(oidcng): make isPublicClient label translatable

### DIFF
--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Form/Entity/OidcngEntityType.php
@@ -149,6 +149,7 @@ class OidcngEntityType extends AbstractType
                 CheckboxType::class,
                 [
                     'required' => false,
+                    'label' => 'entity.edit.label.isPublicClient',
                     'attr' => [
                         'required' => false,
                         'data-help' => 'entity.edit.information.isPublicClient',

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/messages.en.yml
@@ -268,6 +268,7 @@ entity.edit.information.accessTokenValidity: Text should be set in web translati
 entity.edit.information.resourceServers: Text should be set in web translations
 entity.edit.information.redirectUrls: Text should be set in web translations
 entity.edit.information.isPublicClient: Text should be set in web translations
+entity.edit.label.isPublicClient: Is public client
 entity.edit.label.isPublicOnDashboard: Make your service publicly visible in the SURFconext dashboard
 entity.edit.information.isPublicOnDashboard: The SURFconext dashboard shows institutions a list of applications that are connected to SURFconext. If you tick the checkbox, your application will be visible to everyone, and instutions can request to connect. Leave the checkbox unticked if you have an application that is for one institution only and you do not want other institutions to be able to log in to your application as well.
 entity.edit.information.pastedMetadata: Text should be set in web translations


### PR DESCRIPTION
## Summary

- Add missing `label` option to `isPublicClient` CheckboxType in `OidcngEntityType`
- Add `entity.edit.label.isPublicClient` translation key to `messages.en.yml`

Without the `label` option, Symfony auto-generated the label from the field name and bypassed the translator entirely.

Closes #1456

## Test plan

- [ ] Open OIDC entity create/edit form — verify "Is public client" label renders
- [ ] `composer test` passes