### PR TITLE
Feature/issue 1379 resource server publish error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Fix: editing an existing resource server (oauth20_rs) always failed with a confusing dual success+error message and no change applied in Manage. Root cause: `MetaData::merge()` overwrote `nameIdFormat` with `null` when the form command returned `null` (the RS form has no NameIDFormat field), causing the diff to send `metaDataFields.NameIDFormat: null` to Manage, which rejected the update. Additionally, published production RS entities were incorrectly routed through the change-request flow instead of being published directly.
 Remove integration with Teams
 Add integration with Invite
 - Fix: `organizationUnitAttribute` was silently dropped from the Manage payload because `setOrganizationUnitAttribute()` did not call `setAttribute()`. The attribute is now correctly included when saving SAML and OIDC entities.

--- a/ci/qa/phpstan-baseline.php
+++ b/ci/qa/phpstan-baseline.php
@@ -448,7 +448,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	// identifier: method.notFound
 	'message' => '#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#',
-	'count' => 2,
+	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityTestCommandHandler.php',
 ];
 $ignoreErrors[] = [

--- a/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityTestCommandHandler.php
+++ b/src/Surfnet/ServiceProviderDashboard/Application/CommandHandler/Entity/PublishEntityTestCommandHandler.php
@@ -86,7 +86,7 @@ class PublishEntityTestCommandHandler implements CommandHandler
                     $e->getMessage()
                 )
             );
-            $this->requestStack->getSession()->getFlashBag()->add('error', 'entity.edit.error.publish');
+            throw $e;
         }
     }
 

--- a/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/MetaData.php
+++ b/src/Surfnet/ServiceProviderDashboard/Domain/Entity/Entity/MetaData.php
@@ -176,7 +176,7 @@ class MetaData implements Comparable
         $this->entityId = is_null($metaData->getEntityId()) ? null : $metaData->getEntityId();
         $this->metaDataUrl = is_null($metaData->getMetaDataUrl()) ? null : $metaData->getMetaDataUrl();
         $this->acsLocations = is_null($metaData->getAcsLocations()) ? null : $metaData->getAcsLocations();
-        $this->nameIdFormat = is_null($metaData->getNameIdFormat()) ? null : $metaData->getNameIdFormat();
+        $this->nameIdFormat = is_null($metaData->getNameIdFormat()) ? $this->nameIdFormat : $metaData->getNameIdFormat();
         $this->descriptionEn = is_null($metaData->getDescriptionEn()) ? null : $metaData->getDescriptionEn();
         $this->descriptionNl = is_null($metaData->getDescriptionNl()) ? null : $metaData->getDescriptionNl();
         $this->nameEn = is_null($metaData->getNameEn()) ? null : $metaData->getNameEn();

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityControllerTrait.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityControllerTrait.php
@@ -156,7 +156,7 @@ trait EntityControllerTrait
             case $entity->getEnvironment() === Constants::ENVIRONMENT_TEST:
                 $publishEntityCommand = new PublishEntityTestCommand($entity, $applicant);
                 break;
-            case $isEntityChangeRequest:
+            case $isEntityChangeRequest && !$entity?->isOidcngResourceServer():
                 $publishEntityCommand = new EntityChangeRequestCommand($entity, $applicant);
                 break;
             case $entity->getEnvironment() === Constants::ENVIRONMENT_PRODUCTION:

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityEditController.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Controller/EntityEditController.php
@@ -94,7 +94,9 @@ class EntityEditController extends AbstractController
                         $response = $this->publishEntity($entity, $command, $isProductionEntityEdit, $request);
 
                         if ($response instanceof Response) {
-                            if ($environment !== Constants::ENVIRONMENT_PRODUCTION) {
+                            if ($environment !== Constants::ENVIRONMENT_PRODUCTION
+                                && !$flashBag->has('error')
+                            ) {
                                 $this->addFlash('info', 'entity.edit.metadata.flash.success');
                             }
                             return $response;

--- a/tests/integration/Application/CommandHandler/Entity/PublishEntityTestCommandHandlerTest.php
+++ b/tests/integration/Application/CommandHandler/Entity/PublishEntityTestCommandHandlerTest.php
@@ -190,10 +190,6 @@ class PublishEntityTestCommandHandlerTest extends MockeryTestCase
             ->shouldReceive('error')
             ->times(1);
 
-        $this->requestStack
-            ->shouldReceive('getSession->getFlashBag->add')
-            ->with('error', 'entity.edit.error.publish');
-
         $this->entityService
             ->shouldReceive('getPristineManageEntityById')
             ->andReturn($manageEntity);
@@ -206,6 +202,7 @@ class PublishEntityTestCommandHandlerTest extends MockeryTestCase
             ->with($manageEntity, $manageEntity, $command->getApplicant())
             ->andThrow(PublishMetadataException::class);
 
+        $this->expectException(PublishMetadataException::class);
         $this->commandHandler->handle($command);
     }
 

--- a/tests/unit/Domain/Entity/Entity/MetaDataTest.php
+++ b/tests/unit/Domain/Entity/Entity/MetaDataTest.php
@@ -202,6 +202,16 @@ class MetaDataTest extends TestCase
      *
      * See: https://www.pivotaltracker.com/story/show/182411730/comments/233831779
      */
+    public function testMergePreservesNameIdFormatWhenIncomingIsNull(): void
+    {
+        $existing = $this->metaData('a');
+        $incoming = $this->metaData('null');
+
+        $existing->merge($incoming);
+
+        self::assertEquals('nameIdFormat-transient', $existing->getNameIdFormat());
+    }
+
     public function test_acs_locations_are_formed_correctly_as_array()
     {
         $data['data'] = json_decode(file_get_contents(__DIR__.'/fixture/read_response.json'), true);
@@ -229,7 +239,7 @@ class MetaDataTest extends TestCase
         yield [
             $this->metaData('a'),
             $this->metaData('null'),
-            $this->metaData('null'),
+            $this->metaData('null_preserve_name_id_format'),
         ];
     }
 
@@ -284,6 +294,21 @@ class MetaDataTest extends TestCase
                     null,
                     null,
                     null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    $contactList,
+                    $organization,
+                    $coin,
+                    $logo
+                );
+            case 'null_preserve_name_id_format':
+                return new MetaData(
+                    null,
+                    null,
+                    null,
+                    'nameIdFormat-transient',
                     null,
                     null,
                     null,

--- a/tests/webtests/Manage/Client/FakePublishEntityClient.php
+++ b/tests/webtests/Manage/Client/FakePublishEntityClient.php
@@ -22,6 +22,7 @@ use RuntimeException;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\Contact;
 use Surfnet\ServiceProviderDashboard\Domain\Entity\ManageEntity;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\PublishEntityRepository as PublishEntityRepositoryInterface;
+use Surfnet\ServiceProviderDashboard\Infrastructure\HttpClient\Exceptions\RuntimeException\PublishMetadataException;
 
 class FakePublishEntityClient implements PublishEntityRepositoryInterface
 {
@@ -31,7 +32,14 @@ class FakePublishEntityClient implements PublishEntityRepositoryInterface
 
     public function reset()
     {
-        $this->write([]);
+        $this->write(['__publishFails' => false]);
+    }
+
+    public function registerPublishFailure(): void
+    {
+        $data = $this->read();
+        $data['__publishFails'] = true;
+        $this->write($data);
     }
 
     public function registerPublishResponse(string $entityId, string $response)
@@ -52,8 +60,12 @@ class FakePublishEntityClient implements PublishEntityRepositoryInterface
         Contact $contact,
         string $part = ''
     ): mixed {
+        $data = $this->read();
+        if ($data['__publishFails'] ?? false) {
+            throw new PublishMetadataException('Simulated Manage publish failure');
+        }
         $entityId = $entity->getMetaData()->getEntityId();
-        $publishResponses = $this->read();
+        $publishResponses = $data;
         if (!array_key_exists($entityId, $publishResponses)) {
             throw new RuntimeException(sprintf('No pre programmed response is available for entity "%s"', $entityId));
         }

--- a/tests/webtests/ResourceServerEditTest.php
+++ b/tests/webtests/ResourceServerEditTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Webtests;
+
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\DataFixtures\ORM\WebTestFixtures;
+
+class ResourceServerEditTest extends WebTestCase
+{
+    private string $rsManageId = 'aabb1234-cfdd-4283-a8f1-a29ba5036262';
+    private string $rsEntityId = 'https://rs.example.com';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadFixtures();
+
+        $this->registerManageEntityRaw('test', json_encode([
+            'id' => $this->rsManageId,
+            'type' => 'oauth20_rs',
+            'data' => [
+                'entityid' => $this->rsEntityId,
+                'state' => 'testaccepted',
+                'active' => true,
+                'metaDataFields' => [
+                    'NameIDFormat' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+                    'name:en' => 'Test Resource Server',
+                    'name:nl' => 'Test Resource Server NL',
+                    'description:en' => 'A test resource server',
+                    'description:nl' => 'Een test resource server',
+                    'contacts:0:contactType' => 'support',
+                    'contacts:0:givenName' => 'John',
+                    'contacts:0:surName' => 'Doe',
+                    'contacts:0:emailAddress' => 'john.support@example.com',
+                    'contacts:1:contactType' => 'administrative',
+                    'contacts:1:givenName' => 'Jane',
+                    'contacts:1:surName' => 'Doe',
+                    'contacts:1:emailAddress' => 'jane.admin@example.com',
+                    'contacts:2:contactType' => 'technical',
+                    'contacts:2:givenName' => 'Jim',
+                    'contacts:2:surName' => 'Doe',
+                    'contacts:2:emailAddress' => 'jim.tech@example.com',
+                    'coin:service_team_id' => WebTestFixtures::TEAMNAME_SURF,
+                    'secret' => '$2a$05$dJoujExEfn9HPtF9p5uYFuCl7AfzyRdNiEeM5oFoAq9KUF6RrZY9C',
+                ],
+                'type' => 'oauth20-rs',
+            ],
+        ]));
+
+        $this->testPublicationClient->registerPublishResponse(
+            $this->rsEntityId,
+            json_encode(['id' => $this->rsManageId])
+        );
+
+        $this->logIn();
+        $this->switchToService('SURFnet');
+    }
+
+    public function testEditingExistingResourceServerSucceeds(): void
+    {
+        $crawler = self::$pantherClient->request('GET', "/entity/edit/test/{$this->rsManageId}/1");
+
+        $form = $crawler->selectButton('Publish')->form();
+
+        $form->setValues([
+            'dashboard_bundle_entity_type[metadata][nameEn]' => 'Updated Resource Server',
+            'dashboard_bundle_entity_type[metadata][nameNl]' => 'Bijgewerkte Resource Server NL',
+        ]);
+
+        self::$pantherClient->submit($form);
+
+        self::assertNotOnPage('An error occurred');
+        self::assertNotOnPage('entity.edit.error.publish');
+    }
+
+    /**
+     * Regression test for issue #1379: when a test-env publish fails, only the error flash must
+     * appear — not a success flash alongside it.
+     */
+    public function testFailedPublishShowsOnlyErrorFlash(): void
+    {
+        $this->testPublicationClient->registerPublishFailure();
+
+        $crawler = self::$pantherClient->request('GET', "/entity/edit/test/{$this->rsManageId}/1");
+
+        $form = $crawler->selectButton('Publish')->form();
+
+        self::$pantherClient->submit($form);
+
+        self::assertOnPage('Unable to publish the entity, try again later');
+        self::assertNotOnPage('Your changes were saved');
+    }
+}


### PR DESCRIPTION
# Bug #1379 — Error when editing a resource server

## Symptom

When a user edits an existing resource server and saves, both a **success message and an error message** appear simultaneously. The change is never applied in Manage.

## Root cause

When a user edits a resource server, form data is merged into the existing Manage entity via `MetaData::merge()`.

The resource server form has **no `NameIDFormat` field** — the user never needs to set it. As a result, `SaveOidcngResourceServerEntityCommand::getNameIdFormat()` always returns `null`.

`MetaData::merge()` did the following:

```php
// Wrong: if the new value is null → overwrite with null
$this->nameIdFormat = is_null($metaData->getNameIdFormat()) ? null : $metaData->getNameIdFormat();
```

The correct logic is: *if the new value is null, preserve the existing value.* This is what `Coin::merge()` already does correctly:

```php
// Correct: if the new value is null → keep the old value
$this->excludeFromPush = is_null($coin->getExcludeFromPush()) ? $this->excludeFromPush : $coin->getExcludeFromPush();
```

## Step-by-step failure

1. Existing resource server in Manage has `NameIDFormat = "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"`
2. After merge, `NameIDFormat = null` (the form supplies no value for this field)
3. The diff between the two versions includes `metaDataFields.NameIDFormat: null`
4. That `null` is sent to Manage via the merge API
5. Manage rejects it and returns a response without `id`
6. SPD throws an error — but due to a secondary bug also shows a success message → confusing dual message

## When was this introduced?

Present since **2020-09-08** (`30d6531a` — "Add Oidc TNG resource server support"). The wrong null-handling was in the code from day one when resource server support was added. Only formally reported in 2025 because resource servers are rarely edited after initial creation.

## Fix

| File | Change |
|------|--------|
| `MetaData::merge()` | Preserve `nameIdFormat` when the incoming value is `null` |
| `EntityControllerTrait` | Resource servers in production bypass the change-request flow and are published directly |
| `EntityEditController` | Success flash is only shown when no error flash was added by the command handler |
