### PR TITLE
fix: block server-side fetch of metadata/logo URLs pointing at internal hosts

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -74,6 +74,14 @@ saml_remote_idp_certificate=MIIDuDCCAqCgAwIBAgIJAPdqJ9JQKN6vMA0GCSqGSIb3DQEBBQUA
 # The default timeout for Curl requests when retrieving metadata
 metadata_url_timeout=30
 
+# CIDR ranges (JSON array) that must not be reachable via a user-supplied
+# metadata/logo URL fetched server-side, in addition to the always-blocked
+# RFC1918/loopback/link-local/reserved ranges. Real internal ranges are
+# environment-specific and must be set by Ansible on deploy — do NOT put
+# real ranges here. The example below is illustrative only: it already
+# falls within the link-local range that is blocked by default.
+metadata_logo_fetch_blocked_ip_ranges='["169.254.169.254/32"]'
+
 # Manage defaults
 
 ## Manage test instance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Fix: SSRF vulnerability fixed. Add the ip's you need to block to the env. example: blocked_ip_ranges='["169.254.169.254/32"]'. See env.dist. 
 - Fix: editing an existing resource server (oauth20_rs) always failed with a confusing dual success+error message and no change applied in Manage. Root cause: `MetaData::merge()` overwrote `nameIdFormat` with `null` when the form command returned `null` (the RS form has no NameIDFormat field), causing the diff to send `metaDataFields.NameIDFormat: null` to Manage, which rejected the update. Additionally, published production RS entities were incorrectly routed through the change-request flow instead of being published directly.
 Remove integration with Teams
 Add integration with Invite

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
     "symfony/form": "^6.4.13",
     "symfony/framework-bundle": "^6.4.17",
     "symfony/http-client": "6.4.*",
+    "symfony/http-foundation": "^6.4.13",
     "symfony/mailer": "^6.4.13",
     "symfony/monolog-bundle": "^3.10.0",
     "symfony/polyfill-apcu": "^1.31",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e6d9576a23c4166c948d259aba72354",
+    "content-hash": "f696ebf9b6e1b2aae4bd3211730afa72",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -5987,16 +5987,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v6.4.41",
+            "version": "v6.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "48d76c29a67a301e0f7779a512bf76417395ffef"
+                "reference": "23dcf8e0f59cbbfa9d2894f58fd8be6833794372"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/48d76c29a67a301e0f7779a512bf76417395ffef",
-                "reference": "48d76c29a67a301e0f7779a512bf76417395ffef",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/23dcf8e0f59cbbfa9d2894f58fd8be6833794372",
+                "reference": "23dcf8e0f59cbbfa9d2894f58fd8be6833794372",
                 "shasum": ""
             },
             "require": {
@@ -6044,7 +6044,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v6.4.41"
+                "source": "https://github.com/symfony/http-foundation/tree/v6.4.42"
             },
             "funding": [
                 {
@@ -6064,7 +6064,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-24T10:54:17+00:00"
+            "time": "2026-06-16T10:12:24+00:00"
         },
         {
             "name": "symfony/http-kernel",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -11,18 +11,35 @@ parameters:
     manage_verify_ssl: true
     allow_logo_private_hosts: false
     logo_verify_ssl: true
+    allow_metadata_private_hosts: false
+    metadata_verify_ssl: true
+    # CIDR ranges that must not be reachable via a user-supplied metadata/logo
+    # URL fetched server-side, in addition to RFC1918/loopback/link-local/
+    # reserved ranges, which are always blocked regardless of this list.
+    # Needed because internal infrastructure may also be addressed via
+    # public IP space.
+    #
+    # Real values are deployment-specific and must NOT be committed here —
+    # they are injected via the metadata_logo_fetch_blocked_ip_ranges env
+    # var (JSON array of CIDR strings), set by Ansible per environment.
+    # See .env.dist for the (safe) default.
+    metadata_logo_fetch_blocked_ip_ranges: '%env(json:metadata_logo_fetch_blocked_ip_ranges)%'
 
 when@ci:
     parameters:
         manage_verify_ssl: false
         allow_logo_private_hosts: true
         logo_verify_ssl: false
+        allow_metadata_private_hosts: true
+        metadata_verify_ssl: false
 
 when@dev:
     parameters:
         manage_verify_ssl: false
         allow_logo_private_hosts: true
         logo_verify_ssl: false
+        allow_metadata_private_hosts: true
+        metadata_verify_ssl: false
 
 services:
     # default configuration for services in *this* file

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/config/services.yml
@@ -198,7 +198,13 @@ services:
     class: GuzzleHttp\Client
 
   Surfnet\ServiceProviderDashboard\Legacy\Metadata\Fetcher:
-    arguments: [ '@surfnet.dashboard.metadata.client', '@logger', '%env(metadata_url_timeout)%' ]
+    arguments:
+      - '@surfnet.dashboard.metadata.client'
+      - '@logger'
+      - '%env(metadata_url_timeout)%'
+      - '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\HostBlocklistCheckerInterface'
+      - '%allow_metadata_private_hosts%'
+      - '%metadata_verify_ssl%'
 
 
   Surfnet\ServiceProviderDashboard\Application\Metadata\JsonGeneratorStrategy:
@@ -304,16 +310,21 @@ services:
       - { name: validator.constraint_validator, alias: valid_redirect_url }
 
   Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\ValidMetadataUrlValidator:
+    arguments: [ '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\HostBlocklistCheckerInterface', '%allow_metadata_private_hosts%' ]
     tags:
       - { name: validator.constraint_validator, alias: metadata_url }
 
   Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\ValidLogoValidator:
-    arguments: [ '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\CurlLogoValidationHelper', '%allow_logo_private_hosts%' ]
+    arguments: [ '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\CurlLogoValidationHelper', '@Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\HostBlocklistCheckerInterface', '%allow_logo_private_hosts%' ]
     tags:
       - { name: validator.constraint_validator, alias: logo }
 
   Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\CurlLogoValidationHelper:
     arguments: [ '@logger', '%logo_verify_ssl%' ]
+
+  Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\HostBlocklistCheckerInterface:
+    class: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\HostBlocklistChecker
+    arguments: [ '%metadata_logo_fetch_blocked_ip_ranges%' ]
 
   Surfnet\ServiceProviderDashboard\Infrastructure\Jira\Repository\IssueRepository:
     arguments:

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/validators.en.yml
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Resources/translations/validators.en.yml
@@ -6,6 +6,7 @@ validator.logo.not_an_image: 'Logo is not a valid image. Press question mark for
 validator.logo.download_failed: 'The logo could not be downloaded to the server.'
 validator.logo.private_host: 'The logo URL resolves to a private or reserved address and cannot be used.'
 validator.entity_id.invalid_url: 'Invalid metadataUrl.'
+validator.entity_id.private_host: 'The metadata URL resolves to a private or reserved address and cannot be used.'
 validator.entity_id.invalid_entity_id: 'Invalid entityId.'
 validator.entity_id.registry_failure: 'Failed checking registry.'
 validator.entity_id.already_exists: 'Entity has already been registered.'

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/CurlLogoValidationHelper.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/CurlLogoValidationHelper.php
@@ -39,7 +39,7 @@ class CurlLogoValidationHelper implements LogoValidationHelperInterface
      * @throws LogoInvalidTypeException
      * @throws LogoNotFoundException
      */
-    public function validateLogo(string $url): string
+    public function validateLogo(string $url, ?string $resolvedIp = null): string
     {
         $this->logger->debug(sprintf('Validating logo: "%s" using curl', $url));
 
@@ -51,6 +51,10 @@ class CurlLogoValidationHelper implements LogoValidationHelperInterface
         curl_setopt($ch, CURLOPT_TIMEOUT, 10);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $this->verifySsl);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, $this->verifySsl ? 2 : 0);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
+        curl_setopt($ch, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+        curl_setopt($ch, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+        $this->pinResolvedIp($ch, $url, $resolvedIp);
 
         $body = (string) curl_exec($ch);
 
@@ -80,5 +84,21 @@ class CurlLogoValidationHelper implements LogoValidationHelperInterface
         }
 
         return $body;
+    }
+
+    private function pinResolvedIp(\CurlHandle $ch, string $url, ?string $resolvedIp): void
+    {
+        if ($resolvedIp === null) {
+            return;
+        }
+
+        $host = parse_url($url, PHP_URL_HOST);
+        if ($host === null || $host === false) {
+            return;
+        }
+
+        $port = parse_url($url, PHP_URL_PORT)
+            ?? (strtolower((string) parse_url($url, PHP_URL_SCHEME)) === 'https' ? 443 : 80);
+        curl_setopt($ch, CURLOPT_RESOLVE, ["$host:$port:$resolvedIp"]);
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/HostBlocklistChecker.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/HostBlocklistChecker.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service;
+
+use Symfony\Component\HttpFoundation\IpUtils;
+
+class HostBlocklistChecker implements HostBlocklistCheckerInterface
+{
+    /**
+     * @param string[] $blockedIpRanges CIDR notation, e.g. '10.0.0.0/8'
+     */
+    public function __construct(
+        private readonly array $blockedIpRanges = [],
+    ) {
+    }
+
+    public function isBlocked(string $url): bool
+    {
+        $host = parse_url($url, PHP_URL_HOST);
+        if ($host === null || $host === false || $host === '') {
+            return true;
+        }
+
+        return $this->isIpBlocked($this->resolve($host));
+    }
+
+    public function isIpBlocked(?string $ip): bool
+    {
+        if ($ip === null) {
+            return true;
+        }
+
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
+            return true;
+        }
+
+        return IpUtils::checkIp($ip, $this->blockedIpRanges);
+    }
+
+    public function resolve(string $host): ?string
+    {
+        $host = trim($host, '[]');
+
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return $host;
+        }
+
+        $ip = gethostbyname($host);
+
+        return $ip !== $host ? $ip : null;
+    }
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/HostBlocklistCheckerInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/HostBlocklistCheckerInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service;
+
+interface HostBlocklistCheckerInterface
+{
+    public function isBlocked(string $url): bool;
+
+    public function resolve(string $host): ?string;
+
+    public function isIpBlocked(?string $ip): bool;
+}

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/LogoValidationHelperInterface.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Service/LogoValidationHelperInterface.php
@@ -39,5 +39,5 @@ interface LogoValidationHelperInterface
      * @throws LogoInvalidTypeException
      * @throws LogoNotFoundException
      */
-    public function validateLogo(string $url): string;
+    public function validateLogo(string $url, ?string $resolvedIp = null): string;
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/ValidLogoValidator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/ValidLogoValidator.php
@@ -20,6 +20,7 @@ namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Valida
 
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Exception\LogoInvalidTypeException;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Exception\LogoNotFoundException;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\HostBlocklistCheckerInterface;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\LogoValidationHelperInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -43,6 +44,7 @@ class ValidLogoValidator extends ConstraintValidator
 
     public function __construct(
         private readonly LogoValidationHelperInterface $logoValidationHelper,
+        private readonly HostBlocklistCheckerInterface $hostBlocklistChecker,
         private readonly bool $allowLogoPrivateHosts = false,
     ) {
     }
@@ -53,13 +55,16 @@ class ValidLogoValidator extends ConstraintValidator
             return;
         }
 
-        if (!$this->allowLogoPrivateHosts && $this->isPrivateHost($value)) {
+        $host = parse_url($value, PHP_URL_HOST);
+        $ip = $host !== null && $host !== false ? $this->hostBlocklistChecker->resolve($host) : null;
+
+        if (!$this->allowLogoPrivateHosts && $this->hostBlocklistChecker->isIpBlocked($ip)) {
             $this->context->addViolation(self::STATUS_PRIVATE_HOST);
             return;
         }
 
         try {
-            $body = $this->logoValidationHelper->validateLogo($value);
+            $body = $this->logoValidationHelper->validateLogo($value, $ip);
             if (getimagesizefromstring($body) === false) {
                 $this->context->addViolation($constraint->message);
             }
@@ -68,24 +73,5 @@ class ValidLogoValidator extends ConstraintValidator
         } catch (LogoInvalidTypeException) {
             $this->context->addViolation(self::STATUS_INVALID_TYPE);
         }
-    }
-
-    private function isPrivateHost(string $url): bool
-    {
-        $host = parse_url($url, PHP_URL_HOST);
-        if ($host === null || $host === false || $host === '') {
-            return true;
-        }
-
-        // Strip IPv6 brackets, e.g. [::1] -> ::1
-        $host = trim($host, '[]');
-
-        $ip = filter_var($host, FILTER_VALIDATE_IP) !== false ? $host : gethostbyname($host);
-
-        return filter_var(
-            $ip,
-            FILTER_VALIDATE_IP,
-            FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
-        ) === false;
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/ValidMetadataUrlValidator.php
+++ b/src/Surfnet/ServiceProviderDashboard/Infrastructure/DashboardBundle/Validator/Constraints/ValidMetadataUrlValidator.php
@@ -19,11 +19,19 @@
 namespace Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints;
 
 use Exception;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\HostBlocklistCheckerInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
 class ValidMetadataUrlValidator extends ConstraintValidator
 {
+    final public const STATUS_PRIVATE_HOST = 'validator.entity_id.private_host';
+
+    public function __construct(
+        private readonly HostBlocklistCheckerInterface $hostBlocklistChecker,
+        private readonly bool $allowMetadataPrivateHosts = false,
+    ) {
+    }
 
     /**
      * @param string     $value
@@ -41,6 +49,10 @@ class ValidMetadataUrlValidator extends ConstraintValidator
         } catch (Exception) {
             $this->context->addViolation('validator.entity_id.invalid_url');
             return;
+        }
+
+        if (!$this->allowMetadataPrivateHosts && $this->hostBlocklistChecker->isBlocked($value)) {
+            $this->context->addViolation(self::STATUS_PRIVATE_HOST);
         }
     }
 }

--- a/src/Surfnet/ServiceProviderDashboard/Legacy/Metadata/Fetcher.php
+++ b/src/Surfnet/ServiceProviderDashboard/Legacy/Metadata/Fetcher.php
@@ -20,13 +20,19 @@ namespace Surfnet\ServiceProviderDashboard\Legacy\Metadata;
 
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Psr7\UriResolver;
+use GuzzleHttp\Psr7\Utils;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Surfnet\ServiceProviderDashboard\Application\Metadata\FetcherInterface;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\HostBlocklistCheckerInterface;
 use Surfnet\ServiceProviderDashboard\Legacy\Metadata\Exception\MetadataFetchException;
 use Exception;
 
 class Fetcher implements FetcherInterface
 {
+    private const MAX_REDIRECTS = 5;
+
     private readonly int $timeout;
 
     private static string $curlErrorRegex = '/cURL error (\d+):/';
@@ -35,6 +41,9 @@ class Fetcher implements FetcherInterface
         private readonly ClientInterface $guzzle,
         private readonly LoggerInterface $logger,
         $timeout,
+        private readonly HostBlocklistCheckerInterface $hostBlocklistChecker,
+        private readonly bool $allowMetadataPrivateHosts = false,
+        private readonly bool $verifySsl = true,
     ) {
         $this->timeout = (int) $timeout;
     }
@@ -46,9 +55,9 @@ class Fetcher implements FetcherInterface
     public function fetch($url): string
     {
         try {
-            $guzzleOptions = [ 'timeout' => $this->timeout, 'verify' => false ];
-            $response = $this->guzzle->request('GET', $url, $guzzleOptions);
-            return $response->getBody()->getContents();
+            return $this->fetchFollowingRedirects($url)->getBody()->getContents();
+        } catch (MetadataFetchException $e) {
+            throw $e;
         } catch (ConnectException $e) {
             $this->logger->info('Metadata CURL exception', ['e' => $e]);
             $curlError = ' (' . $this->getCurlErrorDescription($e->getMessage()) . ').';
@@ -57,6 +66,73 @@ class Fetcher implements FetcherInterface
             $this->logger->info('Metadata exception', ['e' => $e]);
             throw new MetadataFetchException('Failed retrieving the metadata.');
         }
+    }
+
+    private function fetchFollowingRedirects(string $url): ResponseInterface
+    {
+        for ($redirectCount = 0; $redirectCount <= self::MAX_REDIRECTS; $redirectCount++) {
+            $ip = $this->guardAgainstBlockedHost($url);
+            $response = $this->guzzle->request('GET', $url, $this->buildGuzzleOptions($url, $ip));
+
+            if (!$this->isRedirect($response)) {
+                return $response;
+            }
+
+            $url = (string) UriResolver::resolve(Utils::uriFor($url), Utils::uriFor($response->getHeaderLine('Location')));
+        }
+
+        throw new MetadataFetchException('Failed retrieving the metadata (too many redirects).');
+    }
+
+    private function isRedirect(ResponseInterface $response): bool
+    {
+        $statusCode = $response->getStatusCode();
+
+        return $statusCode >= 300 && $statusCode < 400 && $response->hasHeader('Location');
+    }
+
+    private function guardAgainstBlockedHost(string $url): ?string
+    {
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+        if (!in_array($scheme, ['http', 'https'], true)) {
+            $this->logger->info('Metadata URL uses an unsupported scheme', ['url' => $url]);
+            throw new MetadataFetchException('Failed retrieving the metadata.');
+        }
+
+        $host = parse_url($url, PHP_URL_HOST);
+        $ip = $host !== null && $host !== false ? $this->hostBlocklistChecker->resolve($host) : null;
+
+        if (!$this->allowMetadataPrivateHosts && $this->hostBlocklistChecker->isIpBlocked($ip)) {
+            $this->logger->info('Metadata URL resolves to a blocked host', ['url' => $url]);
+            throw new MetadataFetchException('Failed retrieving the metadata.');
+        }
+
+        return $ip;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildGuzzleOptions(string $url, ?string $ip): array
+    {
+        $guzzleOptions = [
+            'timeout' => $this->timeout,
+            'verify' => $this->verifySsl,
+            'allow_redirects' => false,
+            'curl' => [
+                CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+                CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+            ],
+        ];
+
+        $host = parse_url($url, PHP_URL_HOST);
+        if ($ip !== null && $host !== null && $host !== false) {
+            $port = parse_url($url, PHP_URL_PORT)
+                ?? (strtolower((string) parse_url($url, PHP_URL_SCHEME)) === 'https' ? 443 : 80);
+            $guzzleOptions['curl'][CURLOPT_RESOLVE] = ["$host:$port:$ip"];
+        }
+
+        return $guzzleOptions;
     }
 
     private function getCurlErrorDescription(string $message): string

--- a/tests/integration/Infrastructure/DashboardBundle/Validator/Constraints/ValidLogoValidatorTest.php
+++ b/tests/integration/Infrastructure/DashboardBundle/Validator/Constraints/ValidLogoValidatorTest.php
@@ -22,6 +22,7 @@ use Mockery as m;
 use Mockery\Mock;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Exception\LogoInvalidTypeException;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Exception\LogoNotFoundException;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\HostBlocklistCheckerInterface;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\LogoValidationHelperInterface;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\ValidLogo;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\ValidLogoValidator;
@@ -34,11 +35,19 @@ class ValidLogoValidatorTest extends ConstraintValidatorTestCase
      */
     private $validationHelper;
 
+    /**
+     * @var HostBlocklistCheckerInterface|Mock
+     */
+    private $hostBlocklistChecker;
+
     protected function createValidator()
     {
         $this->validationHelper = m::mock(LogoValidationHelperInterface::class);
+        $this->hostBlocklistChecker = m::mock(HostBlocklistCheckerInterface::class);
+        $this->hostBlocklistChecker->shouldReceive('resolve')->andReturn('93.184.216.34')->byDefault();
+        $this->hostBlocklistChecker->shouldReceive('isIpBlocked')->andReturn(false)->byDefault();
 
-        return new ValidLogoValidator($this->validationHelper, false);
+        return new ValidLogoValidator($this->validationHelper, $this->hostBlocklistChecker, false);
     }
 
     public function test_success_png()
@@ -105,6 +114,24 @@ class ValidLogoValidatorTest extends ConstraintValidatorTestCase
         $violation = $violations->get(0);
 
         $this->assertEquals('validator.logo.wrong_type', $violation->getMessageTemplate());
+    }
+
+    public function test_private_host_is_blocked()
+    {
+        $constraint = new ValidLogo();
+
+        $this->hostBlocklistChecker = m::mock(HostBlocklistCheckerInterface::class);
+        $this->hostBlocklistChecker->shouldReceive('resolve')->andReturn('169.254.169.254');
+        $this->hostBlocklistChecker->shouldReceive('isIpBlocked')->andReturn(true);
+        $this->validator = new ValidLogoValidator($this->validationHelper, $this->hostBlocklistChecker, false);
+        $this->validator->initialize($this->context);
+
+        $this->validator->validate('http://169.254.169.254/logo.png', $constraint);
+
+        $violations = $this->context->getViolations();
+        $violation = $violations->get(0);
+
+        $this->assertEquals('validator.logo.private_host', $violation->getMessageTemplate());
     }
 
     public function test_unable_to_download()

--- a/tests/integration/Infrastructure/DashboardBundle/Validator/Constraints/ValidMetadataUrlValidatorTest.php
+++ b/tests/integration/Infrastructure/DashboardBundle/Validator/Constraints/ValidMetadataUrlValidatorTest.php
@@ -20,7 +20,9 @@ namespace Surfnet\ServiceProviderDashboard\Tests\Integration\Infrastructure\Dash
 
 use GuzzleHttp\Handler\MockHandler;
 use Mockery as m;
+use Mockery\Mock;
 use Surfnet\ServiceProviderDashboard\Domain\Repository\EntityRepository;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\HostBlocklistCheckerInterface;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\ValidMetadataUrl;
 use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\ValidMetadataUrlValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
@@ -37,6 +39,11 @@ class ValidMetadataUrlValidatorTest extends ConstraintValidatorTestCase
      */
     private $repository;
 
+    /**
+     * @var HostBlocklistCheckerInterface|Mock
+     */
+    private $hostBlocklistChecker;
+
     protected function tearDown(): void
     {
         parent::tearDown();
@@ -46,7 +53,10 @@ class ValidMetadataUrlValidatorTest extends ConstraintValidatorTestCase
     protected function createValidator()
     {
         $this->mockHandler = new MockHandler();
-        return new ValidMetadataUrlValidator();
+        $this->hostBlocklistChecker = m::mock(HostBlocklistCheckerInterface::class);
+        $this->hostBlocklistChecker->shouldReceive('isBlocked')->andReturn(false)->byDefault();
+
+        return new ValidMetadataUrlValidator($this->hostBlocklistChecker, false);
     }
 
     public function test_success()
@@ -68,5 +78,34 @@ class ValidMetadataUrlValidatorTest extends ConstraintValidatorTestCase
             $violations->get(0)->getMessageTemplate(),
             'Expected certain violation but dit not receive it.'
         );
+    }
+
+    public function test_private_host_is_blocked()
+    {
+        $this->hostBlocklistChecker = m::mock(HostBlocklistCheckerInterface::class);
+        $this->hostBlocklistChecker->shouldReceive('isBlocked')->andReturn(true);
+        $this->validator = new ValidMetadataUrlValidator($this->hostBlocklistChecker, false);
+        $this->validator->initialize($this->context);
+
+        $this->validator->validate('http://169.254.169.254/metadata', new ValidMetadataUrl());
+
+        $violations = $this->context->getViolations();
+        $this->assertCount(1, $violations);
+        $this->assertEquals(
+            'validator.entity_id.private_host',
+            $violations->get(0)->getMessageTemplate()
+        );
+    }
+
+    public function test_allow_metadata_private_hosts_skips_check()
+    {
+        $this->hostBlocklistChecker = m::mock(HostBlocklistCheckerInterface::class);
+        $this->hostBlocklistChecker->shouldNotReceive('isBlocked');
+        $this->validator = new ValidMetadataUrlValidator($this->hostBlocklistChecker, true);
+        $this->validator->initialize($this->context);
+
+        $this->validator->validate('http://169.254.169.254/metadata', new ValidMetadataUrl());
+
+        $this->assertNoViolation();
     }
 }

--- a/tests/unit/Infrastructure/DashboardBundle/Service/HostBlocklistCheckerTest.php
+++ b/tests/unit/Infrastructure/DashboardBundle/Service/HostBlocklistCheckerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Tests\Unit\Infrastructure\DashboardBundle\Service;
+
+use PHPUnit\Framework\TestCase;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\HostBlocklistChecker;
+
+class HostBlocklistCheckerTest extends TestCase
+{
+    public function testPublicIpIsAllowed(): void
+    {
+        $checker = new HostBlocklistChecker();
+
+        $this->assertFalse($checker->isBlocked('https://93.184.216.34/metadata'));
+    }
+
+    public function testLoopbackIpIsBlocked(): void
+    {
+        $checker = new HostBlocklistChecker();
+
+        $this->assertTrue($checker->isBlocked('http://127.0.0.1/metadata'));
+    }
+
+    public function testRfc1918RangeIsBlocked(): void
+    {
+        $checker = new HostBlocklistChecker();
+
+        $this->assertTrue($checker->isBlocked('http://10.1.2.3/metadata'));
+    }
+
+    public function testCloudMetadataEndpointIsBlockedViaExplicitCidr(): void
+    {
+        $checker = new HostBlocklistChecker(['169.254.169.254/32']);
+
+        $this->assertTrue($checker->isBlocked('http://169.254.169.254/latest/meta-data/'));
+    }
+
+    public function testPublicIpInExplicitDenylistIsBlocked(): void
+    {
+        $checker = new HostBlocklistChecker(['198.51.100.0/24']);
+
+        $this->assertTrue($checker->isBlocked('http://198.51.100.42/metadata'));
+    }
+
+    public function testPublicIpOutsideDenylistIsNotBlocked(): void
+    {
+        $checker = new HostBlocklistChecker(['198.51.100.0/24']);
+
+        $this->assertFalse($checker->isBlocked('http://93.184.216.34/metadata'));
+    }
+
+    public function testUrlWithoutHostIsBlocked(): void
+    {
+        $checker = new HostBlocklistChecker();
+
+        $this->assertTrue($checker->isBlocked('not-a-url'));
+    }
+
+    public function testResolveReturnsLiteralIpUnchanged(): void
+    {
+        $checker = new HostBlocklistChecker();
+
+        $this->assertEquals('93.184.216.34', $checker->resolve('93.184.216.34'));
+    }
+
+    public function testIsIpBlockedReturnsTrueForNull(): void
+    {
+        $checker = new HostBlocklistChecker();
+
+        $this->assertTrue($checker->isIpBlocked(null));
+    }
+
+    public function testIsIpBlockedMatchesIsBlockedForTheSameHost(): void
+    {
+        $checker = new HostBlocklistChecker(['198.51.100.0/24']);
+
+        $this->assertTrue($checker->isIpBlocked($checker->resolve('127.0.0.1')));
+        $this->assertTrue($checker->isIpBlocked($checker->resolve('198.51.100.42')));
+        $this->assertFalse($checker->isIpBlocked($checker->resolve('93.184.216.34')));
+    }
+}

--- a/tests/unit/Legacy/Metadata/FetcherTest.php
+++ b/tests/unit/Legacy/Metadata/FetcherTest.php
@@ -30,6 +30,7 @@ use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Mock;
 use Psr\Log\LoggerInterface;
+use Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Service\HostBlocklistCheckerInterface;
 use Surfnet\ServiceProviderDashboard\Legacy\Metadata\Fetcher;
 
 class FetcherTest extends MockeryTestCase
@@ -48,6 +49,11 @@ class FetcherTest extends MockeryTestCase
     private $logger;
 
     /**
+     * @var HostBlocklistCheckerInterface|Mock
+     */
+    private $hostBlocklistChecker;
+
+    /**
      * @var MockHandler
      */
     private $mockHandler;
@@ -60,13 +66,106 @@ class FetcherTest extends MockeryTestCase
 
         $this->client = $client;
         $this->logger = m::mock(LoggerInterface::class);
-        $this->fetcher = new Fetcher($this->client, $this->logger, 11);
+        $this->hostBlocklistChecker = m::mock(HostBlocklistCheckerInterface::class);
+        $this->hostBlocklistChecker->shouldReceive('resolve')->andReturn(null)->byDefault();
+        $this->hostBlocklistChecker->shouldReceive('isIpBlocked')->andReturn(false)->byDefault();
+        $this->fetcher = new Fetcher($this->client, $this->logger, 11, $this->hostBlocklistChecker);
     }
 
     public function test_it_can_fetch_xml_from_an_url()
     {
         $this->mockHandler->append(new Response(200, [], '<xml>'));
         $xml = $this->fetcher->fetch('https://www.ibuildings.nl/saml/metadata.xml');
+        $this->assertEquals('<xml>', $xml);
+    }
+
+    public function test_it_blocks_a_url_that_resolves_to_a_blocked_host()
+    {
+        $this->hostBlocklistChecker = m::mock(HostBlocklistCheckerInterface::class);
+        $this->hostBlocklistChecker->shouldReceive('resolve')->andReturn('169.254.169.254');
+        $this->hostBlocklistChecker->shouldReceive('isIpBlocked')->with('169.254.169.254')->andReturn(true);
+        $this->fetcher = new Fetcher($this->client, $this->logger, 11, $this->hostBlocklistChecker);
+
+        $this->logger
+            ->shouldReceive('info')
+            ->with('Metadata URL resolves to a blocked host', ['url' => 'http://169.254.169.254/metadata']);
+
+        $this->expectExceptionMessage('Failed retrieving the metadata.');
+        $this->expectException(\Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException::class);
+        $this->fetcher->fetch('http://169.254.169.254/metadata');
+    }
+
+    public function test_it_resolves_the_host_exactly_once_and_reuses_it_for_the_pin()
+    {
+        $this->hostBlocklistChecker = m::mock(HostBlocklistCheckerInterface::class);
+        $this->hostBlocklistChecker->shouldReceive('resolve')->once()->andReturn('93.184.216.34');
+        $this->hostBlocklistChecker->shouldReceive('isIpBlocked')->once()->with('93.184.216.34')->andReturn(false);
+        $this->fetcher = new Fetcher($this->client, $this->logger, 11, $this->hostBlocklistChecker);
+
+        $this->mockHandler->append(new Response(200, [], '<xml>'));
+        $xml = $this->fetcher->fetch('https://www.ibuildings.nl/saml/metadata.xml');
+        $this->assertEquals('<xml>', $xml);
+    }
+
+    public function test_it_validates_and_pins_every_redirect_hop()
+    {
+        $this->hostBlocklistChecker = m::mock(HostBlocklistCheckerInterface::class);
+        $this->hostBlocklistChecker->shouldReceive('resolve')->once()->with('www.ibuildings.nl')->andReturn('93.184.216.34');
+        $this->hostBlocklistChecker->shouldReceive('resolve')->once()->with('redirected.example.org')->andReturn('93.184.216.35');
+        $this->hostBlocklistChecker->shouldReceive('isIpBlocked')->with('93.184.216.34')->andReturn(false);
+        $this->hostBlocklistChecker->shouldReceive('isIpBlocked')->with('93.184.216.35')->andReturn(false);
+        $this->fetcher = new Fetcher($this->client, $this->logger, 11, $this->hostBlocklistChecker);
+
+        $this->mockHandler->append(new Response(301, ['Location' => 'https://redirected.example.org/metadata.xml']));
+        $this->mockHandler->append(new Response(200, [], '<xml>'));
+
+        $xml = $this->fetcher->fetch('https://www.ibuildings.nl/saml/metadata.xml');
+        $this->assertEquals('<xml>', $xml);
+    }
+
+    public function test_it_blocks_a_redirect_that_resolves_to_a_blocked_host()
+    {
+        $this->hostBlocklistChecker = m::mock(HostBlocklistCheckerInterface::class);
+        $this->hostBlocklistChecker->shouldReceive('resolve')->once()->with('www.ibuildings.nl')->andReturn('93.184.216.34');
+        $this->hostBlocklistChecker->shouldReceive('resolve')->once()->with('169.254.169.254')->andReturn('169.254.169.254');
+        $this->hostBlocklistChecker->shouldReceive('isIpBlocked')->with('93.184.216.34')->andReturn(false);
+        $this->hostBlocklistChecker->shouldReceive('isIpBlocked')->with('169.254.169.254')->andReturn(true);
+        $this->fetcher = new Fetcher($this->client, $this->logger, 11, $this->hostBlocklistChecker);
+
+        $this->mockHandler->append(new Response(302, ['Location' => 'http://169.254.169.254/metadata']));
+
+        $this->logger
+            ->shouldReceive('info')
+            ->with('Metadata URL resolves to a blocked host', ['url' => 'http://169.254.169.254/metadata']);
+
+        $this->expectExceptionMessage('Failed retrieving the metadata.');
+        $this->expectException(\Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException::class);
+        $this->fetcher->fetch('https://www.ibuildings.nl/saml/metadata.xml');
+    }
+
+    public function test_it_rejects_an_ftp_scheme_url()
+    {
+        $this->hostBlocklistChecker->shouldNotReceive('resolve');
+        $this->hostBlocklistChecker->shouldNotReceive('isIpBlocked');
+
+        $this->logger
+            ->shouldReceive('info')
+            ->with('Metadata URL uses an unsupported scheme', ['url' => 'ftp://www.ibuildings.nl/metadata.xml']);
+
+        $this->expectExceptionMessage('Failed retrieving the metadata.');
+        $this->expectException(\Surfnet\ServiceProviderDashboard\Application\Exception\InvalidArgumentException::class);
+        $this->fetcher->fetch('ftp://www.ibuildings.nl/metadata.xml');
+    }
+
+    public function test_it_allows_a_blocked_host_when_allow_metadata_private_hosts_is_true()
+    {
+        $this->hostBlocklistChecker = m::mock(HostBlocklistCheckerInterface::class);
+        $this->hostBlocklistChecker->shouldNotReceive('isIpBlocked');
+        $this->hostBlocklistChecker->shouldReceive('resolve')->andReturn(null)->byDefault();
+        $this->fetcher = new Fetcher($this->client, $this->logger, 11, $this->hostBlocklistChecker, true);
+
+        $this->mockHandler->append(new Response(200, [], '<xml>'));
+        $xml = $this->fetcher->fetch('http://169.254.169.254/metadata');
         $this->assertEquals('<xml>', $xml);
     }
 

--- a/tests/webtests/Resources/config/services.yml
+++ b/tests/webtests/Resources/config/services.yml
@@ -42,6 +42,11 @@ services:
         tags:
             - { name: validator.constraint_validator, alias: logo }
 
+    Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Validator\Constraints\ValidMetadataUrlValidator:
+        class: Surfnet\ServiceProviderDashboard\Webtests\Validator\Constraints\MockValidMetadataUrlValidator
+        tags:
+            - { name: validator.constraint_validator, alias: metadata_url }
+
     Surfnet\ServiceProviderDashboard\Infrastructure\Manage\Client\QueryClient:
         class: Surfnet\ServiceProviderDashboard\Webtests\Manage\Client\FakeQueryClient
         arguments: ['/../../../../var/webtest-test-query-client-manage.json']

--- a/tests/webtests/Validator/Constraints/MockValidMetadataUrlValidator.php
+++ b/tests/webtests/Validator/Constraints/MockValidMetadataUrlValidator.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\ServiceProviderDashboard\Webtests\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class MockValidMetadataUrlValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint)
+    {
+        return;
+    }
+}


### PR DESCRIPTION
## Summary
- Metadata URL was fetched server-side with no check on the target host, allowing SSRF against internal infrastructure (loopback, private ranges, our own internal ranges even though those are publicly addressed, cloud metadata endpoints).
- Enforced at the actual fetch point (`Fetcher::fetch`), not only in form validation, since metadata import can bypass the entity form.
- Redirect hops are re-checked; outgoing request is pinned to the validated IP to close a DNS-rebinding gap.
- Logo URL validator reused the same shared check (previously only blocked private ranges, not our own public-but-internal ranges).
- TLS certificate verification, previously unconditionally disabled on the metadata fetch, is now enabled by default.

## Test plan
- [x] `composer check` (phpcs, phpmd, phpstan, unit + integration tests) passes
- [x] New unit tests for `HostBlocklistChecker` (private ranges, explicit CIDR denylist, cloud metadata endpoint)
- [x] New/updated tests for `Fetcher`, `ValidMetadataUrlValidator`, `ValidLogoValidator` covering blocked-host and allow-flag behavior